### PR TITLE
Fix test_state_transfer_rvt_root_validation_after_adding_blocks

### DIFF
--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -356,7 +356,9 @@ class SkvbcStateTransferTest(ApolloTest):
                 print(f'Replica {replica_to_restart} will be restarted.')
                 bft_network.stop_replica(replica_to_restart, True)
                 bft_network.start_replica(replica_to_restart)
-                await trio.sleep(seconds=1)
+                # Restarted replica should get enough time to load metric holding last-stored-checkpoint
+                # Ideally concord should not allow to read metric while replica is still coming up or going down
+                await trio.sleep(seconds=2)
 
         # Validate that the RVT root values are in sync after all of the prunings and restarts have finished
         await bft_network.wait_for_replicas_rvt_root_values_to_be_in_sync(bft_network.all_replicas())

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -1219,6 +1219,7 @@ class BftTestNetwork:
                         last_stable = await self.get_metric(replica_id, self, 'Gauges', "lastStableSeqNum")
                         last_stable_seqs.append(last_stable)
                         action.log(message_type="lastStableSeqNum", replica=replica_id, last_stable=last_stable)
+                    assert checkpoint >= last_stable / 150, "Probably got wrong checkpoint as input"
                     if sum(x == 150 * checkpoint for x in last_stable_seqs) == len(replicas):
                         break
                     else:


### PR DESCRIPTION
* **Problem Overview**  
Last-stored-checkpoint metric was being read from just restarted
replica. Increased wait time to 2 sec. Ideally metric should not be
allowed to read while replica is still coming up or going down.

* **Testing Done**  
Ran test locally 50+ times with HW config same as CI.