### PR TITLE
Get rid of unneeded memory allocations in the client pool

### DIFF
--- a/client/client_pool/include/client/client_pool/external_client.hpp
+++ b/client/client_pool/include/client/client_pool/external_client.hpp
@@ -117,8 +117,6 @@ class ConcordClient {
   static uint16_t num_of_replicas_;
   static uint16_t required_num_of_replicas_;
   static size_t max_reply_size_;
-  // A shared memory for all clients to return reply because for now the reply is not important
-  static std::shared_ptr<std::vector<char>> reply_;
   static bool delayed_behaviour_;
   static std::set<bft::client::ReplicaId> all_replicas_;
   static config_pool::ConcordClientPoolConfig pool_config_;
@@ -136,7 +134,6 @@ class ConcordClient {
   using PendingRequests = std::deque<bftEngine::ClientRequest>;
   PendingRequests pending_requests_;
   PendingReplies pending_replies_;
-  size_t batching_buffer_reply_offset_ = 0UL;
   bftEngine::OperationResult clientRequestExecutionResult_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_before_send_map_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> cid_response_map_;


### PR DESCRIPTION
* **Problem Overview**  
  Clientservice memory usage is currently quite high. This is caused by two main factors: 
  1. Static memory buffer allocation per client/batch/request - will be optimized in this PR
  2. TCP buffer allocation per client/replica - will be optimized when we move to the multiplex channel
  After we moved to a new BFT client, we stopped providing memory to it to be filled by the replicas response. 
  Thus we don't need to pre-allocate static memory chunks anymore. In case the memory buffer has been 
  provided by the caller (e.g. for the performance tests), this buffer is used to return the response to the caller, as before.
* **Testing Done**  
  Full 5 days run on a reserved system
