### PR TITLE
UTT new interface (WIP)

### DIFF
--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -191,3 +191,7 @@ set(newutt_src
 add_library(newutt STATIC ${newutt_src})
 target_link_libraries(newutt PUBLIC utt)
 target_include_directories(newutt PUBLIC include)
+add_subdirectory(tests)
+
+
+

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -180,6 +180,7 @@ add_subdirectory(libxutils)
 set(newutt_src 
     libutt/src/details.cpp
     libutt/src/commitment.cpp
+    libutt/src/registratorIdentity.cpp
     libutt/src/common.cpp
     )
 add_library(newutt STATIC ${newutt_src})

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -179,6 +179,7 @@ add_subdirectory(libxutils)
 
 set(newutt_src 
     libutt/src/details.cpp
+    libutt/src/commitment.cpp
     )
 add_library(newutt STATIC ${newutt_src})
 target_link_libraries(newutt PUBLIC utt)

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -181,6 +181,7 @@ set(newutt_src
     libutt/src/details.cpp
     libutt/src/nullifier.cpp
     libutt/src/commitment.cpp
+    libutt/src/clientIdentity.cpp
     libutt/src/registratorIdentity.cpp
     libutt/src/common.cpp
     )

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -182,6 +182,7 @@ set(newutt_src
     libutt/src/nullifier.cpp
     libutt/src/commitment.cpp
     libutt/src/clientIdentity.cpp
+    libutt/src/bankIdentity.cpp
     libutt/src/mint.cpp
     libutt/src/coin.cpp
     libutt/src/registratorIdentity.cpp

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -180,6 +180,7 @@ add_subdirectory(libxutils)
 set(newutt_src 
     libutt/src/details.cpp
     libutt/src/commitment.cpp
+    libutt/src/common.cpp
     )
 add_library(newutt STATIC ${newutt_src})
 target_link_libraries(newutt PUBLIC utt)

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -176,3 +176,10 @@ enable_testing()
 add_subdirectory(libutt)
 add_subdirectory(libxassert)
 add_subdirectory(libxutils)
+
+set(newutt_src 
+    libutt/src/details.cpp
+    )
+add_library(newutt STATIC ${newutt_src})
+target_link_libraries(newutt PUBLIC utt)
+target_include_directories(newutt PUBLIC include)

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -182,6 +182,7 @@ set(newutt_src
     libutt/src/nullifier.cpp
     libutt/src/commitment.cpp
     libutt/src/clientIdentity.cpp
+    libutt/src/coin.cpp
     libutt/src/registratorIdentity.cpp
     libutt/src/common.cpp
     )

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -179,6 +179,7 @@ add_subdirectory(libxutils)
 
 set(newutt_src 
     libutt/src/details.cpp
+    libutt/src/nullifier.cpp
     libutt/src/commitment.cpp
     libutt/src/registratorIdentity.cpp
     libutt/src/common.cpp

--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -182,6 +182,7 @@ set(newutt_src
     libutt/src/nullifier.cpp
     libutt/src/commitment.cpp
     libutt/src/clientIdentity.cpp
+    libutt/src/mint.cpp
     libutt/src/coin.cpp
     libutt/src/registratorIdentity.cpp
     libutt/src/common.cpp

--- a/utt/include/bankIdentity.hpp
+++ b/utt/include/bankIdentity.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <string>
+#include <memory>
+#include <vector>
+namespace libutt {
+class RandSigShareSK;
+}
+namespace libutt::api {
+class BankIdentity {
+ public:
+  BankIdentity(const std::string& id, const std::string& bsk);
+  template <typename T>
+  std::vector<uint8_t> sign(T& data) const;
+  const std::string& getId() const;
+
+ private:
+  std::string bid_;
+  std::unique_ptr<libutt::RandSigShareSK> bsk_;
+};
+}  // namespace libutt::api

--- a/utt/include/clientIdentity.hpp
+++ b/utt/include/clientIdentity.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "commitment.hpp"
+#include "details.hpp"
+#include "common.hpp"
+#include <memory>
+namespace libutt {
+class AddrSK;
+class RandSigPK;
+}  // namespace libutt
+namespace libutt::api {
+class ClientIdentity {
+ public:
+  ClientIdentity(const std::string& pid, const std::string& bpk);
+  Commitment generatePartialRCM(Details& d);
+  std::string getPid() const;
+  std::vector<uint64_t> getPRFSecretKey() const;
+  std::vector<uint64_t> getPidHash() const;
+  void setIBEDetails(const std::vector<uint8_t>& sk, const std::vector<uint8_t>& mpk);
+  void setRCM(const Commitment& comm, const std::vector<uint8_t>& sig);
+  void randomizeRCM();
+  std::pair<Commitment, std::vector<uint8_t>> getRcm() const;
+  template <typename T>
+  bool validate(const T&);
+
+ private:
+  std::unique_ptr<libutt::AddrSK> ask_;
+  std::unique_ptr<libutt::RandSigPK> bpk_;
+  Commitment rcm_;
+  std::vector<uint8_t> rcm_sig_;
+};
+}  // namespace libutt::api

--- a/utt/include/coin.hpp
+++ b/utt/include/coin.hpp
@@ -12,7 +12,12 @@ class ClientIdentity;
 class Coin {
  public:
   enum Type { Normal = 0x0, Budget };
-  Coin(Details& d, const std::vector<uint64_t>& sn, const std::vector<uint64_t>& val, Type p, const std::vector<uint64_t>& exp_date, ClientIdentity& cid);
+  Coin(Details& d,
+       const std::vector<uint64_t>& sn,
+       const std::vector<uint64_t>& val,
+       Type p,
+       const std::vector<uint64_t>& exp_date,
+       ClientIdentity& cid);
   const Nullifier& getNullifier() const;
   bool hasSig() const;
   void setSig(const std::vector<uint8_t>& sig);

--- a/utt/include/coin.hpp
+++ b/utt/include/coin.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "details.hpp"
+#include "clientIdentity.hpp"
+#include "nullifier.hpp"
+#include "commitment.hpp"
+#include <memory>
+namespace libutt {
+class Coin;
+}
+namespace libutt::api {
+class ClientIdentity;
+class Coin {
+ public:
+  enum Type { Normal = 0x0, Budget };
+  Coin(Details& d, const std::vector<uint64_t>& sn, const std::vector<uint64_t>& val, Type p, const std::vector<uint64_t>& exp_date, ClientIdentity& cid);
+  const Nullifier& getNullifier() const;
+  bool hasSig() const;
+  void setSig(const std::vector<uint8_t>& sig);
+  Type getType() const;
+  std::vector<uint8_t> getSig() const;
+  void randomize();
+
+ private:
+  friend class ClientIdentity;
+  std::unique_ptr<libutt::Coin> coin_;
+  std::unique_ptr<Nullifier> nullifier_;
+  bool has_sig_{false};
+
+  Type type_;
+};
+}  // namespace libutt::api

--- a/utt/include/commitment.hpp
+++ b/utt/include/commitment.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "details.hpp"
+#include <vector>
+#include <cstdint>
+namespace libutt {
+class Comm;
+}
+namespace libutt::api {
+class Commitment;
+}
+libutt::api::Commitment operator+(libutt::api::Commitment lhs, const libutt::api::Commitment& rhs);
+namespace libutt::api {
+class RegistratorIdentity;
+class ClientIdentity;
+class Commitment {
+ public:
+  enum Type { REGISTRATION = 0, VALUE, COIN };
+  static std::vector<Commitment> create(Details& d,
+                                        Type t,
+                                        const std::vector<std::vector<uint64_t>>& messages,
+                                        std::vector<std::vector<uint64_t>>& randomizations,
+                                        bool withG2);
+  Commitment(Details& d, Type t, const std::vector<std::vector<uint64_t>>& messages, bool withG2);
+  Commitment(const std::string& comm);
+  Commitment(const Commitment& comm);
+  Commitment();
+  Commitment& operator=(const Commitment&);
+  Commitment& operator+=(const Commitment&);
+  std::vector<uint64_t> randomize(Details& d, Type t);
+  static size_t getCommitmentSn(const Commitment& comm);
+  static std::string getCommitmentHash(const Commitment& comm);
+
+ private:
+  friend class RegistratorIdentity;
+  friend class ClientIdentity;
+  std::shared_ptr<libutt::Comm> comm_;
+};
+}  // namespace libutt::api

--- a/utt/include/common.hpp
+++ b/utt/include/common.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "commitment.hpp"
+#include "details.hpp"
+#include <memory>
+#include <vector>
+#include <map>
+
+namespace libutt::api {
+struct RegistrationDetails {
+  Commitment rcm_;
+  std::vector<uint8_t> rcm_sig_;
+  std::vector<uint8_t> dsk_pub_;
+  std::vector<uint8_t> dsk_priv_;
+};
+
+class Utils {
+ public:
+  static std::vector<uint8_t> aggregateSigShares(Details& d,
+                                                 Commitment::Type t,
+                                                 uint32_t n,
+                                                 const std::map<uint32_t, std::vector<uint8_t>>& rsigs,
+                                                 std::vector<std::vector<uint64_t>> randomness);
+};
+}  // namespace libutt::api

--- a/utt/include/details.hpp
+++ b/utt/include/details.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <string>
+#include <memory>
+namespace libutt {
+class Params;
+}
+namespace libutt::api {
+class Details {
+ public:
+  static Details& instance() {
+    static Details d;
+    return d;
+  }
+  void init();
+  libutt::Params& getParams();
+
+ private:
+  std::unique_ptr<libutt::Params> params;
+};
+}  // namespace libutt::api

--- a/utt/include/mint.hpp
+++ b/utt/include/mint.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <string>
+#include <memory>
+#include <vector>
+#include "coin.hpp"
+#include "clientIdentity.hpp"
+#include "details.hpp"
+namespace libutt {
+class MintOp;
+}  // namespace libutt
+namespace libutt::api {
+class BankIdentity;
+}
+namespace libutt::api::operations {
+
+class Mint {
+ public:
+  Mint(const std::string& uniqueHash, size_t value, const std::string& recipPID);
+  bool validate(const std::string& uniqueHash, size_t value, const std::string& recipPID) const;
+  Coin claimCoin(Details& d,
+                 ClientIdentity& cid,
+                 uint32_t n,
+                 const std::map<uint32_t, std::vector<uint8_t>>& rsigs) const;
+
+ private:
+  friend class libutt::api::BankIdentity;
+  std::unique_ptr<libutt::MintOp> op_;
+};
+}  // namespace libutt::api::operations

--- a/utt/include/nullifier.hpp
+++ b/utt/include/nullifier.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "details.hpp"
+#include <vector>
+
+namespace libutt {
+class Nullifier;
+}
+namespace libutt::api {
+class Nullifier {
+ public:
+  Nullifier(Details& d,
+            const std::vector<uint64_t>& prf_secret_key,
+            const std::vector<uint64_t>& sn,
+            const std::vector<uint64_t>& randomization);
+  bool validate(Details& d) const;
+  std::string toString() const;
+
+ private:
+  std::unique_ptr<libutt::Nullifier> nullifier_;
+};
+}  // namespace libutt::api

--- a/utt/include/registratorIdentity.hpp
+++ b/utt/include/registratorIdentity.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "commitment.hpp"
+#include "common.hpp"
+#include "details.hpp"
+#include <string>
+#include <memory>
+#include <vector>
+namespace libutt {
+class RegAuthShareSK;
+class RegAuthPK;
+}  // namespace libutt
+namespace libutt::api {
+class RegistratorIdentity {
+ public:
+  RegistratorIdentity(const std::string& id, const std::string& rsk, const std::string& rbk);
+  RegistrationDetails registerClient(Details& d,
+                                     const std::string& pid,
+                                     const std::vector<uint64_t>& pid_hash,
+                                     const Commitment& partiail_comm) const;
+  bool validateRCM(const Commitment& comm, const std::vector<uint8_t>& sig);
+
+ private:
+  std::vector<uint8_t> generateSecretForPid(const std::string& pid) const;
+  std::vector<uint8_t> getMPK() const;
+  std::string id_;
+  std::unique_ptr<RegAuthShareSK> rsk_;
+  std::unique_ptr<RegAuthPK> rpk_;
+};
+}  // namespace libutt::api

--- a/utt/libutt/include/utt/Address.h
+++ b/utt/libutt/include/utt/Address.h
@@ -39,7 +39,8 @@ class AddrSK {
   // Registration signature on rcm
   RandSig rs;
 
- public:
+  IBE::MPK mpk_;
+
   std::string getPid() const { return pid; }
   Fr getPidHash() const;
 

--- a/utt/libutt/include/utt/BurnOp.h
+++ b/utt/libutt/include/utt/BurnOp.h
@@ -3,18 +3,19 @@
 #include <cstddef>
 #include <optional>
 
-#include <xassert/XAssert.h>
-#include <xutils/Log.h>
-
 namespace libutt {
+class BurnOp;
+class AddrSK;
 class Coin;
 class Params;
-class BurnOp;
 class RandSigPK;
 class RegAuthPK;
+}  // namespace libutt
 
 std::ostream& operator<<(std::ostream&, const libutt::BurnOp&);
 std::istream& operator>>(std::istream&, libutt::BurnOp&);
+
+namespace libutt {
 
 // Represents an operation that burns a valid coin. This operation should be
 // part of a public transaction (e.g., a transaction that converts an anonymous
@@ -52,8 +53,8 @@ class BurnOp {
   bool operator==(const BurnOp& o) const;
   bool operator!=(const BurnOp& o) const { return !operator==(o); }
 
-  friend std::ostream& operator<<(std::ostream&, const libutt::BurnOp&);
-  friend std::istream& operator>>(std::istream&, libutt::BurnOp&);
+  friend std::ostream& ::operator<<(std::ostream&, const libutt::BurnOp&);
+  friend std::istream& ::operator>>(std::istream&, libutt::BurnOp&);
 };
 
 }  // end of namespace libutt

--- a/utt/libutt/include/utt/Coin.h
+++ b/utt/libutt/include/utt/Coin.h
@@ -75,7 +75,8 @@ class Coin {
  public:
   // WARNING: Used only for deserialization
   Coin() {}
-
+  // Used to create the coin's partial commitment (without nullfier)
+  Coin(const CommKey& ck, const Fr& sn, const Fr& val, const Fr& type, const Fr& exp_date, const Fr& pidHash);
   // Used in TxOut::tryMakeMine and Factory
   Coin(const CommKey& ck,
        const Nullifier::Params& np,

--- a/utt/libutt/include/utt/IBE.h
+++ b/utt/libutt/include/utt/IBE.h
@@ -137,7 +137,7 @@ class IBE {
    * The IBE authority's master PK
    */
   class MSK {
-   protected:
+   public:
     // the master SK of the IBE authority
     Fr msk;
 
@@ -175,6 +175,9 @@ std::istream& operator>>(std::istream&, libutt::IBE::Params&);
 
 std::ostream& operator<<(std::ostream&, const libutt::IBE::MPK&);
 std::istream& operator>>(std::istream&, libutt::IBE::MPK&);
+
+std::ostream& operator<<(std::ostream&, const libutt::IBE::MSK&);
+std::istream& operator>>(std::istream&, libutt::IBE::MSK&);
 
 // WARNING: Serialization and deserialization operators, must be in the global namespace
 std::ostream& operator<<(std::ostream&, const libutt::IBE::Ctxt&);

--- a/utt/libutt/include/utt/MintOp.h
+++ b/utt/libutt/include/utt/MintOp.h
@@ -2,17 +2,25 @@
 
 #include <cstddef>
 #include <optional>
-
+#include <vector>
 #include <xassert/XAssert.h>
 #include <xutils/Log.h>
-
+#include <utt/PolyCrypto.h>
 namespace libutt {
 class Coin;
 class Params;
 class MintOp;
+class RandSigShare;
+class RandSigShareSK;
+class RandSigSharePK;
+class AddrSK;
+class RandSigPK;
+}  // namespace libutt
 
 std::ostream& operator<<(std::ostream&, const libutt::MintOp&);
 std::istream& operator>>(std::istream&, libutt::MintOp&);
+
+namespace libutt {
 
 // Represents an operation that creates a new coin. This operation should be
 // part of a public transaction (e.g., a transaction that converts public money
@@ -24,21 +32,22 @@ class MintOp {
   Fr value;    // value of the new coin
   // Notice that all data members are public because we assume that creating an anonymous new coin should be part of a
   // public transaction
-
  public:
+  friend std::ostream& ::operator<<(std::ostream&, const libutt::MintOp&);
+  friend std::istream& ::operator>>(std::istream&, libutt::MintOp&);
   // uniqueHash should depend on the full transaction that contains this action.
   // NB: In order to make sure that the value of uniqueHash is unique it is possible to add a random value
   // to the transaction
-  MintOp(std::string uniqueHash, size_t value, const std::string& recipPID);
+  MintOp(const std::string& uniqueHash, size_t value, const std::string& recipPID);
 
-  MintOp(std::istream& in) { in >> *this; }
+  MintOp(std::istream& in);
 
   size_t getSize() const { return _fr_size * 3; }
 
   // uniqueHash, value and recipPID should be taken from the public transaction
   // NB: a possible way to prevent non-unique values of uniqueHash is to also verify that the new serial number was
   // never used in the past (in such a case, the replicas should not sign the new coin)
-  bool validate(std::string uniqueHash, size_t value, std::string recipPID) const;
+  bool validate(const std::string& uniqueHash, size_t value, const std::string& recipPID) const;
 
   RandSigShare shareSignCoin(const RandSigShareSK& bskShare) const;
 
@@ -54,12 +63,9 @@ class MintOp {
   std::string getHashHex() const;
 
   Fr getSN() { return sn; }
-
+  Fr getVal() { return value; }
   bool operator==(const MintOp& o) const { return ((sn == o.sn) && (pidHash == o.pidHash) && (value == o.value)); }
   bool operator!=(const MintOp& o) const { return !operator==(o); }
-
-  friend std::ostream& operator<<(std::ostream&, const libutt::MintOp&);
-  friend std::istream& operator>>(std::istream&, libutt::MintOp&);
 };
 
 }  // end of namespace libutt

--- a/utt/libutt/include/utt/Nullifier.h
+++ b/utt/libutt/include/utt/Nullifier.h
@@ -63,7 +63,7 @@ class Nullifier {
   Nullifier() {}
 
   Nullifier(std::istream& in) : Nullifier() { in >> *this; }
-
+  Nullifier(const Params& p, const Fr& prf, const Fr& sn, const Fr& t);
   /**
    * Used to create a nullifier when spending the specified coin via a transaction.
    *

--- a/utt/libutt/include/utt/RegAuth.h
+++ b/utt/libutt/include/utt/RegAuth.h
@@ -8,11 +8,18 @@
 namespace libutt {
 class AddrSK;
 class RegAuthPK;
+class RegAuthSharePK;
+class RegAuthShareSK;
 }  // namespace libutt
 
 std::ostream& operator<<(std::ostream& out, const libutt::RegAuthPK& rpk);
 std::istream& operator>>(std::istream& in, libutt::RegAuthPK& rpk);
 
+std::ostream& operator<<(std::ostream& out, const libutt::RegAuthSharePK& rpk);
+std::istream& operator>>(std::istream& in, libutt::RegAuthSharePK& rpk);
+
+std::ostream& operator<<(std::ostream& out, const libutt::RegAuthShareSK& rsk);
+std::istream& operator>>(std::istream& in, libutt::RegAuthShareSK& rsk);
 namespace libutt {
 
 class RegAuthPK {
@@ -27,6 +34,18 @@ class RegAuthPK {
   bool operator!=(const RegAuthPK& o) const { return !operator==(o); }
 };
 
+class RegAuthSharePK {
+ public:
+  RandSigSharePK vk;  // re-randomizable signature PK, needed to verify registration commitments
+
+  IBE::MPK mpk;  // IBE MPK, need to derive encryption PKs for users by TXN creators
+
+ public:
+  bool operator==(const RegAuthSharePK& o) const { return vk == o.vk && mpk == o.mpk; }
+
+  bool operator!=(const RegAuthSharePK& o) const { return !operator==(o); }
+};
+
 class RegAuthSK {
  public:
   CommKey ck_reg;  // registration commitment key, needed to create registration commitments
@@ -34,12 +53,14 @@ class RegAuthSK {
 
   IBE::Params p;
   IBE::MSK msk;  // IBE MSK, needed to issue encryption SKs to users
+  std::vector<RegAuthShareSK> shares;
 
  public:
   RegAuthSK() {}
 
  public:
   static RegAuthSK random(const CommKey& ck_reg, const IBE::Params& p);
+  static RegAuthSK generateKeyAndShares(CommKey& baseComm, size_t t, size_t n, const IBE::Params& p);
 
  public:
   // AddrSK randomUser() const;
@@ -47,6 +68,25 @@ class RegAuthSK {
 
   RegAuthPK toPK() const {
     RegAuthPK pk;
+    pk.vk = sk.toPK();
+    pk.mpk = msk.toMPK(p);
+    return pk;
+  }
+};
+
+class RegAuthShareSK {
+ public:
+  CommKey ck_reg;     // registration commitment key, needed to create registration commitments
+  RandSigShareSK sk;  // re-randomizable signature shared SK, needed to sign registration commitments
+
+  IBE::Params p;
+  IBE::MSK msk;  // IBE MSK, needed to issue encryption SKs to users
+
+ public:
+  RegAuthShareSK() {}
+
+  RegAuthSharePK toPK() const {
+    RegAuthSharePK pk;
     pk.vk = sk.toPK();
     pk.mpk = msk.toMPK(p);
     return pk;

--- a/utt/libutt/include/utt/Serialization.h
+++ b/utt/libutt/include/utt/Serialization.h
@@ -112,4 +112,28 @@ void deserializeVector(std::istream& in, std::vector<T>& v) {
   }
 }
 
+template <typename T>
+std::string serialize(const T& data) {
+  std::stringstream ss;
+  ss << data;
+  return ss.str();
+}
+template <typename T>
+T deserialize(const std::string& data) {
+  std::stringstream ss;
+  ss.str(data);
+  T ret;
+  ss >> ret;
+  return ret;
+}
+
+template <typename T>
+T deserialize(const std::vector<uint8_t>& data) {
+  std::stringstream ss;
+  ss.str(std::string(data.begin(), data.end()));
+  T ret;
+  ss >> ret;
+  return ret;
+}
+
 }  // namespace libutt

--- a/utt/libutt/src/BurnOp.cpp
+++ b/utt/libutt/src/BurnOp.cpp
@@ -16,6 +16,9 @@
 
 #include <utt/Serialization.h>
 
+#include <xassert/XAssert.h>
+#include <xutils/Log.h>
+#include <xutils/Utils.h>
 struct InternalDataOfBurnOp {
   std::string pid;   // owner pid
   libutt::Fr value;  // value of the burned coin
@@ -24,12 +27,8 @@ struct InternalDataOfBurnOp {
   libutt::Tx tx;
 };
 
-namespace libutt {
-
 std::ostream& operator<<(std::ostream& out, const libutt::BurnOp& op) {
   InternalDataOfBurnOp* d = (InternalDataOfBurnOp*)op.p;
-  assertTrue(d != nullptr);
-
   out << (d->pid) << endl;
   out << (d->value) << endl;
   out << (d->r_d) << endl;
@@ -60,6 +59,8 @@ std::istream& operator>>(std::istream& in, libutt::BurnOp& op) {
 
   return in;
 }
+
+namespace libutt {
 
 BurnOp::BurnOp(std::istream& in) : p(nullptr) { in >> *this; }
 

--- a/utt/libutt/src/Coin.cpp
+++ b/utt/libutt/src/Coin.cpp
@@ -78,8 +78,8 @@ std::istream& operator>>(std::istream& in, libutt::Coin& c) {
 namespace libutt {
 Coin::Coin(const CommKey& ck, const Fr& sn, const Fr& val, const Fr& type, const Fr& exp_date, const Fr& pidHash)
     : ck(ck), pid_hash(pidHash), sn(sn), val(val), type(type), exp_date(exp_date), t(Fr::random_element()) {
-      Coin::commit();
-    }
+  Coin::commit();
+}
 
 Coin::Coin(const CommKey& ck,
            const Nullifier::Params& np,

--- a/utt/libutt/src/Coin.cpp
+++ b/utt/libutt/src/Coin.cpp
@@ -76,6 +76,10 @@ std::istream& operator>>(std::istream& in, libutt::Coin& c) {
 }
 
 namespace libutt {
+Coin::Coin(const CommKey& ck, const Fr& sn, const Fr& val, const Fr& type, const Fr& exp_date, const Fr& pidHash)
+    : ck(ck), pid_hash(pidHash), sn(sn), val(val), type(type), exp_date(exp_date), t(Fr::random_element()) {
+      Coin::commit();
+    }
 
 Coin::Coin(const CommKey& ck,
            const Nullifier::Params& np,

--- a/utt/libutt/src/IBE.cpp
+++ b/utt/libutt/src/IBE.cpp
@@ -37,6 +37,14 @@ std::istream& operator>>(std::istream& in, libutt::IBE::MPK& mpk) {
   return in;
 }
 
+std::ostream& operator<<(std::ostream& out, const libutt::IBE::MSK& msk) {
+  out << msk.msk;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::IBE::MSK& msk) {
+  in >> msk.msk;
+  return in;
+}
 // WARNING: Serialization operators must be in the global namespace
 std::ostream& operator<<(std::ostream& out, const libutt::IBE::Ctxt& c) {
   out << c.R << endl;

--- a/utt/libutt/src/MintOp.cpp
+++ b/utt/libutt/src/MintOp.cpp
@@ -8,10 +8,10 @@
 #include <utt/Comm.h>
 #include <utt/Params.h>
 #include <utt/MintOp.h>
+#include <utt/RandSig.h>
 
-#include <utt/Serialization.h>
-
-namespace libutt {
+#include <xassert/XAssert.h>
+#include <xutils/Log.h>
 
 std::ostream& operator<<(std::ostream& out, const libutt::MintOp& op) {
   out << op.sn << endl;
@@ -29,17 +29,19 @@ std::istream& operator>>(std::istream& in, libutt::MintOp& op) {
   return in;
 }
 
+namespace libutt {
+
 static Fr createSN(std::string uniqueHash) { return hashToField("new sn|" + uniqueHash); }
 
-MintOp::MintOp(std::string uniqueHash, size_t v, const std::string& recipPID) {
+MintOp::MintOp(const std::string& uniqueHash, size_t v, const std::string& recipPID) {
   testAssertGreaterThanOrEqual(v, 1);
 
   sn = createSN(uniqueHash);
   pidHash = AddrSK::pidHash(recipPID);
   value.set_ulong(static_cast<unsigned long>(v));
 }
-
-bool MintOp::validate(std::string uniqueHash, size_t v, std::string recipPID) const {
+MintOp::MintOp(std::istream& in) { in >> *this; }
+bool MintOp::validate(const std::string& uniqueHash, size_t v, const std::string& recipPID) const {
   Fr snV = createSN(uniqueHash);
   Fr pidHashV = AddrSK::pidHash(recipPID);
   Fr valueV;

--- a/utt/libutt/src/Nullifier.cpp
+++ b/utt/libutt/src/Nullifier.cpp
@@ -49,12 +49,12 @@ std::istream& operator>>(std::istream& in, libutt::Nullifier::Params& null) {
 
 namespace libutt {
 
-Nullifier::Nullifier(const Params& p, const AddrSK& ask, const Fr& sn, const Fr& t)
-    : n((ask.s + sn).inverse() * p.h),
-      y(ReducedPairing(n, p.w_tilde) ^ t),
-      vk((ask.s + sn) * p.h_tilde + t * p.w_tilde) {
+Nullifier::Nullifier(const Params& p, const Fr& prf, const Fr& sn, const Fr& t)
+    : n((prf + sn).inverse() * p.h), y(ReducedPairing(n, p.w_tilde) ^ t), vk((prf + sn) * p.h_tilde + t * p.w_tilde) {
   assertTrue(Nullifier::verify(p));
 }
+
+Nullifier::Nullifier(const Params& p, const AddrSK& ask, const Fr& sn, const Fr& t) : Nullifier(p, ask.s, sn, t){};
 
 bool Nullifier::verify(const Params& p) const { return ReducedPairing(n, vk) == p.ehh * y; }
 

--- a/utt/libutt/src/RegAuth.cpp
+++ b/utt/libutt/src/RegAuth.cpp
@@ -6,6 +6,7 @@
 #include <utt/Comm.h>
 #include <utt/RandSig.h>
 #include <utt/RegAuth.h>
+#include <utt/PolyOps.h>
 
 std::ostream& operator<<(std::ostream& out, const libutt::RegAuthPK& rpk) {
   out << rpk.vk;
@@ -19,6 +20,27 @@ std::istream& operator>>(std::istream& in, libutt::RegAuthPK& rpk) {
   return in;
 }
 
+std::ostream& operator<<(std::ostream& out, const libutt::RegAuthSharePK& rpk) {
+  out << rpk.vk;
+  out << rpk.mpk;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::RegAuthSharePK& rpk) {
+  in >> rpk.vk;
+  in >> rpk.mpk;
+  return in;
+}
+
+std::ostream& operator<<(std::ostream& out, const libutt::RegAuthShareSK& rsk) {
+  out << rsk.sk;
+  out << rsk.msk;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::RegAuthShareSK& rsk) {
+  in >> rsk.sk;
+  in >> rsk.msk;
+  return in;
+}
 namespace libutt {
 
 RegAuthSK RegAuthSK::random(const CommKey& ck_reg, const IBE::Params& p) {
@@ -36,6 +58,70 @@ RegAuthSK RegAuthSK::random(const CommKey& ck_reg, const IBE::Params& p) {
   return rsk;
 }
 
+RegAuthSK RegAuthSK::generateKeyAndShares(CommKey& ck_reg, size_t t, size_t n, const IBE::Params& p_) {
+  (void)(ck_reg);
+  RegAuthSK ras;
+  ras.p = p_;
+  ras.msk = IBE::MSK::random();
+  size_t ell = 2;  // Registration commit contains only 3 messages
+  // degree t-1 polynomial f(X) such that t players can reconstruct f(0) = x, which encodes the bank's secret key x
+  std::vector<Fr> poly_f = random_field_elems(t);
+  Fr x = poly_f[0];
+
+  // degree t-1 polynomials Y_k(X) for secret sharing the y_k = Y_k(0)
+  std::vector<std::vector<Fr>> polys_y;
+  // PS16 secrets y_1, y_2, \dots, y_k
+  std::vector<Fr> y;
+  for (size_t k = 0; k < ell; k++) {
+    auto poly = random_field_elems(t);
+    polys_y.push_back(poly);
+    y.push_back(poly[0]);
+  }
+
+  G1 g = G1::random_element();
+  G2 g_tilde = G2::random_element();
+  auto ck = CommKey::fromTrapdoor(g, g_tilde, y);
+
+  ras.ck_reg = ck;
+  // initialize the single-server PS16 SK (useful for testing)
+  ras.sk.ck = ck;
+  ras.sk.x = x;
+  ras.sk.y = y;
+  ras.sk.X = x * g;
+
+  /**
+   * Compute the SK shares [x]_i, [y_k]_i, \forall k\in \{1,\dots,\ell\}
+   * i.e., evaluate the secret-sharing polys at n pre-determined points (i.e., Nth roots of unity, with smallest N = 2^k
+   * >= n)
+   */
+  std::vector<Fr> evals_f = poly_fft(poly_f, n);
+
+  std::vector<std::vector<Fr>> evals_y;
+  for (size_t k = 0; k < ell; k++) {
+    evals_y.push_back(poly_fft(polys_y[k], n));
+  }
+
+  // [x]_i = f(\omega_N^i)
+  // [y_k]_i = Y_k(\omega_N^i), \forall k\in\{1,\dots,\ell\}
+  std::vector<RegAuthShareSK> skRegShares;
+  for (size_t i = 0; i < n; i++) {
+    RegAuthShareSK as;
+    RandSigShareSK ss;
+
+    ss.ck = ras.ck_reg;
+    ss.x_and_ys.push_back(evals_f[i]);
+    for (size_t k = 0; k < ell; k++) {
+      ss.x_and_ys.push_back(evals_y[k][i]);
+    }
+    as.sk = ss;
+    as.ck_reg = ras.ck_reg;
+    as.p = ras.p;
+    as.msk = ras.msk;
+    skRegShares.push_back(as);
+  }
+  ras.shares = skRegShares;
+  return ras;
+}
 // AddrSK RegAuthSK::randomUser() const {
 //    // WARNING: Not a secure PRNG, but okay for this.
 //    return registerUser(std::to_string(rand()) + "@rand.com");

--- a/utt/libutt/src/bankIdentity.cpp
+++ b/utt/libutt/src/bankIdentity.cpp
@@ -1,0 +1,23 @@
+#include "bankIdentity.hpp"
+#include "mint.hpp"
+#include <utt/Params.h>
+#include <utt/RandSig.h>
+#include <utt/Serialization.h>
+#include <utt/MintOp.h>
+#include <vector>
+
+namespace libutt::api {
+BankIdentity::BankIdentity(const std::string& id, const std::string& bsk) {
+  bid_ = id;
+  bsk_.reset(new libutt::RandSigShareSK());
+  *bsk_ = libutt::deserialize<libutt::RandSigShareSK>(bsk);
+}
+
+const std::string& BankIdentity::getId() const { return bid_; }
+template <>
+std::vector<uint8_t> BankIdentity::sign<operations::Mint>(operations::Mint& mint) const {
+  auto res = mint.op_->shareSignCoin(*bsk_);
+  auto res_str = libutt::serialize<libutt::RandSigShare>(res);
+  return std::vector<uint8_t>(res_str.begin(), res_str.end());
+}
+}  // namespace libutt::api

--- a/utt/libutt/src/clientIdentity.cpp
+++ b/utt/libutt/src/clientIdentity.cpp
@@ -1,0 +1,56 @@
+#include "clientIdentity.hpp"
+#include "coin.hpp"
+#include <utt/IBE.h>
+#include <utt/Address.h>
+#include <utt/RandSig.h>
+#include <utt/Params.h>
+#include <utt/Serialization.h>
+#include <utt/Coin.h>
+#include <vector>
+#include <sstream>
+namespace libutt::api {
+ClientIdentity::ClientIdentity(const std::string& pid, const std::string& bpk) {
+  ask_.reset(new libutt::AddrSK());
+  ask_->pid = pid;
+  ask_->s = Fr::random_element();
+  ask_->pid_hash = AddrSK::pidHash(pid);
+  bpk_.reset(new libutt::RandSigPK());
+  *bpk_ = libutt::deserialize<libutt::RandSigPK>(bpk);
+}
+Commitment ClientIdentity::generatePartialRCM(Details& d) {
+  std::vector<std::vector<uint64_t>> m = {getPidHash(), ask_->s.to_words(), Fr::zero().to_words()};
+  auto comm = Commitment(d, Commitment::Type::REGISTRATION, m, true);
+  return comm;
+}
+
+std::string ClientIdentity::getPid() const { return ask_->pid; }
+std::vector<uint64_t> ClientIdentity::getPidHash() const { return ask_->getPidHash().to_words(); }
+std::vector<uint64_t> ClientIdentity::getPRFSecretKey() const { return ask_->s.to_words(); }
+
+void ClientIdentity::setIBEDetails(const std::vector<uint8_t>& sk, const std::vector<uint8_t>& mpk) {
+  ask_->e = libutt::deserialize<libutt::IBE::EncSK>(std::string(sk.begin(), sk.end()));
+  ask_->mpk_ = libutt::deserialize<libutt::IBE::MPK>(std::string(mpk.begin(), mpk.end()));
+}
+
+void ClientIdentity::setRCM(const Commitment& comm, const std::vector<uint8_t>& sig) {
+  rcm_ = comm;
+  rcm_sig_ = sig;
+  ask_->rs = libutt::deserialize<libutt::RandSig>(sig);
+}
+
+std::pair<Commitment, std::vector<uint8_t>> ClientIdentity::getRcm() const { return {rcm_, rcm_sig_}; }
+template <>
+bool ClientIdentity::validate<Coin>(const Coin& c) {
+  return c.coin_->hasValidSig(*bpk_);
+}
+void ClientIdentity::randomizeRCM() {
+  auto r_delta = rcm_.randomize(Details::instance(), Commitment::Type::REGISTRATION);
+  Fr fr_r_delta;
+  fr_r_delta.from_words(r_delta);
+  auto rand_sig = libutt::deserialize<libutt::RandSig>(rcm_sig_);
+  rand_sig.rerandomize(fr_r_delta, Fr::random_element());
+  auto tmp_sig = libutt::serialize<libutt::RandSig>(rand_sig);
+  rcm_sig_ = std::vector<uint8_t>(tmp_sig.begin(), tmp_sig.end());
+}
+
+}  // namespace libutt::api

--- a/utt/libutt/src/coin.cpp
+++ b/utt/libutt/src/coin.cpp
@@ -1,0 +1,37 @@
+#include "coin.hpp"
+#include <utt/Coin.h>
+#include <utt/Params.h>
+#include <utt/Serialization.h>
+#include <utt/RandSig.h>
+
+namespace libutt::api {
+Coin::Coin(Details& d, const std::vector<uint64_t>& sn, const std::vector<uint64_t>& val, Type t, const std::vector<uint64_t>& exp_date, ClientIdentity& cid) {
+  Fr fr_sn;
+  fr_sn.from_words(sn);
+  Fr fr_val;
+  fr_val.from_words(val);
+  Fr fr_type = t == Type::Normal ? libutt::Coin::NormalType() : libutt::Coin::BudgetType(); 
+  Fr fr_exp_date;
+  fr_exp_date.from_words(exp_date);
+  Fr pid_hash;
+  pid_hash.from_words(cid.getPidHash());
+  coin_.reset(new libutt::Coin(d.getParams().ck_coin, fr_sn, fr_val, fr_type, fr_exp_date, pid_hash));
+  nullifier_.reset(new Nullifier(d, cid.getPRFSecretKey(), sn, Fr::random_element().to_words()));
+  type_ = t;
+}
+const Nullifier& Coin::getNullifier() const { return *nullifier_; }
+bool Coin::hasSig() const { return has_sig_; }
+void Coin::setSig(const std::vector<uint8_t>& sig) {
+  coin_->sig = libutt::deserialize<libutt::RandSig>(std::string(sig.begin(), sig.end()));
+  has_sig_ = true;
+}
+Coin::Type Coin::getType() const { return type_; }
+std::vector<uint8_t> Coin::getSig() const { 
+  auto str_sig = libutt::serialize<libutt::RandSig>(coin_->sig);
+  return std::vector<uint8_t>(str_sig.begin(), str_sig.end()); 
+  }
+void Coin::randomize() {
+  Fr u_delta = Fr::random_element();
+  coin_->sig.rerandomize(coin_->r, u_delta);
+}
+}  // namespace libutt::api

--- a/utt/libutt/src/coin.cpp
+++ b/utt/libutt/src/coin.cpp
@@ -5,12 +5,17 @@
 #include <utt/RandSig.h>
 
 namespace libutt::api {
-Coin::Coin(Details& d, const std::vector<uint64_t>& sn, const std::vector<uint64_t>& val, Type t, const std::vector<uint64_t>& exp_date, ClientIdentity& cid) {
+Coin::Coin(Details& d,
+           const std::vector<uint64_t>& sn,
+           const std::vector<uint64_t>& val,
+           Type t,
+           const std::vector<uint64_t>& exp_date,
+           ClientIdentity& cid) {
   Fr fr_sn;
   fr_sn.from_words(sn);
   Fr fr_val;
   fr_val.from_words(val);
-  Fr fr_type = t == Type::Normal ? libutt::Coin::NormalType() : libutt::Coin::BudgetType(); 
+  Fr fr_type = t == Type::Normal ? libutt::Coin::NormalType() : libutt::Coin::BudgetType();
   Fr fr_exp_date;
   fr_exp_date.from_words(exp_date);
   Fr pid_hash;
@@ -26,10 +31,10 @@ void Coin::setSig(const std::vector<uint8_t>& sig) {
   has_sig_ = true;
 }
 Coin::Type Coin::getType() const { return type_; }
-std::vector<uint8_t> Coin::getSig() const { 
+std::vector<uint8_t> Coin::getSig() const {
   auto str_sig = libutt::serialize<libutt::RandSig>(coin_->sig);
-  return std::vector<uint8_t>(str_sig.begin(), str_sig.end()); 
-  }
+  return std::vector<uint8_t>(str_sig.begin(), str_sig.end());
+}
 void Coin::randomize() {
   Fr u_delta = Fr::random_element();
   coin_->sig.rerandomize(coin_->r, u_delta);

--- a/utt/libutt/src/commitment.cpp
+++ b/utt/libutt/src/commitment.cpp
@@ -1,0 +1,90 @@
+#include "commitment.hpp"
+#include <utt/Comm.h>
+#include <utt/Params.h>
+#include <utt/RandSig.h>
+#include <utt/Serialization.h>
+#include <utt/PolyCrypto.h>
+
+#include <sstream>
+
+libutt::api::Commitment operator+(libutt::api::Commitment lhs, const libutt::api::Commitment& rhs) {
+  libutt::api::Commitment comm = lhs;
+  comm += rhs;
+  return comm;
+}
+
+namespace libutt::api {
+libutt::CommKey getCommitmentKey(libutt::Params& p, Commitment::Type t) {
+  switch (t) {
+    case Commitment::Type::REGISTRATION:
+      return p.ck_reg;
+    case Commitment::Type::VALUE:
+      return p.ck_val;
+    case Commitment::Type::COIN:
+      return p.ck_coin;
+      return libutt::CommKey();
+  }
+}
+std::vector<Commitment> Commitment::create(Details& d,
+                                           Type t,
+                                           const std::vector<std::vector<uint64_t>>& messages,
+                                           std::vector<std::vector<uint64_t>>& randomizations,
+                                           bool withG2) {
+  std::vector<Fr> fr_messages(messages.size());
+  for (size_t i = 0; i < messages.size(); i++) {
+    fr_messages[i].from_words(messages.at(i));
+  }
+  std::vector<Fr> fr_randomness(randomizations.size());
+  for (size_t i = 0; i < randomizations.size(); i++) {
+    fr_randomness[i].from_words(randomizations.at(i));
+  }
+
+  auto comms = libutt::Comm::create(getCommitmentKey(d.getParams(), t), fr_messages, fr_randomness, withG2);
+  std::vector<Commitment> ret(comms.size());
+  for (size_t i = 0; i < comms.size(); i++) {
+    *(ret[i].comm_) = comms[i];
+  }
+  return ret;
+}
+
+Commitment::Commitment(Details& d, Type t, const std::vector<std::vector<uint64_t>>& messages, bool withG2) {
+  std::vector<Fr> fr_messages(messages.size());
+  for (size_t i = 0; i < messages.size(); i++) {
+    fr_messages[i].from_words(messages.at(i));
+  }
+  comm_.reset(new libutt::Comm());
+  *comm_ = libutt::Comm::create(getCommitmentKey(d.getParams(), t), fr_messages, withG2);
+}
+Commitment::Commitment(const std::string& comm) {
+  comm_.reset(new libutt::Comm());
+  *comm_ = libutt::deserialize<libutt::Comm>(comm);
+}
+Commitment::Commitment() { comm_.reset(new libutt::Comm()); }
+Commitment& Commitment::operator=(const Commitment& comm) {
+  comm_.reset(new libutt::Comm());
+  *comm_ = *comm_ = *comm.comm_;
+  return *this;
+}
+
+Commitment::Commitment(const Commitment& comm) {
+  comm_.reset(new libutt::Comm());
+  *comm_ = *comm.comm_;
+}
+
+size_t Commitment::getCommitmentSn(const Commitment& comm) {
+  return std::hash<std::string>{}(libutt::serialize<libutt::Comm>(*(comm.comm_)));
+}
+std::string Commitment::getCommitmentHash(const Commitment& comm) {
+  return hashToHex("rcm|" + libutt::serialize<libutt::Comm>(*(comm.comm_)));
+}
+Commitment& Commitment::operator+=(const Commitment& comm) {
+  (*comm_) += *(comm.comm_);
+  return *this;
+}
+
+std::vector<uint64_t> Commitment::randomize(Details& d, Type t) {
+  Fr u_delta = Fr::random_element();
+  comm_->rerandomize(getCommitmentKey(d.getParams(), t), u_delta);
+  return u_delta.to_words();
+}
+}  // namespace libutt::api

--- a/utt/libutt/src/common.cpp
+++ b/utt/libutt/src/common.cpp
@@ -1,0 +1,36 @@
+#include "common.hpp"
+#include <utt/RandSig.h>
+#include <utt/Comm.h>
+#include <utt/Serialization.h>
+#include <utt/Params.h>
+namespace libutt::api {
+std::vector<uint8_t> Utils::aggregateSigShares(Details& d,
+                                               Commitment::Type t,
+                                               uint32_t n,
+                                               const std::map<uint32_t, std::vector<uint8_t>>& rsigs,
+                                               std::vector<std::vector<uint64_t>> randomness) {
+  std::vector<libutt::RandSigShare> shares;
+  std::vector<size_t> signers;
+  for (const auto& [sid, rsig] : rsigs) {
+    shares.push_back(libutt::deserialize<libutt::RandSigShare>(rsig));
+    signers.push_back((size_t)sid);
+  }
+  std::vector<Fr> fr_randomness(randomness.size());
+  for (size_t i = 0; i < randomness.size(); i++) fr_randomness[i].from_words(randomness[i]);
+  libutt::CommKey ck;
+  switch (t) {
+    case Commitment::Type::REGISTRATION:
+      ck = d.getParams().ck_reg;
+      break;
+    case Commitment::Type::VALUE:
+      ck = d.getParams().ck_val;
+      break;
+    case Commitment::Type::COIN:
+      ck = d.getParams().ck_coin;
+      break;
+  }
+  auto csig = libutt::RandSigShare::aggregate((size_t)(n), shares, signers, ck, fr_randomness);
+  auto str_csig = libutt::serialize<libutt::RandSig>(csig);
+  return std::vector<uint8_t>(str_csig.begin(), str_csig.end());
+}
+}  // namespace libutt::api

--- a/utt/libutt/src/details.cpp
+++ b/utt/libutt/src/details.cpp
@@ -1,0 +1,43 @@
+#include <sstream>
+
+#include "details.hpp"
+#include <utt/RangeProof.h>
+#include <utt/NtlLib.h>
+#include <utt/Params.h>
+
+namespace libutt::api {
+using Fr = typename libff::default_ec_pp::Fp_type;
+void Details::init() {
+  unsigned char* randSeed = nullptr;  // TODO: initialize entropy source
+  int size = 0;                       // TODO: initialize entropy source
+
+  // Apparently, libff logs some extra info when computing pairings
+  libff::inhibit_profiling_info = true;
+
+  // AB: We _info disables printing of information and _counters prevents tracking of profiling information. If we are
+  // using the code in parallel, disable both the logs.
+  libff::inhibit_profiling_counters = true;
+
+  // Initializes the default EC curve, so as to avoid "surprises"
+  libff::default_ec_pp::init_public_params();
+
+  // Initializes the NTL finite field
+  NTL::ZZ p = NTL::conv<ZZ>("21888242871839275222246405745257275088548364400416034343698204186575808495617");
+  NTL::ZZ_p::init(p);
+
+  NTL::SetSeed(randSeed, size);
+
+#ifdef USE_MULTITHREADING
+  // NOTE: See https://stackoverflow.com/questions/11095309/openmp-set-num-threads-is-not-working
+  loginfo << "Using " << getNumCores() << " threads" << endl;
+  omp_set_dynamic(0);                                    // Explicitly disable dynamic teams
+  omp_set_num_threads(static_cast<int>(getNumCores()));  // Use 4 threads for all consecutive parallel regions
+#else
+  // loginfo << "NOT using multithreading" << endl;
+#endif
+
+  RangeProof::Params::initializeOmegas();
+  params.reset(new libutt::Params());
+}
+libutt::Params& Details::getParams() { return *params; }
+}  // namespace libutt::api

--- a/utt/libutt/src/mint.cpp
+++ b/utt/libutt/src/mint.cpp
@@ -1,0 +1,34 @@
+#include "mint.hpp"
+#include "coin.hpp"
+#include "common.hpp"
+#include <utt/MintOp.h>
+#include <utt/Params.h>
+#include <utt/Coin.h>
+#include <utt/Serialization.h>
+
+namespace libutt::api::operations {
+Mint::Mint(const std::string& uniqueHash, size_t value, const std::string& recipPID) {
+  op_.reset(new libutt::MintOp(uniqueHash, value, recipPID));
+}
+bool Mint::validate(const std::string& uniqueHash, size_t value, const std::string& recipPID) const {
+  return op_->validate(uniqueHash, value, recipPID);
+}
+Coin Mint::claimCoin(Details& d,
+                     ClientIdentity& cid,
+                     uint32_t n,
+                     const std::map<uint32_t, std::vector<uint8_t>>& rsigs) const {
+  Fr r_pid = Fr::zero(), r_sn = Fr::zero(), r_val = Fr::zero(), r_type = Fr::zero(), r_expdate = Fr::zero();
+  std::vector<std::vector<uint64_t>> r = {
+      r_pid.to_words(), r_sn.to_words(), r_val.to_words(), r_type.to_words(), r_expdate.to_words()};
+  auto sig = Utils::aggregateSigShares(d, Commitment::Type::COIN, n, rsigs, r);
+  libutt::api::Coin c(d,
+                      op_->getSN().to_words(),
+                      op_->getVal().to_words(),
+                      Coin::Type::Normal,
+                      libutt::Coin::DoesNotExpire().to_words(),
+                      cid);
+  c.setSig(sig);
+  c.randomize();
+  return c;
+}
+}  // namespace libutt::api::operations

--- a/utt/libutt/src/nullifier.cpp
+++ b/utt/libutt/src/nullifier.cpp
@@ -1,0 +1,23 @@
+#include "nullifier.hpp"
+#include <utt/Nullifier.h>
+#include <utt/Params.h>
+#include <utt/Serialization.h>
+
+namespace libutt::api {
+Nullifier::Nullifier(Details& d,
+                     const std::vector<uint64_t>& prf_secret_key,
+                     const std::vector<uint64_t>& sn,
+                     const std::vector<uint64_t>& randomization) {
+  Fr sprf;
+  sprf.from_words(prf_secret_key);
+  Fr frsn;
+  frsn.from_words(sn);
+  Fr frrandom;
+  frrandom.from_words(randomization);
+  nullifier_.reset(new libutt::Nullifier(d.getParams().null, sprf, frsn, frrandom));
+}
+
+bool Nullifier::validate(Details& d) const { return nullifier_->verify(d.getParams().null); }
+
+std::string Nullifier::toString() const { return libutt::serialize<libutt::Nullifier>(*nullifier_); }
+}  // namespace libutt::api

--- a/utt/libutt/src/registratorIdentity.cpp
+++ b/utt/libutt/src/registratorIdentity.cpp
@@ -1,0 +1,57 @@
+#include "registratorIdentity.hpp"
+#include "commitment.hpp"
+#include "common.hpp"
+#include <utt/RegAuth.h>
+#include <utt/RandSig.h>
+#include <utt/Serialization.h>
+#include <utt/Comm.h>
+#include <utt/IBE.h>
+#include <utt/PolyCrypto.h>
+#include <utt/Params.h>
+namespace libutt::api {
+RegistratorIdentity::RegistratorIdentity(const std::string& id, const std::string& rsk, const std::string& rbk) {
+  id_ = id;
+  rsk_.reset(new libutt::RegAuthShareSK());
+  *rsk_ = libutt::deserialize<libutt::RegAuthShareSK>(rsk);
+  rpk_.reset(new libutt::RegAuthPK());
+  *rpk_ = libutt::deserialize<libutt::RegAuthPK>(rbk);
+}
+RegistrationDetails RegistratorIdentity::registerClient(Details& d,
+                                                        const std::string& pid,
+                                                        const std::vector<uint64_t>& pid_hash,
+                                                        const Commitment& partial_comm) const {
+  RegistrationDetails rd;
+  Fr reg_sn;
+  // The clinet sends a commitment that contains its PRF key, hence, by taking the hash as sequence number we do commit
+  // to this PRF keyu as well So, eventually, the commitment here is for the client pid, and PRF secret key.
+  reg_sn.set_ulong(Commitment::getCommitmentSn(partial_comm));
+  std::vector<std::vector<uint64_t>> m = {pid_hash, reg_sn.to_words(), Fr::zero().to_words()};
+  auto comm = Commitment(d, Commitment::Type::REGISTRATION, m, true);
+  rd.rcm_ = comm;
+  Fr fr_pid;
+  fr_pid.from_words(pid_hash);
+  std::string h1 = Commitment::getCommitmentHash(rd.rcm_);
+  G1 H = libutt::hashToGroup<G1>("ps16base|" + h1);
+  auto res = rsk_->sk.shareSign({(fr_pid * H), (reg_sn * H)}, H);
+  auto res_str = libutt::serialize<libutt::RandSigShare>(res);
+  rd.rcm_sig_ = std::vector<uint8_t>(res_str.begin(), res_str.end());
+  rd.dsk_pub_ = getMPK();
+  rd.dsk_priv_ = generateSecretForPid(pid);
+  return rd;
+}
+
+std::vector<uint8_t> RegistratorIdentity::generateSecretForPid(const std::string& pid) const {
+  auto res = rsk_->msk.deriveEncSK(rsk_->p, pid);
+  auto res_str = libutt::serialize<libutt::IBE::EncSK>(res);
+  return std::vector<uint8_t>(res_str.begin(), res_str.end());
+}
+
+std::vector<uint8_t> RegistratorIdentity::getMPK() const {
+  auto res_str = libutt::serialize<libutt::IBE::MPK>(rsk_->toPK().mpk);
+  return std::vector<uint8_t>(res_str.begin(), res_str.end());
+}
+bool RegistratorIdentity::validateRCM(const Commitment& comm, const std::vector<uint8_t>& sig) {
+  libutt::RandSig rsig = libutt::deserialize<libutt::RandSig>(sig);
+  return rsig.verify(*comm.comm_, rpk_->vk);
+}
+}  // namespace libutt::api

--- a/utt/tests/CMakeLists.txt
+++ b/utt/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(newutt_test_sources
+    TestDistributedRegistration.cpp
+    TestMint.cpp
+)
+
+foreach(appSrc ${newutt_test_sources})
+    get_filename_component(appName ${appSrc} NAME_WE)
+    set(appDir ../bin/test)
+
+    add_executable(${appName} ${appSrc})
+    target_link_libraries(${appName} PRIVATE newutt)
+
+    add_test(NAME ${appName} COMMAND ${appName})
+    set_target_properties(${appName} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${appDir})
+endforeach()
+
+target_compile_definitions(TestParallelPairing PRIVATE -DUSE_MULTITHREADING)

--- a/utt/tests/TestDistributedRegistration.cpp
+++ b/utt/tests/TestDistributedRegistration.cpp
@@ -1,0 +1,34 @@
+#include "details.hpp"
+#include "testUtils.hpp"
+
+#include <memory>
+#include <vector>
+#include <cstdlib>
+#include <ctime>
+
+using namespace libutt;
+using namespace libutt::api;
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+  size_t thresh = 3;
+  size_t n = 4;
+  size_t c = 10;
+  auto [dkg, rc] = testing::init(n, thresh);
+  auto& d = Details::instance();
+  auto registrators = testing::GenerateRegistrators(n, rc);
+  auto banks = testing::GenerateCommitters(n, dkg);
+  auto clients = testing::GenerateClients(c, dkg.getSK().toPK());
+
+  for (auto& c : clients) {
+    testing::registerClient(d, c, registrators, thresh);
+    for (auto& r : registrators) {
+      c.randomizeRCM();
+      auto rcm_data = c.getRcm();
+      assertTrue(r->validateRCM(rcm_data.first, rcm_data.second));
+    }
+  }
+
+  return 0;
+}

--- a/utt/tests/TestMint.cpp
+++ b/utt/tests/TestMint.cpp
@@ -33,15 +33,15 @@ int main(int argc, char* argv[]) {
     std::vector<std::vector<uint8_t>> rsigs;
     std::string simulatonOfUniqueTxHash = std::to_string(((uint64_t)rand()) * ((uint64_t)rand()) * ((uint64_t)rand()));
     auto mint = Mint(simulatonOfUniqueTxHash, 100, c.getPid());
-    for (size_t i =  0 ; i < banks.size() ; i++) {
+    for (size_t i = 0; i < banks.size(); i++) {
       rsigs.push_back(banks[i]->sign(mint));
     }
     auto sbs = testing::getSubGroup((uint32_t)n, (uint32_t)thresh);
     std::map<uint32_t, std::vector<uint8_t>> sigs;
     for (auto i : sbs) {
-        sigs[i] = rsigs[i];
+      sigs[i] = rsigs[i];
     }
-    auto coin = mint.claimCoin(d, c, (uint32_t) n, sigs);
+    auto coin = mint.claimCoin(d, c, (uint32_t)n, sigs);
     assertTrue(c.validate(coin));
     assertTrue(coin.getNullifier().validate(d));
   }

--- a/utt/tests/TestMint.cpp
+++ b/utt/tests/TestMint.cpp
@@ -1,0 +1,49 @@
+#include "testUtils.hpp"
+
+#include "details.hpp"
+#include "testUtils.hpp"
+#include "mint.hpp"
+#include <utt/MintOp.h>
+#include <utt/Coin.h>
+#include <memory>
+#include <vector>
+#include <cstdlib>
+#include <ctime>
+
+using namespace libutt;
+using namespace libutt::api;
+using namespace libutt::api::operations;
+int main(int argc, char* argv[]) {
+  std::srand(0);
+  (void)argc;
+  (void)argv;
+  size_t thresh = 3;
+  size_t n = 4;
+  size_t c = 10;
+  auto [dkg, rc] = testing::init(n, thresh);
+  auto& d = Details::instance();
+  auto registrators = testing::GenerateRegistrators(n, rc);
+  auto banks = testing::GenerateCommitters(n, dkg);
+  auto clients = testing::GenerateClients(c, dkg.getPK());
+  for (auto& c : clients) {
+    testing::registerClient(d, c, registrators, thresh);
+  }
+
+  for (auto& c : clients) {
+    std::vector<std::vector<uint8_t>> rsigs;
+    std::string simulatonOfUniqueTxHash = std::to_string(((uint64_t)rand()) * ((uint64_t)rand()) * ((uint64_t)rand()));
+    auto mint = Mint(simulatonOfUniqueTxHash, 100, c.getPid());
+    for (size_t i =  0 ; i < banks.size() ; i++) {
+      rsigs.push_back(banks[i]->sign(mint));
+    }
+    auto sbs = testing::getSubGroup((uint32_t)n, (uint32_t)thresh);
+    std::map<uint32_t, std::vector<uint8_t>> sigs;
+    for (auto i : sbs) {
+        sigs[i] = rsigs[i];
+    }
+    auto coin = mint.claimCoin(d, c, (uint32_t) n, sigs);
+    assertTrue(c.validate(coin));
+    assertTrue(coin.getNullifier().validate(d));
+  }
+  return 0;
+}

--- a/utt/tests/testUtils.hpp
+++ b/utt/tests/testUtils.hpp
@@ -23,7 +23,7 @@ using namespace libutt;
 using namespace libutt::api;
 namespace libutt::api::testing {
 std::vector<uint32_t> getSubGroup(uint32_t n, uint32_t size) {
-    std::srand((unsigned int)std::time(0));
+  std::srand((unsigned int)std::time(0));
   std::map<uint32_t, uint32_t> ret;
   for (uint32_t i = 0; i < n; i++) ret[i] = i;
   for (uint32_t i = 0; i < n - size; i++) {

--- a/utt/tests/testUtils.hpp
+++ b/utt/tests/testUtils.hpp
@@ -1,0 +1,96 @@
+#pragma once
+#include "details.hpp"
+#include "bankIdentity.hpp"
+#include "clientIdentity.hpp"
+#include "registratorIdentity.hpp"
+#include "common.hpp"
+#include "coin.hpp"
+#include <utt/RegAuth.h>
+#include <utt/RandSigDKG.h>
+#include <utt/Serialization.h>
+#include <utt/Params.h>
+#include <utt/IBE.h>
+#include <utt/Serialization.h>
+#include <utt/Address.h>
+#include <utt/Comm.h>
+
+#include <vector>
+#include <memory>
+#include <cstdlib>
+#include <iostream>
+#include <ctime>
+using namespace libutt;
+using namespace libutt::api;
+namespace libutt::api::testing {
+std::vector<uint32_t> getSubGroup(uint32_t n, uint32_t size) {
+    std::srand((unsigned int)std::time(0));
+  std::map<uint32_t, uint32_t> ret;
+  for (uint32_t i = 0; i < n; i++) ret[i] = i;
+  for (uint32_t i = 0; i < n - size; i++) {
+    uint32_t index = (uint32_t)(std::rand()) % (uint32_t)(ret.size());
+    ret.erase(index);
+  }
+  std::vector<uint32_t> rret;
+  for (const auto& [k, v] : ret) {
+    (void)k;
+    rret.push_back(v);
+  }
+  return rret;
+}
+std::pair<RandSigDKG, RegAuthSK> init(size_t n, size_t thresh) {
+  auto& d = Details::instance();
+  d.init();
+
+  auto dkg = RandSigDKG(thresh, n, Params::NumMessages);
+  d.getParams() = Params::random(dkg.getCK());
+  auto rc = RegAuthSK::generateKeyAndShares(d.getParams().ck_reg, thresh, n, d.getParams().ibe);
+  d.getParams().ck_reg = rc.ck_reg;
+  return {dkg, rc};
+}
+std::vector<std::shared_ptr<RegistratorIdentity>> GenerateRegistrators(size_t n, const RegAuthSK& rsk) {
+  std::vector<std::shared_ptr<RegistratorIdentity>> registrators;
+  for (size_t i = 0; i < n; i++) {
+    registrators.push_back(std::make_shared<RegistratorIdentity>(
+        std::to_string(i), serialize<RegAuthShareSK>(rsk.shares[i]), serialize<RegAuthPK>(rsk.toPK())));
+  }
+  return registrators;
+}
+
+std::vector<std::shared_ptr<BankIdentity>> GenerateCommitters(size_t n, const RandSigDKG& dkg) {
+  std::vector<std::shared_ptr<BankIdentity>> banks;
+  for (size_t i = 0; i < n; i++) {
+    banks.push_back(std::make_shared<BankIdentity>(std::to_string(i), serialize<RandSigShareSK>(dkg.skShares[i])));
+  }
+  return banks;
+}
+
+std::vector<ClientIdentity> GenerateClients(size_t c, const RandSigPK& rvk) {
+  std::vector<ClientIdentity> clients;
+  std::string bpk = libutt::serialize<libutt::RandSigPK>(rvk);
+  for (size_t i = 0; i < c; i++) {
+    clients.push_back(ClientIdentity("client_" + std::to_string(i), bpk));
+  }
+  return clients;
+}
+
+void registerClient(Details& d,
+                    ClientIdentity& c,
+                    std::vector<std::shared_ptr<RegistratorIdentity>>& registrators,
+                    size_t thresh) {
+  size_t n = registrators.size();
+  std::vector<RegistrationDetails> rd;
+  auto part_comm = c.generatePartialRCM(d);
+  for (auto& r : registrators) {
+    rd.push_back(r->registerClient(d, c.getPid(), c.getPidHash(), part_comm));
+  }
+  auto sids = getSubGroup((uint32_t)n, (uint32_t)thresh);
+  std::map<uint32_t, std::vector<uint8_t>> rsigs;
+  for (auto i : sids) {
+    rsigs[i] = rd[i].rcm_sig_;
+  }
+  auto sig = Utils::aggregateSigShares(
+      d, Commitment::Type::REGISTRATION, (uint32_t)n, rsigs, {Fr::zero().to_words(), Fr::zero().to_words()});
+  c.setRCM(rd[0].rcm_, sig);
+  c.setIBEDetails(rd[0].dsk_priv_, rd[0].dsk_pub_);
+}
+}  // namespace libutt::api::testing


### PR DESCRIPTION
Introducing a new interface to the UTT library to be used by less expert users.
The main goals of this interface are:
1. Expose as less as functionality as possible
2. Use the simplest input parameters types

The following are worth noticing:
1. This implementation also includes a distributed registration functionality
2. The PKI is still based on IBE
3. Cryptographic curve points are represented by std::vector<uint64_t>
4. Signatures are represented as std::vetor<uint8_t>
5. The implementation exposes the "newutt" static lib
6. This PR includes tests for testing the functionality