### PR TITLE
recover fastpath after f replicas restart

### DIFF
--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -382,7 +382,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
 
         #log = foo()
         loop_counter = 0
-        while (loop_counter < 1):
+        while (loop_counter < 100):
             loop_counter = loop_counter + 1
 
             primary = await bft_network.get_current_primary()

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -380,7 +380,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
         # start replicas
         [bft_network.start_replica(i) for i in bft_network.all_replicas()]
 
-        log = foo()
+        #log = foo()
         loop_counter = 0
         while (loop_counter < 1):
             loop_counter = loop_counter + 1
@@ -597,9 +597,8 @@ class SkvbcRestartRecoveryTest(ApolloTest):
     @staticmethod
     async def _await_replicas_in_state_transfer(logger, bft_network, skvbc, primary):
         for r in bft_network.get_live_replicas():
-            logger.log_message("got live replicas")
+            logger.log_message(f"Replica {r} is alive")
             fetching = await bft_network.is_fetching(r)
-            logger.log_message(f"is_fetching: {fetching}")
             if fetching:
                 logger.log_message(f"Replica {r} is fetching, waiting for ST to finish ...")
                 # assuming Primary has latest state


### PR DESCRIPTION
[Apollo] Implement a test where we stop F replicas in order to advance the others multiple Checkpoints, then bring back the replicas that are behind and initiate State Transfer.

Start all Replicas.
Chose F non Primary Replicas to stop.
Advance the others 5 Checkpoints.
Bring back the previously stopped F replicas.
Wait for State Transfer to finish on all.
Verify the system is processing on Fast Path.
Goto Step 2.
