### PR TITLE
Make CADR team code owners (instead of concord-bft-managers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @vmware/concord-bft-managers
+*   @vmware/cadr-team


### PR DESCRIPTION
* **Problem Overview**  
As part of the effort to improve the quality of the PR code reviews, we would like to add a group to github which is owned by the CADR team members. Any PR will have to be approved by this new group.
In order to avoid unnecessary overhead, we recommend that this new group will replace the group concord-bft-managers.

* **Testing Done**  
  N/A (regular CI)
