### PR TITLE
Fix calculation of connected connections count

### DIFF
--- a/bftengine/src/bftengine/MsgsCommunicator.cpp
+++ b/bftengine/src/bftengine/MsgsCommunicator.cpp
@@ -60,8 +60,9 @@ void MsgsCommunicator::send(std::set<NodeNum> dests, char* message, size_t messa
 uint32_t MsgsCommunicator::numOfConnectedReplicas(uint32_t clusterSize) {
   uint32_t ret{0};
   for (uint32_t i = 0; i < clusterSize; ++i) {
-    if (communication_->getCurrentConnectionStatus(i) == ConnectionStatus::Disconnected) continue;
-    ++ret;
+    if (communication_->getCurrentConnectionStatus(i) == ConnectionStatus::Connected) {
+      ++ret;
+    }
   }
   return ret;
 }


### PR DESCRIPTION
* **Problem Overview**  
  While counting number of connected replicas inside `MsgsCommunicator::numOfConnectedReplicas()`, we are incrementing the count when `getCurrentConnectionStatus()` is not Disconnected. But ConnectionStatus can also be `Unknown` as declared [here](https://github.com/vmware/concord-bft/blob/e9488e6d44db412dd568f1f88e3fe8d19c07c75c/communication/include/communication/ICommunication.hpp#L24) . This function will also increment the count in that case. Thus falsely calculating the number of connected connections and can give more number of connected connections than actual. Hence it has the potential to conclude on a false consensus while lesser number of replicas ( < 2f+1) are connected. The problem is not seen currently as `Unknown` state is not being used, but it will be potential bug when this state is used.
In this PR, I've fixed this problem, by adding up count only when getCurrentConnectionStatus() returns connection status as Connected. 
* **Testing Done**  
  Verified using existing apollo test cases and temporary logs which indicates the number of connections are calculated correctly.
