### PR TITLE
Fix initial key exchange issues

### DIFF
--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -237,6 +237,10 @@ void KeyExchangeManager::sendKeyExchange(const SeqNum& sn) {
     LOG_INFO(KEY_EX_LOG, "we already have a candidate for this sequence number, trying to send it again");
     msg.pubkey = candidate_private_keys_.generated.pub;
     msg.repID = repID_;
+    SeqNum new_sn = sn;
+    if ((sn - candidate_private_keys_.generated.sn) / checkpointWindowSize < 2)
+      new_sn = candidate_private_keys_.generated.sn;
+    candidate_private_keys_.generated.sn = new_sn;
     msg.generated_sn = candidate_private_keys_.generated.sn;
     msg.epoch = EpochManager::instance().getSelfEpochNumber();
     std::stringstream ss;

--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -230,11 +230,14 @@ void KeyExchangeManager::sendKeyExchange(const SeqNum& sn) {
     return;
   }
   KeyExchangeMsg msg;
-  if (sn == candidate_private_keys_.generated.sn && !candidate_private_keys_.generated.cid.empty()) {
+  if (!candidate_private_keys_.generated.cid.empty()) {
+    // In some cases, we may try to send another key exchange message before the previous one has been committed (i.e,
+    // initial key exchange after VC/ST, two consecutive key exchange commands). In this case, we want to reuse the old
+    // generated key-exchange message
     LOG_INFO(KEY_EX_LOG, "we already have a candidate for this sequence number, trying to send it again");
     msg.pubkey = candidate_private_keys_.generated.pub;
     msg.repID = repID_;
-    msg.generated_sn = sn;
+    msg.generated_sn = candidate_private_keys_.generated.sn;
     msg.epoch = EpochManager::instance().getSelfEpochNumber();
     std::stringstream ss;
     concord::serialize::Serializable::serialize(ss, msg);


### PR DESCRIPTION
* **Problem Overview**  
  An initial key exchange may be invoked from 3 different threads (where we configured to start with n-f replicas):
  1. from the start thread (with sequence number 0)
  2. from the message processing thread (with sequence number 0) if VC happened
  3. from the state transfer thread in case the replica started with state transfer (with the last transferred sequence number)
These three threads may collide between themselves where we get the new key message of ourselves through the consensus (for example, if the state transfer thread  created a new candidate key before the previous one committed)
This PR is to fix these issues by adding some more conditions and constraints on the creation and committing of keys.
* **Testing Done**  
  CI tests

