### PR TITLE
Fix for view change not getting triggered.

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3548,6 +3548,11 @@ void ReplicaImp::onSeqNumIsStable(SeqNum newStableSeqNum, bool hasStateInformati
     tryToSendPrePrepareMsg(false);
   }
 
+  if (!currentViewIsActive()) {
+    LOG_INFO(GL, "tryToEnterView after Stable Sequence Number is Received ...");
+    tryToEnterView();
+  }
+
   auto seq_num_to_stop_at = ControlStateManager::instance().getCheckpointToStopAt();
 
   // Once a replica is has got the the wedge point, it mark itself as wedged. Then, once it restarts, it cleans


### PR DESCRIPTION
Problem Overview
https://jira.eng.vmware.com/browse/BC-22658

Issue : View change is not triggered if stable checkpoint is received
after the request for view change. It just waits and keeps on ignoring the messages.

Fix : Trigger the view change when latest stable checkpoint number is received.

Testing Done
Verified the fix in local environment by running the apollo test case for test_missed_two_view_changes.
