### PR TITLE
Enable multiplex and unified certs by default

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -253,9 +253,9 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                30u,
                "Amount of keys to get at once via multiGet when iterating state");
 
-  CONFIG_PARAM(enableMultiplexChannel, bool, false, "whether multiplex communication channel is enabled")
+  CONFIG_PARAM(enableMultiplexChannel, bool, true, "whether multiplex communication channel is enabled")
 
-  CONFIG_PARAM(useUnifiedCertificates, bool, false, "A flag to use unified Certificates");
+  CONFIG_PARAM(useUnifiedCertificates, bool, true, "A flag to use unified Certificates");
 
   CONFIG_PARAM(adaptivePruningIntervalDuration,
                std::chrono::milliseconds,

--- a/client/bftclient/include/bftclient/config.h
+++ b/client/bftclient/include/bftclient/config.h
@@ -66,6 +66,7 @@ struct ClientConfig {
   uint16_t f_val;
   uint16_t c_val;
   RetryTimeoutConfig retry_timeout_config;
+  bool use_unified_certs = false;
   std::optional<std::string> transaction_signing_private_key_file_path = std::nullopt;
   std::optional<concord::secretsmanager::SecretData> secrets_manager_config = std::nullopt;
   std::optional<std::string> replicas_master_key_folder_path = "./replicas_rsa_keys";

--- a/client/bftclient/test/bft_client_api_tests.cpp
+++ b/client/bftclient/test/bft_client_api_tests.cpp
@@ -61,6 +61,7 @@ class ClientApiTestFixture : public ::testing::Test {
                                1,
                                0,
                                RetryTimeoutConfig{},
+                               0,
                                nullopt};
 
   // Just print all received messages from a client

--- a/client/reconfiguration/test/poll_based_state_client_test.cpp
+++ b/client/reconfiguration/test/poll_based_state_client_test.cpp
@@ -122,6 +122,7 @@ class ClientApiTestFixture : public ::testing::Test {
                                1,
                                0,
                                RetryTimeoutConfig{},
+                               0,
                                std::nullopt};
 
   Config cre_config{5, 10};

--- a/scripts/linux/create_tls_certs.sh
+++ b/scripts/linux/create_tls_certs.sh
@@ -2,7 +2,7 @@
 # Creates simple self-signed certificates to use with TCP/TLS module
 # by default, the script:
 # 1) Creates "certs" folder in the current folder if use_unified_certificates is false
-#    With unified_certs new folder tls_certs will be created 
+#    With use_unified_certs new folder tls_certs will be created 
 # 2) Starts from node ID 0
 #
 # Examples usage:
@@ -31,9 +31,9 @@ fi
 i=$start_node_id
 last_node_id=$((i + $1 - 1))
 
-use_unified_certificates=false
+use_unified_certificates=$4
 
-if [ "$use_unified_certificates" = true ]; then
+if [ $use_unified_certificates == 1 ]; then
    echo "Use Unified Certificates"
 
    dir=$2
@@ -41,60 +41,21 @@ if [ "$use_unified_certificates" = true ]; then
       dir="tls_certs"
    fi
 
-   start_c=1
-
    while [ $i -le $last_node_id ]; do
       echo "processing replica $i/$last_node_id"
       certDir=$dir/$i
 
       mkdir -p $certDir
 
-      if [ $i -le 6 ]; then      # For replicas/TRS from 0-6, total 7
-         
-         k=$((i+1)) 
-         openssl ecparam -name secp384r1 -genkey -noout -out $certDir/pk.pem
+      openssl ecparam -name secp384r1 -genkey -noout -out $certDir/pk.pem
 
-         openssl req -new -key $certDir/pk.pem -nodes -days 365 -x509 \
-            -subj "/C=NA/ST=NA/L=NA/O=host_uuid${i}/OU=${i}/CN=concord${k}" -out $certDir/node.cert
+      openssl req -new -key $certDir/pk.pem -nodes -days 365 -x509 \
+         -subj "/C=NA/ST=NA/L=NA/O=host_uuid${i}/OU=${i}/CN=node${i}" -out $certDir/node.cert
 
-         openssl enc -base64 -aes-256-cbc -e -in $certDir/pk.pem -K ${KEY} -iv ${IV}  \
-               -p -out $certDir/pk.pem.enc 2>/dev/null
-
-      elif [[ $i == 39 || $i == 40 ]]; then   
-      # These are two principal ids of clientservice1 (39) and clientservice2 (40)
-         openssl ecparam -name secp384r1 -genkey -noout -out $certDir/pk.pem
-
-         openssl req -new -key $certDir/pk.pem -nodes -days 365 -x509 \
-            -subj "/C=NA/ST=NA/L=NA/O=clientservice${start_c}/OU=${i}/CN=node${i}" -out $certDir/node.cert
-
-         openssl enc -base64 -aes-256-cbc -e -in $certDir/pk.pem -K ${KEY} -iv ${IV}  \
-               -p -out $certDir/pk.pem.enc 2>/dev/null
-
-         (( start_c=start_c+1 ))
-      else 
-         openssl ecparam -name secp384r1 -genkey -noout -out $certDir/pk.pem
-
-         openssl req -new -key $certDir/pk.pem -nodes -days 365 -x509 \
-            -subj "/C=NA/ST=NA/L=NA/O=host_uuid${i}/OU=${i}/CN=node${i}" -out $certDir/node.cert
-
-         openssl enc -base64 -aes-256-cbc -e -in $certDir/pk.pem -K ${KEY} -iv ${IV}  \
-               -p -out $certDir/pk.pem.enc 2>/dev/null
-
-      fi
+      openssl enc -base64 -aes-256-cbc -e -in $certDir/pk.pem -K ${KEY} -iv ${IV}  \
+            -p -out $certDir/pk.pem.enc 2>/dev/null
       (( i=i+1 ))
    done
-   # Create certs for trutil
-    echo "processing client for trutil"
-    clientDir=$dir/"trutil"
-    mkdir -p $clientDir
-
-    openssl ecparam -name secp384r1 -genkey -noout -out $clientDir/pk.pem
-
-    openssl req -new -key $clientDir/pk.pem -nodes -days 36500 -x509 \
-        -subj "/C=NA/ST=NA/L=NA/O=trutil/OU=trutil/CN=trutil" -out $clientDir/node.cert
-
-    openssl enc -base64 -aes-256-cbc -e -in  $clientDir/pk.pem -K ${KEY} -iv ${IV}  \
-        -p -out $clientDir/pk.pem.enc 2>/dev/null
 else 
    dir=$2
    if [ -z "$dir" ]; then

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -350,7 +350,11 @@ class SkvbcReconfigurationTest(ApolloTest):
     def collect_client_certificates(self, bft_network, targets):
         certs = {}
         for t in targets:
-            client_cert_path = os.path.join(bft_network.certdir, str(t), str(bft_network.cre_id),"client", "client.cert")
+            client_cert_path = os.path.join(bft_network.certdir, str(t), str(bft_network.cre_id))
+            if bft_network.use_unified_certs:
+                client_cert_path = os.path.join(client_cert_path, "node.cert")
+            else:
+                client_cert_path = os.path.join(client_cert_path, "client", "client.cert")
             with open(client_cert_path) as orig_cert:
                 orig_cert_text = orig_cert.read()
                 certs[t] = orig_cert_text
@@ -365,7 +369,11 @@ class SkvbcReconfigurationTest(ApolloTest):
             certs_in_effected = certs
         await self.run_client_ke_command(bft_network, True)
         with trio.fail_after(60):
-            client_cert_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id),"client", "client.cert")
+            client_cert_path = os.path.join(bft_network.certdir, str(bft_network.cre_id), str(bft_network.cre_id))
+            if bft_network.use_unified_certs:
+                client_cert_path = os.path.join(client_cert_path, "node.cert")
+            else:
+                client_cert_path = os.path.join(client_cert_path, "client", "client.cert")
             succ = False
             while not succ:
                 succ = True
@@ -552,11 +560,20 @@ class SkvbcReconfigurationTest(ApolloTest):
             reps_data[rep] = {}
             for r in replicas:
                 val = []
-                cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "server", "server.cert")
+                cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r))
+                if bft_network.use_unified_certs:
+                    cert_path = os.path.join(cert_path, "node.cert")
+                else:
+                    cert_path = os.path.join(cert_path, "server", "server.cert")
+
                 with open(cert_path) as orig_key:
                     cert_text = orig_key.readlines()
                     val += [cert_text]
-                cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "client", "client.cert")
+                cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r))
+                if bft_network.use_unified_certs:
+                    cert_path = os.path.join(cert_path, "node.cert")
+                else:
+                    cert_path = os.path.join(cert_path, "client", "client.cert")
                 with open(cert_path) as orig_key:
                     cert_text = orig_key.readlines()
                     val += [cert_text]
@@ -576,14 +593,22 @@ class SkvbcReconfigurationTest(ApolloTest):
                 succ = True
                 for rep in affected_replicas:
                     for r in replicas:
-                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "server", "server.cert")
+                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r))
+                        if bft_network.use_unified_certs:
+                            cert_path = os.path.join(cert_path, "node.cert")
+                        else:
+                            cert_path = os.path.join(cert_path, "server", "server.cert")
                         with open(cert_path) as orig_key:
                             cert_text = orig_key.readlines()
                             diff = difflib.unified_diff(reps_data[rep][r][0], cert_text, fromfile="new", tofile="old", lineterm='')
                             lines = sum(1 for l in diff)
                             if lines > 0:
                                 continue
-                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r), "client", "client.cert")
+                        cert_path = os.path.join(bft_network.certdir + "/" + str(rep), str(r))
+                        if bft_network.use_unified_certs:
+                            cert_path = os.path.join(cert_path, "node.cert")
+                        else:
+                            cert_path = os.path.join(cert_path, "client", "client.cert")
                         with open(cert_path) as orig_key:
                             cert_text = orig_key.readlines()
                             diff = difflib.unified_diff(reps_data[rep][r][1], cert_text, fromfile="new", tofile="old", lineterm='')

--- a/tests/config/itest_comm_config.hpp
+++ b/tests/config/itest_comm_config.hpp
@@ -52,6 +52,7 @@ class ITestCommConfig {
                                                            uint16_t& num_of_clients,
                                                            uint16_t& num_of_replicas,
                                                            const std::string& config_file_name,
+                                                           bool use_unified_certs,
                                                            const std::string& cert_root_path) = 0;
 
  protected:

--- a/tests/config/test_comm_config.cpp
+++ b/tests/config/test_comm_config.cpp
@@ -178,6 +178,7 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
                                              uint16_t& num_of_clients,
                                              uint16_t& num_of_replicas,
                                              const std::string& config_file_name,
+                                             bool use_unified_certs,
                                              const std::string& cert_root_path) {
   string ip;
   uint16_t port;
@@ -200,7 +201,7 @@ TlsTcpConfig TestCommConfig::GetTlsTCPConfig(bool is_replica,
                       id,
                       cert_root_path,
                       "TLS_AES_256_GCM_SHA384",
-                      false,
+                      use_unified_certs,
                       nullptr,
                       secretData);
   return retVal;

--- a/tests/config/test_comm_config.hpp
+++ b/tests/config/test_comm_config.hpp
@@ -41,6 +41,7 @@ class TestCommConfig : public ITestCommConfig {
                                                    uint16_t& num_of_clients,
                                                    uint16_t& num_of_replicas,
                                                    const std::string& config_file_name,
+                                                   bool use_unified_certs = false,
                                                    const std::string& cert_root_path = "certs") override;
 
  private:

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -51,6 +51,7 @@ creParams setupCreParams(int argc, char** argv) {
                                         {"cert-folder", optional_argument, 0, 'k'},
                                         {"txn-signing-key-path", optional_argument, 0, 't'},
                                         {"interval-timeout", optional_argument, 0, 'o'},
+                                        {"use-unified-certs", optional_argument, 0, 'U'},
                                         {0, 0, 0, 0}};
   creParams cre_param;
   cre_param.replicasKeysFolder = "./replicas_rsa_keys";
@@ -58,7 +59,7 @@ creParams setupCreParams(int argc, char** argv) {
   int o = 0;
   int optionIndex = 0;
   LOG_INFO(GL, "Command line options:");
-  while ((o = getopt_long(argc, argv, "i:f:c:r:n:k:t:o:", longOptions, &optionIndex)) != -1) {
+  while ((o = getopt_long(argc, argv, "i:f:c:r:n:k:t:o:U:", longOptions, &optionIndex)) != -1) {
     switch (o) {
       case 'i': {
         client_config.id = ClientId{concord::util::to<uint16_t>(optarg)};
@@ -96,6 +97,11 @@ creParams setupCreParams(int argc, char** argv) {
         cre_param.certFolder = optarg;
       } break;
 
+      case 'U': {
+        bool use_unified_certs = concord::util::to<bool>(std::string(optarg));
+        client_config.use_unified_certs = use_unified_certs;
+      } break;
+
       case '?': {
         throw std::runtime_error("invalid arguments");
       } break;
@@ -120,8 +126,8 @@ ICommunication* createCommunication(const ClientConfig& cc,
 #ifdef USE_COMM_PLAIN_TCP
   PlainTcpConfig conf = testCommConfig.GetTCPConfig(false, cc.id.val, clients, numOfReplicas, commFileName);
 #elif USE_COMM_TLS_TCP
-  TlsTcpConfig conf =
-      testCommConfig.GetTlsTCPConfig(false, cc.id.val, clients, numOfReplicas, commFileName, certFolder);
+  TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(
+      false, cc.id.val, clients, numOfReplicas, commFileName, cc.use_unified_certs, certFolder);
   if (conf.secretData_.has_value()) {
     sm = std::make_shared<concord::secretsmanager::SecretsManagerEnc>(conf.secretData_.value());
     enc = true;
@@ -254,7 +260,7 @@ int main(int argc, char** argv) {
       enc,
       bft_clients,
       creParams.bftConfig.id.val,
-      false,
+      creParams.bftConfig.use_unified_certs,
       sm_));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientMasterKeyExchangeHandler>(
       creParams.CreConfig.id_,

--- a/tests/simpleTest/simple_test_replica.hpp
+++ b/tests/simpleTest/simple_test_replica.hpp
@@ -250,7 +250,7 @@ class SimpleTestReplica {
         testCommConfig.GetTCPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);
 #elif USE_COMM_TLS_TCP
     TlsTcpConfig conf =
-        testCommConfig.GetTlsTCPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);
+        testCommConfig.GetTlsTCPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName, false);
 #else
     PlainUdpConfig conf =
         testCommConfig.GetUDPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);

--- a/tests/simpleTest/src/simple_test_client.cpp
+++ b/tests/simpleTest/src/simple_test_client.cpp
@@ -31,7 +31,8 @@ bool SimpleTestClient::run() {
 #ifdef USE_COMM_PLAIN_TCP
   PlainTcpConfig conf = testCommConfig.GetTCPConfig(false, id, cp.numOfClients, cp.numOfReplicas, cp.configFileName);
 #elif USE_COMM_TLS_TCP
-  TlsTcpConfig conf = testCommConfig.GetTlsTCPConfig(false, id, cp.numOfClients, cp.numOfReplicas, cp.configFileName);
+  TlsTcpConfig conf =
+      testCommConfig.GetTlsTCPConfig(false, id, cp.numOfClients, cp.numOfReplicas, cp.configFileName, false);
 #else
   PlainUdpConfig conf = testCommConfig.GetUDPConfig(false, id, cp.numOfClients, cp.numOfReplicas, cp.configFileName);
 #endif

--- a/tests/simpleTest/src/simple_test_replica.cpp
+++ b/tests/simpleTest/src/simple_test_replica.cpp
@@ -113,7 +113,7 @@ SimpleTestReplica *SimpleTestReplica::create_replica(ISimpleTestReplicaBehavior 
       testCommConfig.GetTCPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);
 #elif USE_COMM_TLS_TCP
   TlsTcpConfig conf =
-      testCommConfig.GetTlsTCPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);
+      testCommConfig.GetTlsTCPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName, false);
 #else
   PlainUdpConfig conf =
       testCommConfig.GetUDPConfig(true, rp.replicaId, rp.numOfClients, rp.numOfReplicas, rp.configFileName);

--- a/util/pyclient/bft_config.py
+++ b/util/pyclient/bft_config.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 
 Config = namedtuple('Config', ['id', 'f', 'c', 'max_msg_size', 'req_timeout_milli',
                                'retry_timeout_milli', "certs_path", "txn_signing_keys_path",
-                               "principals_to_participant_map"])
+                               "principals_to_participant_map", "use_unified_certs"])
 
 Replica = namedtuple('Replica', ['id', 'ip', 'port', 'metrics_port'])
 


### PR DESCRIPTION
* **Problem Overview**  
  Enable multiplex and unified_certificates by default
  Apollo support to enable unified certificates per test case  
* **Testing Done** 
 Apollo CI passed locally https://github.com/situ-s/concord-bft/actions/runs/2740259301
 Concord CI testing in progress
 System testing is done by enabling lower end workloads