### PR TITLE
Change test_skvbc_restart_recovery loops to 1

### DIFF
--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -26,7 +26,7 @@ from util import eliot_logging as log
 
 viewChangeTimeoutSec = 5
 
-loops = 16
+loops = 1
 timeouts = 60 # variable is added to vurnable timeouts in case vm is slow.
 
 def start_replica_cmd(builddir, replica_id):


### PR DESCRIPTION
* **Problem Overview**  
The tests are failing after several hours on nightly.
This change is a part of debugging effort.
* **Testing Done**  
 will wait for nightly results
