### PR TITLE
Fix replica restart command handler

### DIFF
--- a/reconfiguration/src/reconfiguration_handler.cpp
+++ b/reconfiguration/src/reconfiguration_handler.cpp
@@ -149,7 +149,7 @@ void ReconfigurationHandler::handleWedgeCommands(bool bft_support,
           if (wedgePt == s) restart_replicas_cb();
         });
       } else {
-        bftEngine::IControlHandler::instance()->addOnStableCheckpointCallBack(restart_replicas_cb);
+        bftEngine::IControlHandler::instance()->addOnSuperStableCheckpointCallBack(restart_replicas_cb);
       }
     }
     if (blockNewConnections) {


### PR DESCRIPTION
* **Problem Overview**  
Issue : On receiving the restart command, replicas should wait for stable sequence number if bft_support is false.
        But it was waiting for stable sequence number only. This was causing a timing issue where one of the replicas was not able to collect
        the stable sequence number as other replicas have already restarted.

Fix : Change callback to superstable sequence number

* **Testing Done**  
  Verified by running the test_restart_no_bft_with_restart_flag 100 times.

Signed-off-by: Kush Agrawal <kusha@vmware.com>


