### PR TITLE
Fix for Restore option in Object Store utility

### DIFF
--- a/kvbc/include/categorization/kv_blockchain.h
+++ b/kvbc/include/categorization/kv_blockchain.h
@@ -74,6 +74,7 @@ class KeyValueBlockchain {
   }
 
   std::optional<Hash> parentDigest(BlockId block_id) const;
+  std::optional<Hash> calculateBlockDigest(BlockId block_id) const;
   bool hasBlock(BlockId block_id) const;
 
   std::vector<std::string> getStaleKeys(BlockId block_id,

--- a/kvbc/include/kvbc_adapter/replica_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/replica_adapter.hpp
@@ -238,6 +238,10 @@ class ReplicaBlockchain : public IBlocksDeleter,
     return kvbc_ == nullptr ? v4_kvbc_->parentDigest(block_id) : kvbc_->parentDigest(block_id);
   }
 
+  std::optional<concord::util::digest::Digest> calculateBlockDigest(BlockId block_id) {
+    return kvbc_ == nullptr ? v4_kvbc_->calculateBlockDigest(block_id) : kvbc_->calculateBlockDigest(block_id);
+  }
+
  private:
   void switch_to_rawptr();
 

--- a/kvbc/include/v4blockchain/detail/st_chain.h
+++ b/kvbc/include/v4blockchain/detail/st_chain.h
@@ -32,6 +32,8 @@ class StChain {
   // Returns the buffer that represents the block
   std::optional<std::string> getBlockData(concord::kvbc::BlockId) const;
   concord::util::digest::BlockDigest getBlockParentDigest(concord::kvbc::BlockId id) const;
+  concord::util::digest::BlockDigest getBlockDigest(concord::kvbc::BlockId id) const;
+
   ///////// ST last block ID
   void resetChain() { last_block_id_ = 0; }
   void updateLastIdAfterDeletion(const kvbc::BlockId);

--- a/kvbc/include/v4blockchain/v4_blockchain.h
+++ b/kvbc/include/v4blockchain/v4_blockchain.h
@@ -64,6 +64,8 @@ class KeyValueBlockchain {
   void pruneOnSTLink(const categorization::Updates &);
   // Gets the digest from block, the digest represents the digest of the previous block i.e. parent digest
   concord::util::digest::BlockDigest parentDigest(BlockId block_id) const;
+  concord::util::digest::BlockDigest calculateBlockDigest(BlockId block_id) const;
+
   std::optional<BlockId> getLastStatetransferBlockId() const;
 
   // In v4 storage in contrast to the categorized storage, pruning does not impact the state i.e. the digest

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -825,6 +825,16 @@ std::optional<Hash> KeyValueBlockchain::parentDigest(BlockId block_id) const {
   return block_chain_.parentDigest(block_id);
 }
 
+std::optional<Hash> KeyValueBlockchain::calculateBlockDigest(BlockId block_id) const {
+  // get the block from ST chain or block chain.
+  auto raw_block = getRawBlock(block_id);
+  if (raw_block) {
+    auto my_block = categorization::RawBlock::serialize(raw_block.value());
+    return computeBlockDigest(block_id, reinterpret_cast<const char*>(my_block.data()), my_block.size());
+  }
+  return std::nullopt;
+}
+
 bool KeyValueBlockchain::hasBlock(BlockId block_id) const {
   const auto last_reachable_block = getLastReachableBlockId();
   if (block_id > last_reachable_block) {

--- a/kvbc/src/v4blockchain/detail/st_chain.cpp
+++ b/kvbc/src/v4blockchain/detail/st_chain.cpp
@@ -92,6 +92,12 @@ concord::util::digest::BlockDigest StChain::getBlockParentDigest(concord::kvbc::
   return block->parentDigest();
 }
 
+concord::util::digest::BlockDigest StChain::getBlockDigest(concord::kvbc::BlockId id) const {
+  auto block = getBlock(id);
+  ConcordAssert(block.has_value());
+  return block->calculateDigest(id);
+}
+
 std::optional<std::string> StChain::getBlockData(concord::kvbc::BlockId id) const {
   auto key = v4blockchain::detail::Blockchain::generateKey(id);
   return native_client_->get(v4blockchain::detail::ST_CHAIN_CF, key);

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -330,6 +330,21 @@ concord::util::digest::BlockDigest KeyValueBlockchain::parentDigest(BlockId bloc
   return block_chain_.getBlockParentDigest(block_id);
 }
 
+concord::util::digest::BlockDigest KeyValueBlockchain::calculateBlockDigest(BlockId block_id) const {
+  const auto last_reachable_block = getLastReachableBlockId();
+  if (block_id > last_reachable_block) {
+    return state_transfer_chain_.getBlockDigest(block_id);
+  }
+  if (block_id < getGenesisBlockId()) {
+    LOG_ERROR(V4_BLOCK_LOG,
+              "Trying to get digest from block " << block_id << " while genesis is " << getGenesisBlockId());
+    concord::util::digest::BlockDigest empty_digest;
+    empty_digest.fill(0);
+    return empty_digest;
+  }
+  return block_chain_.calculateBlockDigest(block_id);
+}
+
 void KeyValueBlockchain::addBlockToSTChain(const BlockId &block_id,
                                            const char *block,
                                            const uint32_t block_size,

--- a/kvbc/test/v4blockchain/v4_blockchain_test.cpp
+++ b/kvbc/test/v4blockchain/v4_blockchain_test.cpp
@@ -1383,7 +1383,7 @@ TEST(recovery, storeLastReachableRevertBatch) {
   }
 }
 
-TEST(recovery, laodLastReachableAfterDeletion) {
+TEST(recovery, loadLastReachableAfterDeletion) {
   std::string dbpath;
   std::random_device seed;
   std::mt19937 gen{seed()};                     // seed the generator
@@ -2480,6 +2480,23 @@ TEST_F(v4_kvbc, all_get_latest_versions) {
       ASSERT_EQ(immutable_versions[i], (latest_versions[i])->version);
     }
   }
+}
+
+TEST_F(v4_kvbc, digest_checks) {
+  uint64_t max_block = 500;
+  uint32_t num_merkle_each = 10;
+  uint32_t num_versioned_each = 10;
+  uint32_t num_immutable_each = 10;
+  create_blocks(max_block, num_merkle_each, num_versioned_each, num_immutable_each);
+  ASSERT_EQ(blockchain->getGenesisBlockId(), 1);
+  ASSERT_EQ(blockchain->getLastReachableBlockId(), max_block);
+
+  for (auto i = blockchain->getGenesisBlockId(); i < blockchain->getLastReachableBlockId(); ++i) {
+    ASSERT_EQ(blockchain->calculateBlockDigest(i), blockchain->parentDigest(i + 1));
+  }
+  concord::util::digest::BlockDigest empty_digest;
+  empty_digest.fill(0);
+  ASSERT_NE(empty_digest, blockchain->calculateBlockDigest(max_block));
 }
 
 // TEST_F(v4_kvbc, trim_blocks) {

--- a/kvbc/tools/object_store_utility/db_restore.cpp
+++ b/kvbc/tools/object_store_utility/db_restore.cpp
@@ -59,7 +59,7 @@ void DBRestore::restore() {
   if (last_reachable_rocks_blockid == 0) {
     LOG_WARN(logger_, "rocksdb is empty, will restore the whole blockchain");
   } else {
-    last_reachable_rocksdb_block_digest = *(kv_blockchain_->getParentDigest(last_reachable_rocks_blockid));
+    last_reachable_rocksdb_block_digest = *(kv_blockchain_->calculateBlockDigest(last_reachable_rocks_blockid));
   }
   LOG_INFO(logger_,
            "Last reachable block in rocksdb: " << last_reachable_rocks_blockid


### PR DESCRIPTION
* **Problem Overview**  
  Restore option of the Obect Store utility was not using the digest of the last reachable block. So we were seeing mistmatch for the checkpoint based restore from some random point in the blockchain. This fix required us to add the blockDigest API at kvbc adapter layer.

* **Testing Done**  
  Added a unit test for the digest checks and also ran all the apollo and unit tests.
Ran the tool manually and got the tool working for this usecase of restore.
Last snippet of the o/p of tool is as below:
```
block: 4792 digest: bcedbab735719d99b99db6d36ac7842e7af92fd0b8318f252454a61aa7e53121, parent digest: 7d12ae53365ed9ddddb63b716be2915484e10f4ee24926fb476ab58a8b2f45c6
last block 4792, digest matches latest checkpoint descriptor: bcedbab735719d99b99db6d36ac7842e7af92fd0b8318f252454a61aa7e53121
Successfully restored 1050 blocks: (3742, 4792]

```
