### PR TITLE
v4_migration_test - disble due to instability on CI

### DIFF
--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -361,17 +361,19 @@ if (BUILD_ROCKSDB_STORAGE)
             stdc++fs
     )
 
-    add_executable(v4_migration_test migrations/v4_migration_test.cpp)
-    add_test(v4_migration_test v4_migration_test)
-    target_link_libraries(v4_migration_test PUBLIC
-            GTest::Main
-            GTest::GTest
-            ${Boost_LIBRARIES}
-            v4migration_tool_lib
-            util
-            corebft
-            kvbc
-            stdc++fs
-            execution_data_cmf
-    )
+    # Disabled due to instability
+    #
+    # add_executable(v4_migration_test migrations/v4_migration_test.cpp)
+    # add_test(v4_migration_test v4_migration_test)
+    # target_link_libraries(v4_migration_test PUBLIC
+    #         GTest::Main
+    #         GTest::GTest
+    #         ${Boost_LIBRARIES}
+    #         v4migration_tool_lib
+    #         util
+    #         corebft
+    #         kvbc
+    #         stdc++fs
+    #         execution_data_cmf
+    # )
 endif (BUILD_ROCKSDB_STORAGE)

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1358,6 +1358,7 @@ class SkvbcReconfigurationTest(ApolloTest):
         crashed_replicas = set(range(replica_count - 2, replica_count))
         await self.send_restart_with_params(bft_network, bft=True, restart=True, faulty_replica_ids=crashed_replicas)
 
+    @unittest.skip("Unstable test")
     @with_trio
     @with_bft_network(start_replica_cmd_with_key_exchange, selected_configs=lambda n, f, c: n == 7, rotate_keys=True, publish_master_keys=True)
     async def test_remove_nodes(self, bft_network):


### PR DESCRIPTION
* **Problem Overview**  
Test is failing on CI, need to disable it till it's fixed.
* **Testing Done**  
NA
