### PR TITLE
Allow reserved pages contain replies of all requests in a batch

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -42,6 +42,7 @@ struct ClientRequestMsgHeader {
   uint32_t cidLength = 0;
   uint16_t reqSignatureLength = 0;
   uint32_t extraDataLength = 0;
+  uint16_t indexInBatch = 0;
 
   // followed by the request (security information, such as signatures, should be part of the request)
 

--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -47,6 +47,7 @@ class IRequestsHandler {
     uint32_t maxReplySize = 0;
     char *outReply = nullptr;
     uint64_t requestSequenceNum = executionSequenceNum;
+    uint16_t reqIndexInClientBatch = 0;
     uint32_t outExecutionStatus = 1;  // UNKNOWN
     uint32_t outActualReplySize = 0;
     uint32_t outReplicaSpecificInfoSize = 0;

--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -236,6 +236,7 @@ void ReadOnlyReplica::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_s
                                                                               reply.maxReplyLength(),
                                                                               reply.replyBuf(),
                                                                               request.requestSeqNum(),
+                                                                              request.requestIndexInBatch(),
                                                                               request.result()});
 
   // DD: Do we need to take care of Time Service here?

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -49,7 +49,10 @@ ReplicaForStateTransfer::ReplicaForStateTransfer(const ReplicaConfig &config,
   ClientsManager::setNumResPages(
       (config.numReplicas + config.numRoReplicas + config.numOfClientProxies + config.numOfExternalClients +
        config.numReplicas + config.numOfClientServices) *
-      ClientsManager::reservedPagesPerClient(config.getsizeOfReservedPage(), config.maxReplyMessageSize));
+      ClientsManager::reservedPagesPerClient(
+          config.getsizeOfReservedPage(),
+          config.maxReplyMessageSize,
+          (config.clientBatchingEnabled && config.preExecutionFeatureEnabled) ? config.clientBatchingMaxMsgsNbr : 1));
   ClusterKeyStore::setNumResPages(config.numReplicas);
 
   if (firstTime_ || !config_.debugPersistentStorageEnabled)

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -69,95 +69,106 @@
 using concordUtil::Timers;
 using namespace std;
 using namespace std::chrono;
-using namespace std::placeholders;
 using namespace concord::diagnostics;
 
 namespace bftEngine::impl {
 
 void ReplicaImp::registerMsgHandlers() {
   msgHandlers_->registerMsgHandler(MsgCode::Checkpoint,
-                                   bind(&ReplicaImp::messageHandler<CheckpointMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<CheckpointMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<CheckpointMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<CheckpointMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::CommitPartial,
-                                   bind(&ReplicaImp::messageHandler<CommitPartialMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<CommitPartialMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::CommitPartial,
+      bind(&ReplicaImp::messageHandler<CommitPartialMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<CommitPartialMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::CommitFull,
-                                   bind(&ReplicaImp::messageHandler<CommitFullMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<CommitFullMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<CommitFullMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<CommitFullMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::FullCommitProof,
-                                   bind(&ReplicaImp::messageHandler<FullCommitProofMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<FullCommitProofMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::FullCommitProof,
+      bind(&ReplicaImp::messageHandler<FullCommitProofMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<FullCommitProofMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::NewView,
-                                   bind(&ReplicaImp::messageHandler<NewViewMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<NewViewMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<NewViewMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<NewViewMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::PrePrepare,
-                                   bind(&ReplicaImp::messageHandler<PrePrepareMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<PrePrepareMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<PrePrepareMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<PrePrepareMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::PartialCommitProof,
-                                   bind(&ReplicaImp::messageHandler<PartialCommitProofMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<PartialCommitProofMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::PartialCommitProof,
+      bind(&ReplicaImp::messageHandler<PartialCommitProofMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<PartialCommitProofMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::PreparePartial,
-                                   bind(&ReplicaImp::messageHandler<PreparePartialMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<PreparePartialMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::PreparePartial,
+      bind(&ReplicaImp::messageHandler<PreparePartialMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<PreparePartialMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::PrepareFull,
-                                   bind(&ReplicaImp::messageHandler<PrepareFullMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<PrepareFullMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<PrepareFullMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<PrepareFullMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::ReqMissingData,
-                                   bind(&ReplicaImp::messageHandler<ReqMissingDataMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ReqMissingDataMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::ReqMissingData,
+      bind(&ReplicaImp::messageHandler<ReqMissingDataMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<ReqMissingDataMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::SimpleAck,
-                                   bind(&ReplicaImp::messageHandler<SimpleAckMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<SimpleAckMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<SimpleAckMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<SimpleAckMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::StartSlowCommit,
-                                   bind(&ReplicaImp::messageHandler<StartSlowCommitMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<StartSlowCommitMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::StartSlowCommit,
+      bind(&ReplicaImp::messageHandler<StartSlowCommitMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<StartSlowCommitMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::ViewChange,
-                                   bind(&ReplicaImp::messageHandler<ViewChangeMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ViewChangeMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<ViewChangeMsg>, this, placeholders::_1),
+                                   bind(&ReplicaImp::validatedMessageHandler<ViewChangeMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::ClientRequest,
-                                   bind(&ReplicaImp::messageHandler<ClientRequestMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ClientRequestMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::ClientRequest,
+      bind(&ReplicaImp::messageHandler<ClientRequestMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<ClientRequestMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(
       MsgCode::PreProcessResult,
-      bind(&ReplicaImp::messageHandler<preprocessor::PreProcessResultMsg>, this, _1),
-      bind(&ReplicaImp::validatedMessageHandler<preprocessor::PreProcessResultMsg>, this, _1));
+      bind(&ReplicaImp::messageHandler<preprocessor::PreProcessResultMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<preprocessor::PreProcessResultMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::ReplicaStatus,
-                                   bind(&ReplicaImp::messageHandler<ReplicaStatusMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ReplicaStatusMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::ReplicaStatus,
+      bind(&ReplicaImp::messageHandler<ReplicaStatusMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<ReplicaStatusMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::AskForCheckpoint,
-                                   bind(&ReplicaImp::messageHandler<AskForCheckpointMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<AskForCheckpointMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::AskForCheckpoint,
+      bind(&ReplicaImp::messageHandler<AskForCheckpointMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<AskForCheckpointMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::ReplicaAsksToLeaveView,
-                                   bind(&ReplicaImp::messageHandler<ReplicaAsksToLeaveViewMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ReplicaAsksToLeaveViewMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::ReplicaAsksToLeaveView,
+      bind(&ReplicaImp::messageHandler<ReplicaAsksToLeaveViewMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<ReplicaAsksToLeaveViewMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::ReplicaRestartReady,
-                                   bind(&ReplicaImp::messageHandler<ReplicaRestartReadyMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ReplicaRestartReadyMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::ReplicaRestartReady,
+      bind(&ReplicaImp::messageHandler<ReplicaRestartReadyMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<ReplicaRestartReadyMsg>, this, placeholders::_1));
 
-  msgHandlers_->registerMsgHandler(MsgCode::ReplicasRestartReadyProof,
-                                   bind(&ReplicaImp::messageHandler<ReplicasRestartReadyProofMsg>, this, _1),
-                                   bind(&ReplicaImp::validatedMessageHandler<ReplicasRestartReadyProofMsg>, this, _1));
+  msgHandlers_->registerMsgHandler(
+      MsgCode::ReplicasRestartReadyProof,
+      bind(&ReplicaImp::messageHandler<ReplicasRestartReadyProofMsg>, this, placeholders::_1),
+      bind(&ReplicaImp::validatedMessageHandler<ReplicasRestartReadyProofMsg>, this, placeholders::_1));
 
   msgHandlers_->registerMsgHandler(MsgCode::StateTransfer,
-                                   bind(&ReplicaImp::messageHandler<StateTransferMsg>, this, _1));
+                                   bind(&ReplicaImp::messageHandler<StateTransferMsg>, this, placeholders::_1));
 
   msgHandlers_->registerInternalMsgHandler([this](InternalMessage &&msg) { onInternalMsg(std::move(msg)); });
 }
@@ -4021,7 +4032,8 @@ ReplicaImp::ReplicaImp(const LoadedReplicaData &ld,
   bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool) { ps_->setEraseMetadataStorageFlag(); });
   bftEngine::ControlStateManager::instance().setRestartReadyFunc(
       [&](uint8_t reason, const std::string &extraData) { sendRepilcaRestartReady(reason, extraData); });
-  bftEngine::EpochManager::instance().setNewEpochFlagHandler(std::bind(&PersistentStorage::setNewEpochFlag, ps_, _1));
+  bftEngine::EpochManager::instance().setNewEpochFlagHandler(
+      std::bind(&PersistentStorage::setNewEpochFlag, ps_, placeholders::_1));
   lastAgreedView = ld.viewsManager->latestActiveView();
 
   if (ld.viewsManager->viewIsActive(lastAgreedView)) {
@@ -4266,7 +4278,8 @@ ReplicaImp::ReplicaImp(const ReplicaConfig &config,
     bftEngine::ControlStateManager::instance().setRemoveMetadataFunc([&](bool) { ps_->setEraseMetadataStorageFlag(); });
     bftEngine::ControlStateManager::instance().setRestartReadyFunc(
         [&](uint8_t reason, const std::string &extraData) { sendRepilcaRestartReady(reason, extraData); });
-    bftEngine::EpochManager::instance().setNewEpochFlagHandler(std::bind(&PersistentStorage::setNewEpochFlag, ps_, _1));
+    bftEngine::EpochManager::instance().setNewEpochFlagHandler(
+        std::bind(&PersistentStorage::setNewEpochFlag, ps_, placeholders::_1));
   }
 }
 
@@ -4670,6 +4683,7 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
                                                                               reply.maxReplyLength(),
                                                                               reply.replyBuf(),
                                                                               request->requestSeqNum(),
+                                                                              request->requestIndexInBatch(),
                                                                               request->result()});
   {
     TimeRecorder scoped_timer(*histograms_.executeReadOnlyRequest);
@@ -4990,6 +5004,7 @@ void ReplicaImp::executeSpecialRequests(PrePrepareMsg *ppMsg,
           static_cast<uint32_t>(config_.getmaxReplyMessageSize() - sizeof(ClientReplyMsgHeader)),
           static_cast<char *>(std::malloc(config_.getmaxReplyMessageSize() - sizeof(ClientReplyMsgHeader))),
           req.requestSeqNum(),
+          req.requestIndexInBatch(),
           req.result()});
 
       numOfSpecialReqs--;
@@ -5060,6 +5075,7 @@ void ReplicaImp::executeRequests(PrePrepareMsg *ppMsg, Bitmap &requestSet, Times
         static_cast<uint32_t>(config_.getmaxReplyMessageSize() - sizeof(ClientReplyMsgHeader)),
         replyBuffer,
         req.requestSeqNum(),
+        req.requestIndexInBatch(),
         req.result(),
         replySize});
 
@@ -5608,6 +5624,7 @@ void ReplicaImp::executeRequestsAndSendResponses(PrePrepareMsg *ppMsg,
         static_cast<uint32_t>(config_.getmaxReplyMessageSize() - sizeof(ClientReplyMsgHeader)),
         replyBuffer,
         req.requestSeqNum(),
+        req.requestIndexInBatch(),
         req.result(),
         replySize});
     // Decode the pre-execution block-id for the conflict detection optimization,
@@ -5669,10 +5686,17 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
                                                                         currentPrimary(),
                                                                         req.outReply,
                                                                         req.outActualReplySize,
+                                                                        req.reqIndexInClientBatch,
                                                                         req.outReplicaSpecificInfoSize,
                                                                         executionResult);
-        send(replyMsg.get(), req.clientId);
-        free(req.outReply);
+        if (replyMsg) {
+          send(replyMsg.get(), req.clientId);
+          free(req.outReply);
+        } else {
+          LOG_DEBUG(GL,
+                    "Failed to allocate and save new reply to storage"
+                        << KVLOG(req.clientId, req.requestSequenceNum, req.reqIndexInClientBatch));
+        }
         req.outReply = nullptr;
         clientsManager->removePendingForExecutionRequest(req.clientId, req.requestSequenceNum);
         continue;
@@ -5689,10 +5713,17 @@ void ReplicaImp::sendResponses(PrePrepareMsg *ppMsg, IRequestsHandler::Execution
                                                                     currentPrimary(),
                                                                     req.outReply,
                                                                     req.outActualReplySize,
+                                                                    req.reqIndexInClientBatch,
                                                                     0,
                                                                     executionResult);
-    send(replyMsg.get(), req.clientId);
-    free(req.outReply);
+    if (replyMsg) {
+      send(replyMsg.get(), req.clientId);
+      free(req.outReply);
+    } else {
+      LOG_DEBUG(GL,
+                "Failed to allocate and save new reply to storage"
+                    << KVLOG(req.clientId, req.requestSequenceNum, req.reqIndexInClientBatch));
+    }
     req.outReply = nullptr;
     clientsManager->removePendingForExecutionRequest(req.clientId, req.requestSequenceNum);
   }

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
@@ -25,7 +25,7 @@ class ClientReplyMsg : public MessageBase {
   static_assert(sizeof(ClientReplyMsgHeader::reqSeqNum) == sizeof(ReqId), "");
   static_assert(sizeof(ClientReplyMsgHeader::currentPrimaryId) == sizeof(ReplicaId), "");
   static_assert(sizeof(ClientReplyMsgHeader::result) == sizeof(uint32_t), "");
-  static_assert(sizeof(ClientReplyMsgHeader) == 28, "ClientRequestMsgHeader is 28B");
+  static_assert(sizeof(ClientReplyMsgHeader) == 28, "ClientReplyMsgHeader is 28B");
 
  public:
   ClientReplyMsg(ReplicaId primaryId, ReqId reqSeqNum, ReplicaId replicaId);

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -46,7 +46,8 @@ ClientRequestMsg::ClientRequestMsg(NodeIdType sender,
                                    const concordUtils::SpanContext& spanContext,
                                    const char* requestSignature,
                                    uint32_t requestSignatureLen,
-                                   const uint32_t extraBufSize)
+                                   uint32_t extraBufSize,
+                                   uint16_t indexInBatch)
     : MessageBase(sender,
                   MsgCode::ClientRequest,
                   spanContext.data().size(),
@@ -54,7 +55,16 @@ ClientRequestMsg::ClientRequestMsg(NodeIdType sender,
   // logical XOR - if requestSignatureLen is zero requestSignature must be null and vise versa
   ConcordAssert((requestSignature == nullptr) == (requestSignatureLen == 0));
   // set header
-  setParams(sender, reqSeqNum, requestLength, flags, reqTimeoutMilli, result, cid, requestSignatureLen, extraBufSize);
+  setParams(sender,
+            reqSeqNum,
+            requestLength,
+            flags,
+            reqTimeoutMilli,
+            result,
+            cid,
+            requestSignatureLen,
+            extraBufSize,
+            indexInBatch);
 
   // set span context
   char* position = body() + sizeof(ClientRequestMsgHeader);
@@ -221,7 +231,8 @@ void ClientRequestMsg::setParams(NodeIdType sender,
                                  uint32_t result,
                                  const std::string& cid,
                                  uint32_t requestSignatureLen,
-                                 uint32_t extraBufSize) {
+                                 uint32_t extraBufSize,
+                                 uint16_t indexInBatch) {
   auto* header = msgBody();
   header->idOfClientProxy = sender;
   header->timeoutMilli = reqTimeoutMilli;
@@ -232,6 +243,7 @@ void ClientRequestMsg::setParams(NodeIdType sender,
   header->cidLength = cid.size();
   header->reqSignatureLength = requestSignatureLen;
   header->extraDataLength = extraBufSize;
+  header->indexInBatch = indexInBatch;
 }
 
 std::string ClientRequestMsg::getCid() const {

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -26,7 +26,7 @@ class ClientRequestMsg : public MessageBase {
   static_assert(sizeof(ClientRequestMsgHeader::msgType) == sizeof(MessageBase::Header::msgType), "");
   static_assert(sizeof(ClientRequestMsgHeader::idOfClientProxy) == sizeof(NodeIdType), "");
   static_assert(sizeof(ClientRequestMsgHeader::reqSeqNum) == sizeof(ReqId), "");
-  static_assert(sizeof(ClientRequestMsgHeader) == 50, "ClientRequestMsgHeader size is 50B");
+  static_assert(sizeof(ClientRequestMsgHeader) == 52, "ClientRequestMsgHeader size is 52B");
   static concord::diagnostics::Recorder sigNatureVerificationRecorder;
   // TODO(GG): more asserts
 
@@ -42,7 +42,8 @@ class ClientRequestMsg : public MessageBase {
                    const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{},
                    const char* requestSignature = nullptr,
                    uint32_t requestSignatureLen = 0,
-                   const uint32_t extraBufSize = 0);
+                   uint32_t extraBufSize = 0,
+                   uint16_t indexInBatch = 0);
 
   ClientRequestMsg(NodeIdType sender);
 
@@ -70,6 +71,8 @@ class ClientRequestMsg : public MessageBase {
 
   uint64_t requestTimeoutMilli() const { return msgBody()->timeoutMilli; }
 
+  uint16_t requestIndexInBatch() const { return msgBody()->indexInBatch; }
+
   std::string getCid() const;
 
   void validate(const ReplicasInfo& repInfo) const override { validateImp(repInfo); }
@@ -95,7 +98,8 @@ class ClientRequestMsg : public MessageBase {
                  uint32_t result,
                  const std::string& cid,
                  uint32_t requestSignatureLen,
-                 uint32_t extraBufSize);
+                 uint32_t extraBufSize,
+                 uint16_t offsetInBatch);
 };
 
 template <>

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1353,7 +1353,8 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
                                                        span_context,
                                                        reqProcessingStatePtr->getReqSignature(),
                                                        reqProcessingStatePtr->getReqSignatureLength(),
-                                                       sigsBuf);
+                                                       sigsBuf,
+                                                       reqOffsetInBatch);
       LOG_DEBUG(logger(),
                 "Pass PreProcessResultMsg to ReplicaImp for consensus"
                     << KVLOG(batchCid, reqSeqNum, reqCid, clientId, reqOffsetInBatch, preProcessResult));
@@ -1368,7 +1369,9 @@ void PreProcessor::finalizePreProcessing(NodeIdType clientId, uint16_t reqOffset
                                                     preProcessResult,
                                                     span_context,
                                                     reqProcessingStatePtr->getReqSignature(),
-                                                    reqProcessingStatePtr->getReqSignatureLength());
+                                                    reqProcessingStatePtr->getReqSignatureLength(),
+                                                    0,
+                                                    reqOffsetInBatch);
       LOG_DEBUG(logger(),
                 "Pass pre-processed ClientRequestMsg to ReplicaImp for consensus"
                     << KVLOG(batchCid, reqSeqNum, reqCid, clientId, reqOffsetInBatch, preProcessResult));
@@ -1756,6 +1759,7 @@ OperationResult PreProcessor::launchReqPreProcessing(const string &batchCid,
       maxPreExecResultSize_,
       preProcessResultBuffer,
       reqSeqNum,
+      reqOffsetInBatch,
       preProcessReqMsg->result()};
   requestsHandler_.preExecute(request, std::nullopt, reqCid, span);
   auto preProcessResult = static_cast<OperationResult>(request.outExecutionStatus);

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.cpp
@@ -29,7 +29,8 @@ PreProcessResultMsg::PreProcessResultMsg(NodeIdType sender,
                                          const concordUtils::SpanContext& spanContext,
                                          const char* messageSignature,
                                          uint32_t messageSignatureLen,
-                                         const std::string& resultSignatures)
+                                         const std::string& resultSignatures,
+                                         uint16_t indexInBatch)
     : ClientRequestMsg(sender,
                        HAS_PRE_PROCESSED_FLAG,
                        reqSeqNum,
@@ -41,7 +42,8 @@ PreProcessResultMsg::PreProcessResultMsg(NodeIdType sender,
                        spanContext,
                        messageSignature,
                        messageSignatureLen,
-                       resultSignatures.size()) {
+                       resultSignatures.size(),
+                       indexInBatch) {
   msgBody_->msgType = MsgCode::PreProcessResult;
   // ClientRequestMsg allocates additional memory for the signatures.
   // Get pointer to it here and assert if the buffer is not big enough.

--- a/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessResultMsg.hpp
@@ -48,7 +48,8 @@ class PreProcessResultMsg : public ClientRequestMsg {
                       const concordUtils::SpanContext& spanContext = concordUtils::SpanContext{},
                       const char* messageSignature = nullptr,
                       uint32_t messageSignatureLen = 0,
-                      const std::string& resultSignatures = "");
+                      const std::string& resultSignatures = "",
+                      uint16_t indexInBatch = 0);
 
   PreProcessResultMsg(bftEngine::ClientRequestMsgHeader* body);
 

--- a/client/bftclient/src/bft_client.cpp
+++ b/client/bftclient/src/bft_client.cpp
@@ -104,6 +104,7 @@ Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool rea
   header->result = 1;  // UNKNOWN
   header->reqSignatureLength = 0;
   header->extraDataLength = 0;
+  header->indexInBatch = 0;
 
   auto* position = msg.data() + header_size;
 

--- a/util/pyclient/bft_client.py
+++ b/util/pyclient/bft_client.py
@@ -193,7 +193,7 @@ class BftClient(ABC):
                 msg, signature, client_id = self._corrupt_signing_params(msg, signature, client_id, corrupt_params)
 
         data = bft_msgs.pack_request(client_id, seq_num, read_only, self.config.req_timeout_milli, cid, msg, result,
-                                     pre_process, reconfiguration=reconfiguration, signature=signature)
+                                     pre_process, reconfiguration=reconfiguration, signature=signature, batch_index=0)
 
         if m_of_n_quorum is None:
             m_of_n_quorum = MofNQuorum.LinearizableQuorum(self.config, [r.id for r in self.replicas])
@@ -239,7 +239,7 @@ class BftClient(ABC):
 
             msg_data = b''.join([msg_data, bft_msgs.pack_request(
                 self.client_id, msg_seq_num, False, self.config.req_timeout_milli, msg_cid, msg, 0, True,
-                reconfiguration=False, span_context=b'', signature=signature)])
+                reconfiguration=False, span_context=b'', signature=signature, batch_index=n)])
 
         data = bft_msgs.pack_batch_request(self.client_id, batch_size, msg_data, cid)
 

--- a/util/pyclient/test_msgs.py
+++ b/util/pyclient/test_msgs.py
@@ -150,9 +150,10 @@ class TestPackUnpack(unittest.TestCase):
         msg = b'hello'
         op_result = 5
         cid = str(req_seq_num)
+        batch_index = 4
 
         packed = bft_msgs.pack_request(client_id, req_seq_num, read_only, timeout_milli, cid, msg, op_result,
-                                       pre_process=False, span_context=span_context)
+                                       pre_process=False, span_context=span_context, batch_index=batch_index)
         header, unpacked_span_context, unpacked_msg, unpacked_cid = bft_msgs.unpack_request(packed)
 
         self.assertEqual(len(span_context), header.span_context_size)
@@ -167,6 +168,7 @@ class TestPackUnpack(unittest.TestCase):
         self.assertEqual(span_context, unpacked_span_context)
         self.assertEqual(msg, unpacked_msg)
         self.assertEqual(cid, unpacked_cid)
+        self.assertEqual(batch_index, header.index_in_batch)
 
     def test_expect_msg_error(self):
         data = b'someinvalidmsg'


### PR DESCRIPTION
* **Problem Overview**  
* Until now we had reserved pages for one request per client. That means that when client sends a batch, only one reply of it is saved to reserved pages. If a one reply (or more) of a batch is missing, the client retransmits the batch. In that case, we would like to have the replies we already sent saved to reserved pages to avoid additional consensuses and executions.
So, with this PR, the reserved pages can contain #batch_size replies (when client batching and pre-processing are enabled).
The location of a reply in client's reserved pages is determined according to request's offset in batch.
* **Testing Done** 
* unit tests and Apollo tests
* Tested locally with docker-compose
