### PR TITLE
State transfer check addition

### DIFF
--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -174,6 +174,8 @@ class SkvbcRestartRecoveryTest(ApolloTest):
 
             old_view = view
 
+            await self._await_replicas_in_state_transfer(log, bft_network, skvbc, current_primary)
+
             # Wait for quorum of replicas to move to a higher view
             with trio.fail_after(seconds=20 + timeouts):
                 while view == old_view:


### PR DESCRIPTION
restart_recovery_suite failed on agree view timeout.

The logs showed that state transfer kicked in which caused timeout.

Could not reproduce locally. Nightly job should reveal correctness of the fix.

