### PR TITLE
Unblock message-processor during initial startup/key-exchange while view change occurs

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -23,7 +23,7 @@
 namespace bftEngine::impl {
 
 class IInternalBFTClient;
-
+class ReplicaImp;
 typedef int64_t SeqNum;  // TODO [TK] redefinition
 
 class KeyExchangeManager {
@@ -34,7 +34,7 @@ class KeyExchangeManager {
   // Send the current main public key of the replica to consensus
   void sendMainPublicKey();
   // Generates and publish the first replica's key,
-  void sendInitialKey(uint32_t prim = 0, const SeqNum& = 0);
+  void sendInitialKey(const ReplicaImp* repImpInstance, const SeqNum& = 0);
   // The execution handler implementation that is called when a key exchange msg has passed consensus.
   std::string onKeyExchange(const KeyExchangeMsg& kemsg, const SeqNum& req_sn, const std::string& cid);
   // Register a IKeyExchanger to notification when keys are rotated.
@@ -188,7 +188,7 @@ class KeyExchangeManager {
    * Samples periodically how many connections the replica has with other replicas.
    * returns when num of connections is (clusterSize - 1) i.e. full communication.
    */
-  void waitForLiveQuorum(uint32_t prim = 0);
+  void waitForLiveQuorum(const ReplicaImp* repImpInstance);
   void waitForFullCommunication();
   void initMetrics(std::shared_ptr<concordMetrics::Aggregator> a, std::chrono::seconds interval);
   // deleted

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4399,7 +4399,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
   onViewNumCallbacks_.add([&](bool) {
     if (config_.keyExchangeOnStart && !KeyExchangeManager::instance().exchanged()) {
       LOG_INFO(GL, "key exchange has not been finished yet. Give it another try");
-      KeyExchangeManager::instance().sendInitialKey(currentPrimary());
+      KeyExchangeManager::instance().sendInitialKey(this);
     }
   });
   stateTransfer->addOnFetchingStateChangeCallback([&](uint64_t) {
@@ -4408,7 +4408,7 @@ ReplicaImp::ReplicaImp(bool firstTime,
     // initial key exchange after completing ST
     if (!isCollectingState()) {
       if (ReplicaConfig::instance().getkeyExchangeOnStart() && !KeyExchangeManager::instance().exchanged()) {
-        KeyExchangeManager::instance().sendInitialKey(currentPrimary(), lastExecutedSeqNum);
+        KeyExchangeManager::instance().sendInitialKey(this, lastExecutedSeqNum);
         LOG_INFO(GL, "Send initial key exchange after completing state transfer " << KVLOG(lastExecutedSeqNum));
       }
     }
@@ -4620,7 +4620,7 @@ void ReplicaImp::start() {
   msgsCommunicator_->startMsgsProcessing(config_.getreplicaId());
 
   if (ReplicaConfig::instance().getkeyExchangeOnStart() && !KeyExchangeManager::instance().exchanged()) {
-    KeyExchangeManager::instance().sendInitialKey(currentPrimary());
+    KeyExchangeManager::instance().sendInitialKey(this);
   } else {
     // If key exchange is disabled, first publish the replica's main (rsa) key to clients
     if (ReplicaConfig::instance().publishReplicasMasterKeyOnStartup) KeyExchangeManager::instance().sendMainPublicKey();


### PR DESCRIPTION
* **Problem Overview**  
Calls to `KeyExchangeManager::instance().sendInitialKey(currentPrimary());` is made from two different threads, 
(1) from the thread that starts the replica
(2) from the message processing thread right after the justified VC, (part of view change callback)
But `sendInitialKey` method has a mutex which means that this method will be blocked for 60 seconds as inside it, it tries to connect to primary for 60 seconds(starts under assumption that replica 0 will be primary). At the same time, if a view change has occurred and primary has changed, it will still be blocked and keep trying to connect to replica 0 for 60 seconds. Thus message processing thread is not able to enter `sendInitialKey` method, as it has to be protected by mutex and the other thread working inside it will not leave for 60 seconds. 
During this, other replicas might start with their message processing but this replica will be delayed as message processing is blocked. Due to delayed processing, and when time-service enabled, it can cause to additional view changes as PPM message processing in such replicas will be delayed making client request message timeout.
**Fix**: Instead of waiting for a fixed primary, I made provision to get current primary inside sendInitialKey function, so that it knows in real time, which primary to connect.
* **Testing Done**  
Added an apollo test case to test this scenario.
Ran test 100 times, to check the fix and stability after adding the fix.
