### PR TITLE
Asan warning fixes

### DIFF
--- a/bftengine/src/bcstatetransfer/DBDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/DBDataStore.cpp
@@ -376,7 +376,7 @@ void DBDataStore::associatePendingResPageWithCheckpointTxn(uint32_t inPageId,
   auto page = pendingPages.find(inPageId);
   ConcordAssert(page != pendingPages.end());
 
-  setResPageTxn(inPageId, inCheckpoint, inPageDigest, page->second, txn);
+  setResPageTxn(inPageId, inCheckpoint, inPageDigest, page->second.get(), txn);
   txn->del(pendingPageKey(inPageId));
 }
 void DBDataStore::deleteAllPendingPagesTxn(ITransaction* txn) {

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.cpp
@@ -238,6 +238,14 @@ void InMemoryDataStore::setResPage(uint32_t inPageId,
   ResPageKey key = {inPageId, inCheckpoint};
   ConcordAssertOR(!checkIfAlreadyExists, (pages.count(key) == 0));
 
+  // Data might already exist in the map so no extra memory should be allocated
+  if (!checkIfAlreadyExists) {
+    ConcordAssert(pages.count(key));
+    ConcordAssert(!memcmp(pages[key].page, inPage, sizeOfReservedPage_));
+    ConcordAssert(!memcmp(&pages[key].pageDigest, &inPageDigest, sizeof(Digest)));
+    return;
+  }
+  
   // prepare page
   char* page = reinterpret_cast<char*>(std::malloc(sizeOfReservedPage_));
   memcpy(page, inPage, sizeOfReservedPage_);

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -32,9 +32,7 @@ class InMemoryDataStore : public DataStore {
   explicit InMemoryDataStore(uint32_t sizeOfReservedPage);
   ~InMemoryDataStore() override {
     deleteAllPendingPages();
-    for (auto& p : pages) {
-      ::free(p.second.page);
-    }
+    pages.clear();
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -183,7 +181,7 @@ class InMemoryDataStore : public DataStore {
   uint64_t firstRequiredBlock = UINT64_MAX;
   uint64_t lastRequiredBlock = UINT64_MAX;
 
-  map<uint32_t, char*> pendingPages;
+  map<uint32_t, std::shared_ptr<char[]>> pendingPages;
 
   struct ResPageKey {
     uint32_t pageId;
@@ -199,7 +197,7 @@ class InMemoryDataStore : public DataStore {
 
   struct ResPageVal {
     Digest pageDigest;
-    char* page;
+    std::shared_ptr<char[]> page;
   };
 
   map<ResPageKey, ResPageVal> pages;
@@ -215,7 +213,7 @@ class InMemoryDataStore : public DataStore {
   const uint32_t getSizeOfReservedPage() const { return sizeOfReservedPage_; }
   const map<uint64_t, CheckpointDesc>& getDescMap() const { return descMap; }
   const map<ResPageKey, ResPageVal>& getPagesMap() const { return pages; }
-  const map<uint32_t, char*>& getPendingPagesMap() const { return pendingPages; }
+  const map<uint32_t, std::shared_ptr<char[]>>& getPendingPagesMap() const { return pendingPages; }
   std::mutex reservedPagesLock_;
   void setInitialized(bool init) { wasInit_ = init; }
   logging::Logger& logger() {

--- a/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
+++ b/bftengine/src/bcstatetransfer/InMemoryDataStore.hpp
@@ -181,7 +181,8 @@ class InMemoryDataStore : public DataStore {
   uint64_t firstRequiredBlock = UINT64_MAX;
   uint64_t lastRequiredBlock = UINT64_MAX;
 
-  map<uint32_t, std::shared_ptr<char[]>> pendingPages;
+  using PagePtr = std::shared_ptr<char[]>;
+  map<uint32_t, PagePtr> pendingPages;
 
   struct ResPageKey {
     uint32_t pageId;
@@ -197,7 +198,7 @@ class InMemoryDataStore : public DataStore {
 
   struct ResPageVal {
     Digest pageDigest;
-    std::shared_ptr<char[]> page;
+    PagePtr page;
   };
 
   map<ResPageKey, ResPageVal> pages;
@@ -213,7 +214,7 @@ class InMemoryDataStore : public DataStore {
   const uint32_t getSizeOfReservedPage() const { return sizeOfReservedPage_; }
   const map<uint64_t, CheckpointDesc>& getDescMap() const { return descMap; }
   const map<ResPageKey, ResPageVal>& getPagesMap() const { return pages; }
-  const map<uint32_t, std::shared_ptr<char[]>>& getPendingPagesMap() const { return pendingPages; }
+  const map<uint32_t, PagePtr>& getPendingPagesMap() const { return pendingPages; }
   std::mutex reservedPagesLock_;
   void setInitialized(bool init) { wasInit_ = init; }
   logging::Logger& logger() {


### PR DESCRIPTION
* **Problem Overview**  
A memory leak in `InMemoryDataStore` was discovered while performing an ASAN run on the `bcstatetransfer_tests` gtest suite.

This Pull Request changes the raw pointers, storing reserved pages, to smart ones (std::shared_ptr).
It adds an additional check to avoid excessive memory allocation and replacement of the same data.


* **Testing Done**  
Ran the relevant gtest and Apollo suites to ensure that the leak is no longer present. 
