### PR TITLE
Optimize immutable writes

### DIFF
--- a/kvbc/include/v4blockchain/detail/latest_keys.h
+++ b/kvbc/include/v4blockchain/detail/latest_keys.h
@@ -133,6 +133,11 @@ class LatestKeys {
   }
 
   std::string getCategoryFromPrefix(const std::string& p) const { return category_mapping_.getCategoryFromPrefix(p); }
+
+  concord::kvbc::categorization::CATEGORY_TYPE categoryType(const std::string& category_id) const {
+    return category_mapping_.categoryType(category_id);
+  }
+
   const std::string& getColumnFamilyFromCategory(const std::string& category_id) const;
   struct LKCompactionFilter : ::rocksdb::CompactionFilter {
     static ::rocksdb::CompactionFilter* getFilter() {

--- a/kvbc/include/v4blockchain/v4_blockchain.h
+++ b/kvbc/include/v4blockchain/v4_blockchain.h
@@ -272,9 +272,10 @@ class KeyValueBlockchain {
 
   // Metrics
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
-  concordMetrics::Component v4_metrics_comp_;
+  mutable concordMetrics::Component v4_metrics_comp_;
   concordMetrics::GaugeHandle blocks_deleted_;
   concordMetrics::CounterHandle deleted_keys_;
+  mutable concordMetrics::CounterHandle immutables_reads_;
 
  public:
   void setAggregator(std::shared_ptr<concordMetrics::Aggregator> aggregator) {

--- a/kvbc/src/v4blockchain/detail/latest_keys.cpp
+++ b/kvbc/src/v4blockchain/detail/latest_keys.cpp
@@ -145,9 +145,8 @@ void LatestKeys::handleCategoryUpdates(const std::string& block_version,
                             << category_id << " prefix " << prefix << " key is hex "
                             << concordUtils::bufferToHex(k.data(), k.size()) << " key size " << k.size()
                             << " value size " << v.data.size() << " raw key " << k);
-    write_batch.put(v4blockchain::detail::IMMUTABLE_KEYS_CF,
-                    getSliceArray(prefix, k),
-                    getSliceArray(v.data, sl_flags, block_version));
+    write_batch.put(
+        v4blockchain::detail::IMMUTABLE_KEYS_CF, getSliceArray(prefix, k), getSliceArray(sl_flags, block_version));
   }
 }
 

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -38,7 +38,8 @@ KeyValueBlockchain::KeyValueBlockchain(
       v4_metrics_comp_{concordMetrics::Component("v4_blockchain", std::make_shared<concordMetrics::Aggregator>())},
       blocks_deleted_{v4_metrics_comp_.RegisterGauge(
           "numOfBlocksDeleted", block_chain_.getGenesisBlockId() > 0 ? (block_chain_.getGenesisBlockId() - 1) : 0)},
-      deleted_keys_{v4_metrics_comp_.RegisterCounter("numOfKeysDeleted", 0)} {
+      deleted_keys_{v4_metrics_comp_.RegisterCounter("numOfKeysDeleted", 0)},
+      immutables_reads_{v4_metrics_comp_.RegisterCounter("numOfimmutableReads", 0)} {
   if (native_client_->createColumnFamilyIfNotExisting(v4blockchain::detail::MISC_CF)) {
     LOG_INFO(V4_BLOCK_LOG, "Created [" << v4blockchain::detail::MISC_CF << "] column family");
   }
@@ -554,6 +555,14 @@ std::optional<categorization::Value> KeyValueBlockchain::get(const std::string &
 
 std::optional<categorization::Value> KeyValueBlockchain::getLatest(const std::string &category_id,
                                                                    const std::string &key) const {
+  auto category_type = latest_keys_.categoryType(category_id);
+  if (category_type == concord::kvbc::categorization::CATEGORY_TYPE::immutable) {
+    immutables_reads_++;
+    v4_metrics_comp_.UpdateAggregator();
+    auto opt_version = latest_keys_.getLatestVersion(category_id, key);
+    if (!opt_version) return std::nullopt;
+    return get(category_id, key, opt_version->version);
+  }
   return latest_keys_.getValue(category_id, key);
 }
 
@@ -596,7 +605,21 @@ void KeyValueBlockchain::multiGet(const std::string &category_id,
 void KeyValueBlockchain::multiGetLatest(const std::string &category_id,
                                         const std::vector<std::string> &keys,
                                         std::vector<std::optional<categorization::Value>> &values) const {
-  return latest_keys_.multiGetValue(category_id, keys, values);
+  auto category_type = latest_keys_.categoryType(category_id);
+  if (category_type == concord::kvbc::categorization::CATEGORY_TYPE::immutable) {
+    immutables_reads_++;
+    v4_metrics_comp_.UpdateAggregator();
+    std::vector<std::optional<categorization::TaggedVersion>> tagged_versions;
+    latest_keys_.multiGetLatestVersion(category_id, keys, tagged_versions);
+    std::vector<BlockId> versions;
+    std::for_each(
+        tagged_versions.begin(), tagged_versions.end(), [&versions](std::optional<categorization::TaggedVersion> &tv) {
+          versions.push_back(tv.has_value() ? tv->version : detail::Blockchain::INVALID_BLOCK_ID);
+        });
+    multiGet(category_id, keys, versions, values);
+    return;
+  }
+  latest_keys_.multiGetValue(category_id, keys, values);
 }
 
 std::optional<categorization::TaggedVersion> KeyValueBlockchain::getLatestVersion(const std::string &category_id,

--- a/kvbc/test/v4blockchain/v4_latest_keys_test.cpp
+++ b/kvbc/test/v4blockchain/v4_latest_keys_test.cpp
@@ -292,7 +292,9 @@ TEST_F(v4_kvbc, add_and_get_keys) {
       } else {
         ASSERT_TRUE(false);
       }
-      ASSERT_EQ(val, v.val);
+      if (v.type != "immutable") {
+        ASSERT_EQ(val, v.val);
+      }
       ASSERT_EQ(id, v.version);
 
       ASSERT_EQ(opt_version->version, v.version);


### PR DESCRIPTION
Immutable keys by agreement are not being read by getLatest API but by get with block id.
Therefore saving their value in the latest CF is redundant.
For safety, in case the application tries to read the latest of on immutable, we'll save the version of the immutable in the latest CF, and perform indirection by first reading its version and then reading the value from the block.

A counter metric was added in order to quickly observe the usage of the getLatest API with immutables.
Tests:
UT that use getLatest for immutable pass.
Apollo and Concord CI.
Running long runs:

- Reduciton of ~25% in storage
- no calls for getLatest with immutable
