### PR TITLE
Fix for deleted dbCheckpoints when scale with --restart executed

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -143,6 +143,7 @@ class DbCheckpointManager {
   // checkpoint_id = 0 indicates rocksdb size
   // only used for apollo test
   std::map<uint64_t, uint64_t> getDbSize();
+  void setIsMetadataErased(bool isMetadataErased) { isMetadataErased_ = isMetadataErased; }
 
  private:
   logging::Logger getLogger() {
@@ -203,6 +204,7 @@ class DbCheckpointManager {
   std::function<SeqNum()> getLastStableSeqNumCb_;
   std::vector<std::function<void(SeqNum)>> onDbCheckpointCreated_;
   std::string dbCheckPointDirPath_;
+  bool isMetadataErased_ = false;
   concordMetrics::Component metrics_;
   concordMetrics::GaugeHandle maxDbCheckpointCreationTimeMsec_;
   concordMetrics::GaugeHandle lastDbCheckpointSizeInMb_;

--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -25,6 +25,7 @@
 #include "ReservedPagesClient.hpp"
 #include "bftengine/EpochManager.hpp"
 #include "bcstatetransfer/AsyncStateTransferCRE.hpp"
+#include "DbCheckpointManager.hpp"
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -194,6 +195,8 @@ IReplica::IReplicaPtr IReplica::createNewReplica(const ReplicaConfig &replicaCon
     }
     LOG_INFO(GL, "erasedMetaData flag = " << erasedMetaData);
     if (erasedMetaData) {
+      // Here when metadata is erased, we need to update DBCheckpointManager.
+      DbCheckpointManager::instance().setIsMetadataErased(true);
       metadataStoragePtr->eraseData();
       isNewStorage = metadataStoragePtr->initMaxSizeOfObjects(objectDescriptors, numOfObjects);
       auto secFileDir = ReplicaConfig::instance().getkeyViewFilePath();


### PR DESCRIPTION
Fix for deleted dbCheckpoints when scale command executed with restart flag

* **Problem Overview**  
  All created db checkpoints deleted from file system when scale with --restart executed.
* **Testing Done**  
  Apollo test is added and same has been tested.
  Also performed maestro multiday run which results no impact on performance.
