### PR TITLE
Fix for intermittent failure of apollo test test_tls_exchange_client_replica_with_st

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -282,6 +282,9 @@ class SkvbcReconfigurationTest(ApolloTest):
             skvbc = kvbc.SimpleKVBCProtocol(bft_network)
             for i in range(100):
                 await skvbc.send_write_kv_set()
+
+            await skvbc.multiple_validate_last_exec_seq_num_for_all_replicas(30);
+
             initial_prim = 0
             next_primary = 1
             bft_network.stop_replica(next_primary)

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -433,6 +433,38 @@ class SimpleKVBCProtocol:
         else:
             return writeset[0][0], writeset[0][1]
 
+    async def validate_last_exec_seq_num_for_all_replicas(self, timeout):
+
+        # Validate if all replicas have same last executed sequence number after the write
+
+        with log.start_action(action_type="validate_last_exec_seq_num_for_all_replicas"):
+            with trio.fail_after(timeout):
+                while True:
+                    repl_counter = 0
+                    last_seq_num0 = await self.bft_network.wait_for_last_executed_seq_num(repl_counter)
+                    while repl_counter < self.bft_network.num_total_replicas() - 1:
+                        repl_counter += 1
+                        last_seq_num1 = await self.bft_network.wait_for_last_executed_seq_num(repl_counter)
+                        if last_seq_num0 != last_seq_num1:
+                            await trio.sleep(0.5)
+                            break
+                    if repl_counter == self.bft_network.num_total_replicas() - 1:
+                        return last_seq_num0
+
+    async def multiple_validate_last_exec_seq_num_for_all_replicas(self, timeout):
+
+        # We fetch last executed sequnce number which is equal for all replicas till we get such two equal sequence numbers.
+        # This is done to avoid the case where sequence numbers for all replicas are same
+        # but there are more sequence numbers remaining for each of them
+
+        with log.start_action(action_type="mutliple_validate_last_exec_seq_num_for_all_replicas"):
+            with trio.fail_after(timeout):
+                while True:
+                    seq_num1 = await self.validate_last_exec_seq_num_for_all_replicas(timeout)
+                    seq_num2 = await self.validate_last_exec_seq_num_for_all_replicas(timeout)
+                    if seq_num1 == seq_num2:
+                        break
+
     async def send_kv_set(self, client, readset, writeset, read_version, long_exec=False, reply_assert=True,
                           raise_slowErrorIfAny=True, description='send_kv_set'):
         seq_num = client.req_seq_num.next()


### PR DESCRIPTION
The apollo test test_tls_exchange_client_replica_with_st failed intermittently (6 out of 100 times) with the following error:


Issue details:

Traceback (most recent call last):
File "/usr/local/lib/python3.6/dist-packages/trio/_timeouts.py", line 106, in fail_at
yield scope
File "/concord-bft/tests/apollo/util/bft.py", line 1213, in wait_for_state_transfer_to_start
nursery.cancel_scope)
File "/usr/local/lib/python3.6/dist-packages/trio/core/_run.py", line 815, in __aexit_
raise combined_error_from_nursery
File "/concord-bft/tests/apollo/util/bft.py", line 1247, in _wait_to_receive_st_msgs
await trio.sleep(0.1)
File "/usr/local/lib/python3.6/dist-packages/trio/_timeouts.py", line 76, in sleep
await sleep_until(trio.current_time() + seconds)
File "/usr/local/lib/python3.6/dist-packages/trio/_timeouts.py", line 57, in sleep_until
await sleep_forever()
File "/usr/local/lib/python3.6/dist-packages/trio/_timeouts.py", line 40, in sleep_forever
await trio.lowlevel.wait_task_rescheduled(lambda _: trio.lowlevel.Abort.SUCCEEDED)
File "/usr/local/lib/python3.6/dist-packages/trio/_core/_traps.py", line 166, in wait_task_rescheduled
return (await _async_yield(WaitTaskRescheduled(abort_func))).unwrap()
File "/usr/local/lib/python3.6/dist-packages/outcome/_impl.py", line 138, in unwrap
raise captured_error
File "/usr/local/lib/python3.6/dist-packages/trio/_core/_run.py", line 1172, in raise_cancel
raise Cancelled._create()
trio.Cancelled: Cancelled

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/concord-bft/tests/apollo/util/bft.py", line 218, in wrapper
await test_with_bft_network()
File "/concord-bft/tests/apollo/util/test_base.py", line 82, in wrapper
raise e
File "/concord-bft/tests/apollo/util/test_base.py", line 73, in wrapper
await async_fn(*args, **kwargs)
File "/concord-bft/tests/apollo/util/bft.py", line 217, in test_with_bft_network
await async_fn(*args, **kwargs, bft_network=bft_network)
File "/concord-bft/tests/apollo/test_skvbc_reconfiguration.py", line 299, in test_tls_exchange_client_replica_with_st
await bft_network.wait_for_state_transfer_to_start()
File "/concord-bft/tests/apollo/util/bft.py", line 1213, in wait_for_state_transfer_to_start
nursery.cancel_scope)
File "/usr/lib/python3.6/contextlib.py", line 99, in _exit_
self.gen.throw(type, value, traceback)
File "/usr/local/lib/python3.6/dist-packages/trio/_timeouts.py", line 108, in fail_at
raise TooSlowError
trio.TooSlowError

----------------------------------------------------------------------

Fix : Provide a minor sleep at the time of stopping replica 1 and at the time of starting replica 1 again , so that seqNum writing for metadata and blockchain are in sync - which is validated at the createRelipcaandSync .

Update on Fix: We create a function in skvbc.py to validate if last sequence number from all replicas are equal, then proceed, 
else, we wait till all are equal. This is called at the place of kv write in test_tls_exchange_client_replica_with_st test case.
This function is called twice, to avoid the case, where all replicas report same sequence number but they are still not the last sequence numbers for each of them.



Testing done: Ran this test 100 times both local and CI and no failures were found.
