### PR TITLE
St fix message free bug during continue send batch

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -2103,7 +2103,7 @@ void BCStateTran::continueSendBatch() {
       if ((rvbGroupDigestsActualSize == 0) || (sb.rvbGroupDigestsExpectedSize != rvbGroupDigestsActualSize)) {
         auto additionalInfo = "Rejecting message - not holding all requested digests (or some other error)" +
                               KVLOG(sb.rvbGroupDigestsExpectedSize, rvbGroupDigestsActualSize);
-        replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(outMsg));
+        ItemDataMsg::free(outMsg);
         sendRejectFetchingMsg(
             RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, sb.destReplicaId, additionalInfo);
         sourceSession_.close();

--- a/bftengine/tests/bcstatetransfer/test_replica.hpp
+++ b/bftengine/tests/bcstatetransfer/test_replica.hpp
@@ -46,7 +46,10 @@ class TestReplica : public IReplicaForStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
   void onTransferringComplete(uint64_t checkpointNumberOfNewState) override { onTransferringCompleteCalled_ = true; };
 
-  void freeStateTransferMsg(char* msg) override { std::free(msg); }
+  void freeStateTransferMsg(char* msg) override {
+    // Same behavior as in ReplicaForStateTransfer
+    std::free(msg - sizeof(MessageBase::Header));
+  }
 
   void sendStateTransferMessage(char* m, uint32_t size, uint16_t replicaId) override {
     sent_messages_.emplace_back(Msg(m, size, replicaId));


### PR DESCRIPTION
* **Problem Overview**  
 core dump observed in BCStateTran::continueSendBatch due to rare FetchBlocksMsg rejection. During rejection a buffer is being freed with the wrong function call. ItemDataMsg::free should be called instead of freeStateTransferMsg.
* **Testing Done**  
There is no way to reproduce this, as there are no logs and I have no idea what is the order of events that caused such rejection. I've added a test that test for similar rejection.
