### PR TITLE
V4 - Optimizing recovery, removing redundant measurements and adding metrics 

### DIFF
--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -22,7 +22,6 @@
 #include <deque>
 #include "OpenTracing.hpp"
 #include "TimeService.hpp"
-#include "ISystemResourceEntity.hpp"
 #include "PersistentStorageImp.hpp"
 
 namespace concord::reconfiguration {
@@ -55,9 +54,7 @@ class IRequestsHandler {
   };
 
   static std::shared_ptr<IRequestsHandler> createRequestsHandler(
-      std::shared_ptr<IRequestsHandler> userReqHandler,
-      const std::shared_ptr<concord::cron::CronTableRegistry> &,
-      concord::performance::ISystemResourceEntity &);
+      std::shared_ptr<IRequestsHandler> userReqHandler, const std::shared_ptr<concord::cron::CronTableRegistry> &);
   typedef std::deque<ExecutionRequest> ExecutionRequestsQueue;
 
   virtual void execute(ExecutionRequestsQueue &requests,

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -287,9 +287,8 @@ IReplica::IReplicaPtr IReplica::createNewRoReplica(const ReplicaConfig &replicaC
 
 std::shared_ptr<IRequestsHandler> IRequestsHandler::createRequestsHandler(
     std::shared_ptr<IRequestsHandler> userReqHandler,
-    const std::shared_ptr<concord::cron::CronTableRegistry> &cronTableRegistry,
-    concord::performance::ISystemResourceEntity &resourceEntity) {
-  auto reqHandler = new bftEngine::RequestHandler(resourceEntity);
+    const std::shared_ptr<concord::cron::CronTableRegistry> &cronTableRegistry) {
+  auto reqHandler = new bftEngine::RequestHandler();
   reqHandler->setUserRequestHandler(userReqHandler);
   reqHandler->setCronTableRegistry(cronTableRegistry);
   return std::shared_ptr<IRequestsHandler>(reqHandler);

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -183,14 +183,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
     return;
   }
   if (userRequestsHandler_) {
-    // Do not measure pre-exec and read requests.
-    auto isPost =
-        (requests.size() > 0 && !(requests.back().flags & (bftEngine::PRE_PROCESS_FLAG | bftEngine::READ_ONLY_FLAG)));
-    ISystemResourceEntity::scopedDurMeasurment m(
-        resourceEntity_, ISystemResourceEntity::type::post_execution_utilization, isPost);
     userRequestsHandler_->execute(requests, timestamp, batchCid, parent_span);
-    // the size of the queue resembles how many requests have passed consensus.
-    resourceEntity_.addMeasurement({ISystemResourceEntity::type::transactions_accumulated, requests.size(), 0, 0});
   }
   return;
 }

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -25,9 +25,7 @@ namespace bftEngine {
 class RequestHandler : public IRequestsHandler {
  public:
   RequestHandler(
-      concord::performance::ISystemResourceEntity &resourceEntity,
-      std::shared_ptr<concordMetrics::Aggregator> aggregator_ = std::make_shared<concordMetrics::Aggregator>())
-      : resourceEntity_(resourceEntity) {
+      std::shared_ptr<concordMetrics::Aggregator> aggregator_ = std::make_shared<concordMetrics::Aggregator>()) {
     using namespace concord::reconfiguration;
     reconfig_handler_.push_back(std::make_shared<ReconfigurationHandler>());
     for (const auto &rh : reconfig_handler_) {
@@ -74,7 +72,6 @@ class RequestHandler : public IRequestsHandler {
   std::shared_ptr<IRequestsHandler> userRequestsHandler_;
   concord::reconfiguration::Dispatcher reconfig_dispatcher_;
   std::shared_ptr<concord::cron::CronTableRegistry> cron_table_registry_;
-  concord::performance::ISystemResourceEntity &resourceEntity_;
 };
 
 }  // namespace bftEngine

--- a/kvbc/include/kvbc_adapter/replica_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/replica_adapter.hpp
@@ -27,7 +27,6 @@
 #include "db_interfaces.h"
 #include "bcstatetransfer/SimpleBCStateTransfer.hpp"
 #include "state_snapshot_interface.hpp"
-#include "ISystemResourceEntity.hpp"
 #include "replica_adapter_auxilliary_types.hpp"
 #include "categorization/kv_blockchain.h"
 #include "v4blockchain/v4_blockchain.h"
@@ -51,7 +50,7 @@ class ReplicaBlockchain : public IBlocksDeleter,
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IBlocksDeleter implementation
   void deleteGenesisBlock() override final { return deleter_->deleteGenesisBlock(); }
-  BlockId deleteBlocksUntil(BlockId until) override final { return deleter_->deleteBlocksUntil(until); }
+  BlockId deleteBlocksUntil(BlockId until) override final;
   void deleteLastReachableBlock() override final { return deleter_->deleteLastReachableBlock(); }
 
   // Helper method, not part of the interface
@@ -273,6 +272,7 @@ class ReplicaBlockchain : public IBlocksDeleter,
   mutable concordMetrics::GaugeHandle add_block_duration;
   mutable concordMetrics::GaugeHandle multiget_latest_duration;
   mutable concordMetrics::GaugeHandle multiget_version_duration;
+  mutable concordMetrics::GaugeHandle delete_blocks_until_duration;
   mutable concordMetrics::CounterHandle get_counter;
   mutable concordMetrics::CounterHandle multiget_lat_version_counter;
 };

--- a/kvbc/include/kvbc_adapter/v4blockchain/blocks_deleter_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/v4blockchain/blocks_deleter_adapter.hpp
@@ -18,7 +18,6 @@
 #include "db_interfaces.h"
 #include "v4blockchain/v4_blockchain.h"
 #include "kvbc_adapter/replica_adapter_auxilliary_types.hpp"
-#include "resources-manager/ISystemResourceEntity.hpp"
 #include "performance_handler.h"
 #include "diagnostics.h"
 
@@ -27,8 +26,7 @@ namespace concord::kvbc::adapter::v4blockchain {
 class BlocksDeleterAdapter : public IBlocksDeleter {
  public:
   virtual ~BlocksDeleterAdapter() { kvbc_ = nullptr; }
-  explicit BlocksDeleterAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc,
-                                const std::optional<aux::AdapterAuxTypes> &aux_types = std::nullopt);
+  explicit BlocksDeleterAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc);
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IBlocksDeleter implementation
@@ -39,7 +37,6 @@ class BlocksDeleterAdapter : public IBlocksDeleter {
 
  private:
   concord::kvbc::v4blockchain::KeyValueBlockchain *kvbc_{nullptr};
-  std::shared_ptr<concord::performance::ISystemResourceEntity> replica_resources_;
 
   struct Recorders {
     static constexpr uint64_t MAX_VALUE_MICROSECONDS = 2ULL * 1000ULL * 1000ULL;  // 2 seconds

--- a/kvbc/include/v4blockchain/detail/latest_keys.h
+++ b/kvbc/include/v4blockchain/detail/latest_keys.h
@@ -148,12 +148,15 @@ class LatestKeys {
                 bool* /*value_changed*/) const override;
   };
 
+  void setDeletedKeysMetric(concordMetrics::CounterHandle* m) { deleted_keys_ = m; }
+
  private:
   // This filter is used to delete stale on update keys if their version is smaller than the genesis block
   // It's being called by RocksDB on compaction
 
   std::shared_ptr<concord::storage::rocksdb::NativeClient> native_client_;
   v4blockchain::detail::Categories category_mapping_;
+  concordMetrics::CounterHandle* deleted_keys_{nullptr};
 };
 
 }  // namespace concord::kvbc::v4blockchain::detail

--- a/kvbc/include/v4blockchain/v4_blockchain.h
+++ b/kvbc/include/v4blockchain/v4_blockchain.h
@@ -156,7 +156,9 @@ class KeyValueBlockchain {
   // path - the path of the blockchain db.
   struct BlockchainRecovery {
     BlockchainRecovery(const std::string &path, const std::optional<kvbc::BlockId> &block_id_at_chkpnt);
-    static std::shared_ptr<storage::rocksdb::NativeClient> getRecoveryDB(const std::string &path, bool is_chkpnt);
+    static std::shared_ptr<storage::rocksdb::NativeClient> getRecoveryDB(const std::string &path,
+                                                                         bool is_chkpnt,
+                                                                         bool read_only);
     static void removeRecoveryDB(const std::string &path, bool is_chkpnt);
     static std::string getPath(const std::string &path, bool is_chkpnt);
   };
@@ -265,12 +267,12 @@ class KeyValueBlockchain {
   std::map<kvbc::BlockId, const ::rocksdb::Snapshot *> chkpnt_snap_shots_;
   // const ::rocksdb::Snapshot *chkpoint_snap_shot_{nullptr};
   util::ThreadPool thread_pool_{1};
-  std::optional<kvbc::BlockId> chkpnt_block_id_;
 
   // Metrics
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
   concordMetrics::Component v4_metrics_comp_;
   concordMetrics::GaugeHandle blocks_deleted_;
+  concordMetrics::CounterHandle deleted_keys_;
 
  public:
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {

--- a/kvbc/src/kvbc_adapter/v4blockchain/blocks_deleter_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/v4blockchain/blocks_deleter_adapter.cpp
@@ -13,28 +13,16 @@
 
 #include "kvbc_adapter/v4blockchain/blocks_deleter_adapter.hpp"
 #include "assertUtils.hpp"
-#include "ReplicaResources.h"
-
-using concord::performance::ISystemResourceEntity;
 
 namespace concord::kvbc::adapter::v4blockchain {
 
-BlocksDeleterAdapter::BlocksDeleterAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc,
-                                           const std::optional<aux::AdapterAuxTypes> &aux_types)
+BlocksDeleterAdapter::BlocksDeleterAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc)
     : kvbc_{kvbc.get()} {
-  if (aux_types.has_value()) {
-    replica_resources_.reset(&(aux_types->resource_entity_));
-  } else {
-    replica_resources_ = std::make_shared<ReplicaResourceEntity>();
-  }
   ConcordAssertNE(kvbc_, nullptr);
-  ConcordAssertEQ(!replica_resources_, false);
 }
 
 BlockId BlocksDeleterAdapter::deleteBlocksUntil(BlockId until) {
   const auto start = std::chrono::steady_clock::now();
-  ISystemResourceEntity::scopedDurMeasurment mes(*replica_resources_,
-                                                 ISystemResourceEntity::type::pruning_avg_time_micro);
   auto upTo = kvbc_->deleteBlocksUntil(until);
 
   auto jobDuration =

--- a/kvbc/src/v4blockchain/detail/latest_keys.cpp
+++ b/kvbc/src/v4blockchain/detail/latest_keys.cpp
@@ -80,6 +80,9 @@ void LatestKeys::handleCategoryUpdates(const std::string& block_version,
                               << concordUtils::bufferToHex(k.data(), k.size()) << " raw key " << k);
     write_batch.del(v4blockchain::detail::LATEST_KEYS_CF, getSliceArray(prefix, k));
   }
+  if (deleted_keys_ && updates.deletes.size() > 0) {
+    *deleted_keys_ += updates.deletes.size();
+  }
 }
 
 void LatestKeys::handleCategoryUpdates(const std::string& block_version,
@@ -111,6 +114,9 @@ void LatestKeys::handleCategoryUpdates(const std::string& block_version,
                               << category_id << " prefix " << prefix << " key is hex "
                               << concordUtils::bufferToHex(k.data(), k.size()) << " raw key " << k);
     write_batch.del(v4blockchain::detail::LATEST_KEYS_CF, getSliceArray(prefix, k));
+  }
+  if (deleted_keys_ && updates.deletes.size() > 0) {
+    *deleted_keys_ += updates.deletes.size();
   }
 }
 

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -36,7 +36,9 @@ KeyValueBlockchain::KeyValueBlockchain(
       state_transfer_chain_{native_client_},
       latest_keys_{native_client_, category_types},
       v4_metrics_comp_{concordMetrics::Component("v4_blockchain", std::make_shared<concordMetrics::Aggregator>())},
-      blocks_deleted_{v4_metrics_comp_.RegisterGauge("numOfBlocksDeleted", (block_chain_.getGenesisBlockId() - 1))} {
+      blocks_deleted_{v4_metrics_comp_.RegisterGauge(
+          "numOfBlocksDeleted", block_chain_.getGenesisBlockId() > 0 ? (block_chain_.getGenesisBlockId() - 1) : 0)},
+      deleted_keys_{v4_metrics_comp_.RegisterCounter("numOfKeysDeleted", 0)} {
   if (native_client_->createColumnFamilyIfNotExisting(v4blockchain::detail::MISC_CF)) {
     LOG_INFO(V4_BLOCK_LOG, "Created [" << v4blockchain::detail::MISC_CF << "] column family");
   }
@@ -44,6 +46,7 @@ KeyValueBlockchain::KeyValueBlockchain(
   // Mark version of blockchain
   native_client_->put(v4blockchain::detail::MISC_CF, kvbc::keyTypes::blockchain_version, kvbc::V4Version());
   v4_metrics_comp_.Register();
+  latest_keys_.setDeletedKeysMetric(&deleted_keys_);
   if (state_transfer_chain_.getLastBlockId() == 0) return;
   // Make sure that if linkSTChainFrom() has been interrupted (e.g. a crash or an abnormal shutdown), all DBAdapter
   // methods will return the correct values. For example, if state transfer had completed and linkSTChainFrom() was
@@ -70,6 +73,7 @@ KeyValueBlockchain::KeyValueBlockchain(
 */
 BlockId KeyValueBlockchain::add(categorization::Updates &&updates) {
   auto scoped = v4blockchain::detail::ScopedDuration{"Add block"};
+  static thread_local uint64_t total_size = 0;
   // Should be performed before we add the block with the current Updates.
   auto future_seq_num_ = thread_pool_.async(
       [this](const categorization::Updates &updates) { return onNewBFTSequenceNumber(updates); }, updates);
@@ -79,13 +83,18 @@ BlockId KeyValueBlockchain::add(categorization::Updates &&updates) {
   auto block_size = block.size();
   auto write_batch = native_client_->getBatch(block_size * updates_to_final_size_ration_);
   auto block_id = add(updates, block, write_batch);
+  total_size += write_batch.size();
   LOG_DEBUG(V4_BLOCK_LOG,
             "Block size is " << block_size << " reserving batch to be " << updates_to_final_size_ration_ * block_size
-                             << " size of final block is " << write_batch.size());
+                             << " size of final block is " << write_batch.size() << " total bytes written to stroage "
+                             << total_size);
   auto sequence_number = future_seq_num_.get();
   native_client_->write(std::move(write_batch));
   block_chain_.setBlockId(block_id);
   if (sequence_number > 0) setLastBlockSequenceNumber(sequence_number);
+  if (block_id % 100 == 0) {
+    v4_metrics_comp_.UpdateAggregator();
+  }
   return block_id;
 }
 
@@ -123,8 +132,9 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
   } else if (last_reachable_id == genesis_id) {
     throw std::logic_error{"Cannot delete only block as a last reachable one"};
   }
-  auto recoverdb =
-      KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(native_client_->path(), chkpnt_block_id_.has_value());
+  auto ro = true;
+  auto is_chkpnt = false;
+  auto recoverdb = KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(native_client_->path(), is_chkpnt, ro);
   auto key = concord::kvbc::v4blockchain::detail::Blockchain::generateKey(last_reachable_id);
   auto batch_data = recoverdb->get(key);
   if (!batch_data.has_value()) {
@@ -136,8 +146,8 @@ void KeyValueBlockchain::deleteLastReachableBlock() {
   auto write_batch = native_client_->getBatch(std::move(*batch_data));
   native_client_->write(std::move(write_batch));
   block_chain_.setBlockId(--last_reachable_id);
-  LOG_INFO(V4_BLOCK_LOG,
-           "Wrote revert updates of block " << last_reachable_id + 1 << " last reachable is " << last_reachable_id);
+  LOG_DEBUG(V4_BLOCK_LOG,
+            "Wrote revert updates of block " << last_reachable_id + 1 << " last reachable is " << last_reachable_id);
 }
 
 /*
@@ -150,7 +160,6 @@ as stable. the set of updates needed for reverting a block is saved on a recover
 block is called.
 */
 void KeyValueBlockchain::storeLastReachableRevertBatch(const std::optional<kvbc::BlockId> &block_id_at_chkpnt) {
-  std::shared_ptr<storage::rocksdb::NativeClient> recoverdb;
   uint64_t unstable_version{};
   auto last_reachable_id = block_chain_.getLastReachable();
   auto genesis_id = block_chain_.getGenesisBlockId();
@@ -176,23 +185,29 @@ void KeyValueBlockchain::storeLastReachableRevertBatch(const std::optional<kvbc:
   iterate over the range, for each block X get the set of updates needed to revert to the state X-1,
   and insert it to the recovery db.
   */
+  auto start_id = unstable_version;
+  if (unstable_version <= stable_version) {
+    return;
+  }
   LOG_INFO(V4_BLOCK_LOG, "reverting from " << unstable_version << " to " << stable_version);
+  uint64_t revert_size = 0;
+  auto ro = false;
+  auto write_batch = native_client_->getBatch();
+  auto recoverdb =
+      KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(native_client_->path(), block_id_at_chkpnt.has_value(), ro);
   while (unstable_version > stable_version) {
-    if (!recoverdb) {
-      recoverdb =
-          KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(native_client_->path(), block_id_at_chkpnt.has_value());
-    }
+    write_batch.clear();
     auto key = concord::kvbc::v4blockchain::detail::Blockchain::generateKey(last_reachable_id);
     auto opt_val = recoverdb->get(key);
     if (!opt_val.has_value()) {
-      LOG_INFO(V4_BLOCK_LOG,
-               "Reverting updates of block " << last_reachable_id << " unstable version " << unstable_version
-                                             << " stable version " << stable_version);
-      auto write_batch = native_client_->getBatch();
+      LOG_DEBUG(V4_BLOCK_LOG,
+                "Reverting updates of block " << last_reachable_id << " unstable version " << unstable_version
+                                              << " stable version " << stable_version);
       latest_keys_.revertLastBlockKeys(*updates, last_reachable_id, write_batch, internal_snapshot.get());
       // delete from blockchain
       block_chain_.deleteBlock(last_reachable_id, write_batch);
-      auto ser_batch = write_batch.data();
+      const auto &ser_batch = write_batch.data();
+      revert_size += ser_batch.size();
       recoverdb->put(key, ser_batch);
     } else {
       LOG_INFO(V4_BLOCK_LOG, "Recovery DB alredy has block " << last_reachable_id << " updates");
@@ -205,6 +220,9 @@ void KeyValueBlockchain::storeLastReachableRevertBatch(const std::optional<kvbc:
     updates = block_chain_.getBlockUpdates(last_reachable_id);
     unstable_version = block_id_at_chkpnt.has_value() ? last_reachable_id : getBlockSequenceNumber(*updates);
   }
+  LOG_INFO(V4_BLOCK_LOG,
+           "Done reverting from version [" << start_id << "] to version [" << unstable_version << "] total bytes "
+                                           << revert_size << " bytes");
 }
 
 /*
@@ -581,13 +599,48 @@ void KeyValueBlockchain::multiGetLatestVersion(
 void KeyValueBlockchain::trimBlocksFromSnapshot(BlockId block_id_at_checkpoint) {
   ConcordAssertNE(block_id_at_checkpoint, detail::Blockchain::INVALID_BLOCK_ID);
   ConcordAssertLE(block_id_at_checkpoint, getLastReachableBlockId());
-  chkpnt_block_id_ = block_id_at_checkpoint;
-  while (block_id_at_checkpoint < getLastReachableBlockId()) {
-    LOG_INFO(V4_BLOCK_LOG,
-             "Deleting last reachable block = " << getLastReachableBlockId()
-                                                << ", DB checkpoint = " << native_client_->path());
-    deleteLastReachableBlock();
+  auto genesis_id = block_chain_.getGenesisBlockId();
+  if (genesis_id >= block_id_at_checkpoint) {
+    throw std::logic_error{"checkpoint block id should be bigger than genesis"};
   }
+  auto start_id = getLastReachableBlockId();
+  auto ro = true;
+  auto is_chkpnt = true;
+  std::shared_ptr<storage::rocksdb::NativeClient> recoverdb;
+  auto trimmed = false;
+  while (getLastReachableBlockId() > block_id_at_checkpoint) {
+    trimmed = true;
+    auto last_reachable_id = getLastReachableBlockId();
+    if (!recoverdb) {
+      recoverdb = KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(native_client_->path(), is_chkpnt, ro);
+    }
+    LOG_DEBUG(
+        V4_BLOCK_LOG,
+        "Deleting last reachable block = " << last_reachable_id << ", DB checkpoint = " << native_client_->path());
+    auto key = concord::kvbc::v4blockchain::detail::Blockchain::generateKey(last_reachable_id);
+    auto batch_data = recoverdb->get(key);
+    if (!batch_data.has_value()) {
+      LOG_FATAL(V4_BLOCK_LOG,
+                "No recovery data found in recovery db " << recoverdb->path() << " for block " << last_reachable_id
+                                                         << ", did you call storeLastReachableRevertBatch?");
+      ConcordAssert(false);
+    }
+    auto write_batch = native_client_->getBatch(std::move(*batch_data));
+    native_client_->write(std::move(write_batch));
+    block_chain_.setBlockId(--last_reachable_id);
+    LOG_DEBUG(V4_BLOCK_LOG,
+              "Wrote revert updates of block " << last_reachable_id + 1 << " last reachable is " << last_reachable_id);
+  }
+  if (trimmed) {
+    LOG_INFO(V4_BLOCK_LOG,
+             "Trimmed range of blocks from [" << start_id << "] to [" << block_id_at_checkpoint
+                                              << "] DB checkpoint db path " << native_client_->path());
+  } else {
+    LOG_INFO(V4_BLOCK_LOG,
+             "Trimming wasn't needed as block id at checkpoint " << block_id_at_checkpoint
+                                                                 << " equals to last reachable " << start_id);
+  }
+
   KeyValueBlockchain::BlockchainRecovery::removeRecoveryDB(native_client_->path(), true);
   native_client_->del(v4blockchain::detail::MISC_CF, RecoverySnapshot::getStorableKey(block_id_at_checkpoint));
 }
@@ -604,18 +657,22 @@ void KeyValueBlockchain::checkpointInProcess(bool flag, kvbc::BlockId block_id_a
   if (flag) {
     auto last_reachable_id = block_chain_.getLastReachable();
     ConcordAssertEQ(last_reachable_id, block_id_at_chkpnt);
-    LOG_INFO(V4_BLOCK_LOG, "Taking snapshot at checkpoint start with block id " << last_reachable_id);
     auto new_snap_shot = RecoverySnapshot{&native_client_->rawDB()};
     chkpnt_snap_shots_[last_reachable_id] = new_snap_shot.get();
+    LOG_INFO(V4_BLOCK_LOG,
+             "Taking snapshot at checkpoint start with block id "
+                 << last_reachable_id << " snapshot sn " << chkpnt_snap_shots_[last_reachable_id]->GetSequenceNumber());
     native_client_->put(v4blockchain::detail::MISC_CF,
                         RecoverySnapshot::getStorableKey(block_id_at_chkpnt),
                         new_snap_shot.getStorableSeqNumAndPreventRelease(last_reachable_id));
   } else {
     if (chkpnt_snap_shots_.count(block_id_at_chkpnt) > 0) {
+      auto sn = chkpnt_snap_shots_[block_id_at_chkpnt]->GetSequenceNumber();
       RecoverySnapshot::releasePreviousSnapshot(chkpnt_snap_shots_[block_id_at_chkpnt], &native_client_->rawDB());
       chkpnt_snap_shots_.erase(block_id_at_chkpnt);
       native_client_->del(v4blockchain::detail::MISC_CF, RecoverySnapshot::getStorableKey(block_id_at_chkpnt));
-      LOG_INFO(V4_BLOCK_LOG, "Released snapshot for checkpoint at block id " << block_id_at_chkpnt);
+      LOG_INFO(V4_BLOCK_LOG,
+               "Released snapshot for checkpoint at block id " << block_id_at_chkpnt << " snapshot sn " << sn);
     } else {
       LOG_WARN(V4_BLOCK_LOG, "Didn't find snapshot for checkpoint at block id " << block_id_at_chkpnt);
     }
@@ -678,13 +735,14 @@ void KeyValueBlockchain::BlockchainRecovery::removeRecoveryDB(const std::string 
 }
 
 std::shared_ptr<storage::rocksdb::NativeClient> KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(
-    const std::string &path, bool is_chkpnt) {
+    const std::string &path, bool is_chkpnt, bool read_only) {
   auto rec_path = getPath(path, is_chkpnt);
-  auto ro = false;
-  fs::create_directory(rec_path);
-  LOG_INFO(V4_BLOCK_LOG, "Openned recoverdb at " << rec_path);
+  if (!read_only) {
+    fs::create_directory(rec_path);
+  }
   std::shared_ptr<storage::IDBClient> db{std::make_shared<storage::rocksdb::Client>(rec_path)};
-  db->init(ro);
+  db->init(read_only);
+  LOG_INFO(V4_BLOCK_LOG, "Openned recoverdb at " << rec_path);
   return concord::storage::rocksdb::NativeClient::fromIDBClient(db);
 }
 

--- a/kvbc/test/v4blockchain/v4_blockchain_test.cpp
+++ b/kvbc/test/v4blockchain/v4_blockchain_test.cpp
@@ -1095,8 +1095,8 @@ TEST(checkpoint_recovery, trimming) {
       blckchn.add(std::move(updates));
     }
 
-    std::vector<std::string> versioned_new_keys;
-    std::vector<std::string> imm_new_keys;
+    // std::vector<std::string> versioned_new_keys;
+    // std::vector<std::string> imm_new_keys;
 
     for (const auto& k : merkle_new_keys) {
       auto val = blckchn.getLatest("merkle", k);
@@ -1118,7 +1118,8 @@ TEST(checkpoint_recovery, trimming) {
     auto native_cl2 = TestRocksDb::createNative(6);
     auto blckchn = v4blockchain::KeyValueBlockchain{native_cl2, true, cat_map};
     {
-      auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(dbpath, true);
+      auto recdb =
+          concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(dbpath, true, true);
       // check that only blocks that were added after calling checkpointInProcess(true) has value in recovery db.
       for (uint64_t i = 0; i <= last_id; ++i) {
         auto opt_val = recdb->get(concord::kvbc::v4blockchain::detail::Blockchain::generateKey(i));
@@ -1212,7 +1213,7 @@ TEST(recovery, blockchain_recovery_class) {
   ASSERT_EQ(exec_path, "/tmp/concord_recovery_execution");
 
   {
-    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, false);
+    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, false, false);
     ASSERT_TRUE(recdb);
     ASSERT_EQ(recdb->path(), "/tmp/concord_recovery_execution");
     ASSERT_TRUE(fs::is_directory(recdb->path()));
@@ -1221,7 +1222,7 @@ TEST(recovery, blockchain_recovery_class) {
   }
 
   {
-    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, true);
+    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, true, false);
     ASSERT_TRUE(recdb);
     ASSERT_EQ(recdb->path(), "/tmp/concord_recovery_checkpoint");
     ASSERT_TRUE(fs::is_directory(recdb->path()));
@@ -1358,7 +1359,7 @@ TEST(recovery, storeLastReachableRevertBatch) {
   }
   // put dummy value to check if storeLastReachableRevertBatch doesn't override
   {
-    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, false);
+    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, false, false);
     auto key = concord::kvbc::v4blockchain::detail::Blockchain::generateKey(numblocks);
     recdb->put(key, std::string{"dummy"});
   }
@@ -1366,7 +1367,7 @@ TEST(recovery, storeLastReachableRevertBatch) {
   ASSERT_TRUE(fs::is_directory(exec_path));
 
   {
-    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, false);
+    auto recdb = concord::kvbc::v4blockchain::KeyValueBlockchain::BlockchainRecovery::getRecoveryDB(path, false, true);
     auto key = concord::kvbc::v4blockchain::detail::Blockchain::generateKey(numblocks - 1);
     auto val = recdb->get(key);
     ASSERT_FALSE(val.has_value());

--- a/storage/include/rocksdb/native_write_batch.h
+++ b/storage/include/rocksdb/native_write_batch.h
@@ -65,7 +65,8 @@ class NativeWriteBatch {
 
   std::size_t size() const;
   std::uint32_t count() const;
-  std::string data() const { return batch_.Data(); }
+  const std::string &data() const { return batch_.Data(); }
+  void clear() { return batch_.Clear(); }
 
  private:
   std::shared_ptr<const NativeClient> client_;


### PR DESCRIPTION
- Adaptive pruning measurements are being taken on the hot path, but this feature is disabled and won't be used.
- Changing recovery to:
1. use a single write batch to create the recovery data.
2. Differentiate between read-only ar write mode when opening the recovery DB.
3. performing all trimming in a single operation, instead of calling deleteLast that per invocation, opens and closes the recovery DB.

- Adding logs and metrics.

tests:
As no new functionality was added, relying on passing CI and Concord CI, multiple Performace runs. 