### PR TITLE
Create  restart recovery suite as a nightly job

### DIFF
--- a/.github/workflows/cmake_restart_recovery_suite.yml
+++ b/.github/workflows/cmake_restart_recovery_suite.yml
@@ -1,4 +1,4 @@
-name: Release build (clang)
+name: Restart recovery suite
 on:
   schedule:
     - cron: '0 5 * * *'
@@ -109,4 +109,3 @@ jobs:
           run: |
             echo "Errors exist in replica logs. Please check Artifacts"
             exit 1
-     

--- a/.github/workflows/cmake_restart_recovery_suite.yml
+++ b/.github/workflows/cmake_restart_recovery_suite.yml
@@ -1,0 +1,112 @@
+name: Release build (clang)
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    outputs:
+      err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
+    strategy:
+      fail-fast: false
+      matrix:
+            compiler:
+                - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
+            ci_build_type:
+                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=FALSE"
+                - "-DCMAKE_BUILD_TYPE=RELEASE -DBUILD_COMM_TCP_TLS=TRUE"
+            use_s3_obj_store:
+                - "-DUSE_S3_OBJECT_STORE=ON"
+                - "-DUSE_S3_OBJECT_STORE=OFF"
+    steps:
+        - name: Cleanup pre-installed tools
+          run: |
+            # This is a fix for https://github.com/actions/virtual-environments/issues/1918
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf /opt/ghc
+            sudo rm -rf "/usr/local/share/boost"
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Create artifact directory
+          run: mkdir -p ${{ github.workspace }}/artifact
+        #- name: Configure core dump location
+        #  run: |
+            # Uncomment the line below to enable core dump collection
+            # echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
+            # Uncomment this is you want to login into the running session.
+            # Please note that the build will block on this step.
+            # Refer to https://github.com/marketplace/actions/debugging-with-tmate
+        #- name: Setup tmate session
+        #  uses: mxschmitt/action-tmate@v2
+        - name: Build and test
+          run: |
+              script -q -e -c "make pull"
+              sudo df -h
+              script -q -e -c "make build \
+                              ${{ matrix.compiler}} \
+                              CONCORD_BFT_CMAKE_FLAGS=\"\
+                              ${{ matrix.ci_build_type }} \
+                              -DBUILD_TESTING=ON \
+                              -DENABLE_RESTART_RECOVERY_TESTS=TRUE \
+                              -DBUILD_COMM_TCP_PLAIN=FALSE \
+                              -DCMAKE_CXX_FLAGS_RELEASE='-O3 -g' \
+                              -DUSE_LOG4CPP=TRUE \
+                              -DBUILD_ROCKSDB_STORAGE=TRUE \
+                              ${{ matrix.use_s3_obj_store }} \
+                              -DUSE_OPENTRACING=ON \
+                              -DOMIT_TEST_OUTPUT=OFF\
+                              -DKEEP_APOLLO_LOGS=TRUE\
+                              -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
+              && script -q -e -c "make test-single-suite TEST_NAME=skvbc_restart_recovery_tests"
+        - name: Prepare artifacts
+          if: failure()
+          run: |
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
+            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
+            path: ${{ github.workspace }}/artifact/
+        - name: Check ERROR/FATAL logs
+          if: always()
+          run: |
+            ./.github/success_action_if_err_logs_exist.sh ./build/tests/apollo/logs
+            echo "file_count=$(find ./build/tests/apollo/logs -name ReplicaErrorLogs.txt | wc -l)" >> $GITHUB_ENV
+        - name: Prepare error artifacts
+          id: prepare_err_artifacts
+          if: ${{ env.file_count > 0 }}
+          run: |
+            sudo chown -R ${USER}:${GROUP} ${PWD}/build
+            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
+            du -h ${{ github.workspace }}/artifact
+            sudo df -h
+            echo "::set-output name=test::success"
+        - name: Upload error artifacts
+          uses: actions/upload-artifact@v2
+          if: ${{ env.file_count > 0 }}
+          with:
+            name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
+            path: ${{ github.workspace }}/artifact/
+  testlog:
+    name: Check ERROR/FATAL logs(Apollo)
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    needs: build
+    steps:
+        - name: Check ERROR/FATAL logs in apollo
+          if: needs.build.outputs.err_output == 'success'
+          run: |
+            echo "Errors exist in replica logs. Please check Artifacts"
+            exit 1
+     


### PR DESCRIPTION
Some tests, which reveal edge cases, take too long for every pr validation, so the nightly job for master is introduced.
