### PR TITLE
Enable the tests in test_skvbc_byzantine_primary_preexecution suite

### DIFF
--- a/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
+++ b/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
@@ -111,7 +111,6 @@ class SkvbcPrimaryByzantinePreExecutionTest(ApolloTest):
         except trio.TooSlowError:
             return await self.check_viewchange_noexcept(bft_network, initial_primary, viewchange_timeout_secs)
 
-    @unittest.skip("Unstable test - BC-17830")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)
@@ -138,7 +137,6 @@ class SkvbcPrimaryByzantinePreExecutionTest(ApolloTest):
 
         await bft_network.assert_successful_pre_executions_count(new_primary, NUM_OF_SEQ_WRITES * BATCH_SIZE)
 
-    @unittest.skip("Unstable test - BC-17830")
     @with_trio
     @with_bft_network(start_replica_cmd_asymmetric_communication, selected_configs=lambda n, f, c: f >= 2)
     @verify_linearizability(pre_exec_enabled=True, no_conflicts=True)


### PR DESCRIPTION
1. test_byzantine_behavior
2. test_byzantine_behavior_with_asymmetric_comm

* **Problem Overview**  
 Tests were disabled as they were unstable.
* **Testing Done**  
  Verified the tests in local environment multiple times.
  Verified the test in CI/CD Pipeline 100 times.