### PR TITLE
view change with isolated replicas

### DIFF
--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -597,7 +597,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
 
             view = await bft_network.get_current_view()
 
-            with net.ReplicaOneWayTwoSubsetsIsolatingAdversary(bft_network, [], replicas_to_isolate) as adversary:
+            with net.ReplicaOneWayTwoSubsetsIsolatingAdversary(bft_network, other_replicas, replicas_to_isolate) as adversary:
                 adversary.interfere()
 
                 bft_network.stop_replica(primary)

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -575,7 +575,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
 
         skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
         loop_count = 0
-        while (loop_count < 5):
+        while (loop_count < 100):
             loop_count = loop_count + 1
 
             primary = await bft_network.get_current_primary()

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -549,6 +549,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
                 run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)
             log.log_message("fast path prevailed")
 
+    @skip_for_tls
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: c == 0, rotate_keys=True)
     @verify_linearizability()

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -598,8 +598,12 @@ class SkvbcRestartRecoveryTest(ApolloTest):
             with net.ReplicaOneWayTwoSubsetsIsolatingAdversary(bft_network, [], replicas_to_isolate) as adversary:
                 adversary.interfere()
 
+                bft_network.stop_replica(primary)
                 await skvbc.run_concurrent_ops(10)
-                await bft_network.wait_for_replicas_to_reach_at_least_view(other_replicas, expected_view=view + 1, timeout=60)
+
+                await bft_network.wait_for_replicas_to_reach_at_least_view(other_replicas, expected_view=view + bft_network.config.f, timeout=60)
+
+            bft_network.start_replica(primary)
 
             await bft_network.wait_for_fast_path_to_be_prevalent(
                 run_ops=lambda: skvbc.run_concurrent_ops(num_ops=20, write_weight=1), threshold=20)

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -585,15 +585,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
             for i in index_list:
                 replicas_to_isolate.append(i % bft_network.config.n)
 
-            other_replicas = [primary]
-            for r1 in bft_network.all_replicas(without={primary}):
-                append = True
-                for r2 in replicas_to_isolate:
-                    if (r1 == r2):
-                        append = False
-                        break
-                if (append):
-                    other_replicas.append(r1)
+            other_replicas = bft_network.all_replicas(without=set(replicas_to_isolate))
 
             view = await bft_network.get_current_view()
 

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -580,8 +580,10 @@ class SkvbcRestartRecoveryTest(ApolloTest):
 
             primary = await bft_network.get_current_primary()
 
-            replicas_to_isolate = random.sample(
-                bft_network.all_replicas(without={primary}), bft_network.config.f - 1)
+            index_list = range(primary + 1, primary + bft_network.config.f)
+            replicas_to_isolate = []
+            for i in index_list:
+                replicas_to_isolate.append(i % bft_network.config.n)
 
             other_replicas = [primary]
             for r1 in bft_network.all_replicas(without={primary}):


### PR DESCRIPTION
A test where we set tings up so that the next F-1 expected next
primaries will not be able to send messages to their peers, but will be able
to accept messages from them, then trigger View Change. In this way we will
be able to test View Changes with multiple View increments, where the
isolated F-1 expected next primaries will not be able to step in as
primaries, but will activate the corresponding view for which it is
theirs turn to become Primary.

Step by step scenario:
1. Use a one way isolating adversary to isolate the F-1 replicas after the current primary in such a way that they cannot send messages to the peers, but can receive messages from them.
2. Stop the current primary.
3. Send Client requests to trigger a View Change.
4. Wait for the system to finish View Change. Note that multiple View increments will happen.
5. Drop the network adversary and verify Fast Commit Path is recovered in the system by introducing client requests.

We can perform this test in a loop multiple times.
