### PR TITLE
Fix for replica crash in collecting state

### DIFF
--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -531,8 +531,6 @@ void SimpleStateTran::startCollectingState() {
 
 bool SimpleStateTran::isCollectingState() const {
   ConcordAssert(isInitialized());
-  ConcordAssert(internalST_->isRunning());
-
   return internalST_->isCollectingState();
 }
 


### PR DESCRIPTION
* **Problem Overview**  
Replica crashed inside function tryToStartOrFinishExecution.
` FATAL|4|concord.bft|message-processing|||4|slow|ReplicaImp.cpp:4705| +Assert: expression '!isCollectingState()' is false in function tryToStartOrFinishExecution`

When tryToStartOrFinishExecution is called, the replica should not be in collecting state.
The way of finding out if replica is in collecting state causes the issue as we have state transfer in different thread now.
So even if we are checking if replica is not in state stander few sec back we cannot be sure,  that after few sec also it will not be in state transfer.

* **Testing Done**  

Tested on 200 TPS, no crash found.
Tested perf-run on 650 TPS and no crash found.
Ran Manual state transfers on 1000 TPS and no crash was found on replica.