### PR TITLE
Rework client-pool-timer-test to avoid races

### DIFF
--- a/client/client_pool/test/CMakeLists.txt
+++ b/client/client_pool/test/CMakeLists.txt
@@ -6,5 +6,4 @@ target_link_libraries(client-pool-timer-test PUBLIC
   concord_client_pool
 )
 
-# Disabled due to instability
-# add_test(client-pool-timer-test client-pool-timer-test)
+add_test(client-pool-timer-test client-pool-timer-test)

--- a/client/client_pool/test/client_pool_timer_test.cpp
+++ b/client/client_pool/test/client_pool_timer_test.cpp
@@ -19,50 +19,154 @@
 
 using concord_client_pool::Timer;
 
+using std::chrono::milliseconds;
+using std::make_shared;
+using std::make_unique;
+using std::shared_ptr;
+
 using namespace std::chrono_literals;
 
-using TestClient = std::shared_ptr<void>;
+using TestClient = shared_ptr<void>;
 
-TEST(client_pool_timer, work_items) {
+const milliseconds kTestTimeout = 5ms;
+
+TEST(client_pool_timer, startCausesCallback) {
   uint16_t num_times_called = 0;
-  std::chrono::milliseconds timeout = 10ms;
-  auto timer = Timer<TestClient>(timeout, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
+  auto timer = Timer<TestClient>(kTestTimeout, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
 
-  // Wait for timeout
   TestClient client1;
   timer.start(client1);
-  std::this_thread::sleep_for(timeout * 2);
-  ASSERT_EQ(num_times_called, 1);
 
-  // Cancel timeout
+  // Note while we expect the timer to make a call back after about kTestTimeout, it makes no hard timing guarantees,
+  // so we may have to wait longer sometimes.
+  while (num_times_called < 1) {  // NOLINT(bugprone-infinite-loop): timer should update num_times_called
+    std::this_thread::sleep_for(kTestTimeout * 2);
+  }
+  EXPECT_EQ(num_times_called, 1) << "Timer::start caused an unexpected number of callbacks to timeout funciton.";
+
+  std::this_thread::sleep_for(kTestTimeout * 20);
+  EXPECT_EQ(num_times_called, 1) << "Timer::start appears to have caused extraneous callback(s) after the initial one.";
+
   TestClient client2;
   timer.start(client2);
-  timer.cancel();
-  ASSERT_EQ(num_times_called, 1);
+  while (num_times_called < 2) {  // NOLINT(bugprone-infinite-loop): timer should update num_times_called
+    std::this_thread::sleep_for(kTestTimeout * 2);
+  }
+  EXPECT_EQ(num_times_called, 2) << "Timer::start caused an unexpected number of callbacks to timeout function.";
 
-  // Wait for timeout
   TestClient client3;
   timer.start(client3);
-  std::this_thread::sleep_for(timeout * 2);
-  ASSERT_EQ(num_times_called, 2);
+  while (num_times_called < 3) {  // NOLINT(bugprone-infinite-loop): timer should update num_times_called
+    std::this_thread::sleep_for(kTestTimeout * 2);
+  }
+  EXPECT_EQ(num_times_called, 3) << "Timer::start caused an unexpected number of callbacks to timeout funciton.";
+}
 
-  // Wait for timeout
-  TestClient client4;
-  timer.start(client4);
-  std::this_thread::sleep_for(timeout * 2);
-  ASSERT_EQ(num_times_called, 3);
+TEST(client_pool_timer, cancelReturnsNonNegativeDuration) {
+  uint16_t num_times_called = 0;
+  auto timer = Timer<TestClient>(kTestTimeout, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
 
-  // Stop timer thread
-  TestClient client5;
-  timer.start(client5);
-  timer.stopTimerThread();
-  ASSERT_EQ(num_times_called, 3);
+  TestClient client;
+  timer.start(client);
 
-  // Starting new timer won't work because the thread is stopped
-  TestClient client6;
-  timer.start(client6);
-  std::this_thread::sleep_for(timeout * 2);
-  ASSERT_EQ(num_times_called, 3);
+  // Note we do not test whether the started timeout was cancelled successfully, since Timer::cancel is not guaranteed
+  // to succeed in cancelling an ongoing timeout.
+  milliseconds time_to_cancellation = timer.cancel();
+  EXPECT_GE(time_to_cancellation.count(), 0) << "Timer::cancel returned a negative duration.";
+
+  time_to_cancellation = timer.cancel();
+  EXPECT_GE(time_to_cancellation.count(), 0)
+      << "Timer::cancel returned a negative duration when called a second time without starting a new timeout.";
+}
+
+TEST(client_pool_timer, stopTimerThreadStopsCallbacks) {
+  uint16_t timer_1_num_times_called = 0;
+  auto timer1 = Timer<TestClient>(kTestTimeout,
+                                  [&timer_1_num_times_called](TestClient&& c) -> void { timer_1_num_times_called++; });
+
+  timer1.stopTimerThread();
+
+  TestClient client1;
+  timer1.start(client1);
+  std::this_thread::sleep_for(kTestTimeout * 20);
+  EXPECT_EQ(timer_1_num_times_called, 0) << "Timer::start caused a callback after Timer::stopTimerThread completed.";
+
+  uint16_t timer_2_num_times_called = 0;
+  auto timer2 = Timer<TestClient>(kTestTimeout,
+                                  [&timer_2_num_times_called](TestClient&& c) -> void { timer_2_num_times_called++; });
+
+  TestClient client2;
+  timer2.start(client2);
+  timer2.stopTimerThread();
+  uint16_t calls_shortly_after_stopping = timer_2_num_times_called;
+
+  TestClient client3;
+  timer2.start(client3);
+  std::this_thread::sleep_for(kTestTimeout * 20);
+  EXPECT_EQ(timer_2_num_times_called, calls_shortly_after_stopping)
+      << "Timer::start caused a callback after Timer::stopTimerThread completed, when stopTimerThread had been called "
+         "while there was potentially an ongoing timeout.";
+}
+
+TEST(client_pool_timer, startCausesCallbacksWithTheCorrectClient) {
+  auto most_recent_client_called = make_shared<uint16_t>(0);
+  uint16_t num_times_called = 0;
+  auto timer = Timer<shared_ptr<uint16_t>>(
+      kTestTimeout, [&num_times_called, &most_recent_client_called](shared_ptr<uint16_t>&& c) -> void {
+        most_recent_client_called = c;
+        num_times_called++;
+      });
+
+  auto client1 = make_shared<uint16_t>(1);
+  timer.start(client1);
+
+  // Note while we expect the timer to make a call back after about kTestTimeout, it makes no hard timing guarantees,
+  // so we may have to wait longer sometimes.
+  while (num_times_called < 1) {  // NOLINT(bugprone-infinite-loop): timer should update num_times_called
+    std::this_thread::sleep_for(kTestTimeout * 2);
+  }
+  EXPECT_EQ(*most_recent_client_called, *client1)
+      << "Timer::start did not correctly provide its ClientT parameter to the Timer's on_timeout function on callback.";
+
+  auto client2 = make_shared<uint16_t>(2);
+  timer.start(client2);
+  while (num_times_called < 2) {  // NOLINT(bugprone-infinite-loop): timer should update num_times_called
+    std::this_thread::sleep_for(kTestTimeout * 2);
+  }
+  EXPECT_EQ(*most_recent_client_called, *client2)
+      << "Timer::start did not correctly provide its ClientT parameter to the Timer's on_timeout function on callback.";
+}
+
+TEST(client_pool_timer, noCallbacksCompleteAfterDestructor) {
+  uint16_t num_times_called = 0;
+  auto timer =
+      make_unique<Timer<TestClient>>(kTestTimeout, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
+
+  TestClient client1;
+  timer->start(client1);
+  timer.reset();
+  uint16_t calls_shortly_after_destructor = num_times_called;
+  std::this_thread::sleep_for(kTestTimeout * 20);
+  EXPECT_EQ(num_times_called, calls_shortly_after_destructor)
+      << "A Timer object appears to have made a callback after its destructor completed.";
+}
+
+TEST(client_pool_timer, timerWith0TimeoutMakesNoCallbacks) {
+  uint16_t num_times_called = 0;
+  auto timer = Timer<TestClient>(0ms, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
+
+  TestClient client1;
+  timer.start(client1);
+
+  std::this_thread::sleep_for(kTestTimeout * 20);
+  EXPECT_EQ(num_times_called, 0)
+      << "Timer::start appears to have caused a callback for a Timer with a timeout interval of 0.";
+
+  EXPECT_EQ(timer.cancel(), 0ms)
+      << "Timer::cancel returned an unexpected value for a Timer constructed with a timeout interval of 0.";
+
+  EXPECT_NO_THROW(timer.stopTimerThread())
+      << "Timer::stopTimerThread unexpectedly threw an exception for a Timer constructed with a timeout interval of 0.";
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This PR reworks `client-pool-timer-test` (a unit test suite implemented in `client/client_pool/test/client_pool_timer_test.cpp`) to avoid race conditions the existing implementation contains, which mostly arose from the existing implementation relying on the timing of timeout callbacks made by the `concord_client_pool::Timer` being tested in ways the Timer does not really guarantee.

This PR also reactivates this test suite, as it was previously deactivated due to its instability. This PR additionally adds some comments to the header file for `concord_client_pool::Timer` (`client/client_pool/include/client_pool/client_pool_timer.hpp`) to try to clarify its expected behavior.

* **Problem Overview**  
Intermittent failures of `client-pool-timer-test` were observed. Specifically, testing assertions in its [existing `work_items` test case](https://github.com/vmware/concord-bft/blob/e9488e6d44db412dd568f1f88e3fe8d19c07c75c/client/client_pool/test/client_pool_timer_test.cpp#L26) could fail. The test case's approach was to construct a `concord_client_pool::Timer` with a timeout callback function that increments a counter and then test that it made timeout callbacks as expected by calling its `start` method, waiting twice the `Timer`'s timeout duration, then expecting the counter to have been incremented. However, expecting the callback to have completed asynchronously within a fixed time frame is inherently not completely reliable, given this is not a hard real-time system and the scheduler could end up delaying and/or interrupting the asynchronous timeout callback. Furthermore, the existing test tested that `concord_client_pool::Timer`'s `cancel` and `stopTimerThread` actually stopped timeout callbacks by starting a timeout, immediately cancelling it, then checking that the counter was not incremented. This is also inherently not completely reliable since the timeout is racing its cancellation, and, for example, the callback could be made before it gets cancelled if the main thread running the unit test case gets interrupted or preempted between the time it starts the timer and the time it completes the cancellation.

* **Testing Done**  
With these changes, I have been able to run the `client-pool-timer-test` suite both with `DCMAKE_BUILD_TYPE=DEBUG` and with `DCMAKE_BUILD_TYPE=Release` 256 consecutive times each without seeing any failures.
