### PR TITLE
Don't assert if ike was not done after state transfer (#2740)

### DIFF
--- a/bftengine/src/bftengine/KeyExchangeManager.cpp
+++ b/bftengine/src/bftengine/KeyExchangeManager.cpp
@@ -134,7 +134,7 @@ void KeyExchangeManager::loadPublicKeys() {
   // after State Transfer public keys for all replicas are expected to exist
   auto num_loaded = publicKeys_.loadAllReplicasKeyStoresFromReservedPages();
   uint32_t liveQuorumSize = ReplicaConfig::instance().waitForFullCommOnStartup ? clusterSize_ : quorumSize_;
-  if (ReplicaConfig::instance().getkeyExchangeOnStart()) {
+  if (ReplicaConfig::instance().getkeyExchangeOnStart() && exchanged()) {
     ConcordAssertGE(num_loaded, liveQuorumSize);
   }
   LOG_INFO(KEY_EX_LOG, "building crypto system after state transfer");


### PR DESCRIPTION
* **Problem Overview**  
    In case we have a VC before the initial KE, the replicas fill their active window with no-ops. Hence, a late replica may start state transfer. However, this replica will assert when state transfer is done because the initial key exchange has not been completed yet.
The solution is not to assert if the initial key exchange has not been done yet.
* **Testing Done**  
  CI

