### PR TITLE
Native build corrections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
+set(CMAKE_C_COMPILER "/usr/bin/clang")
 project(concord-bft VERSION 0.1.0.0 LANGUAGES CXX)
 
 #

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ when a backwards incompatible change is made.
 
 ## Install and Build (Ubuntu Linux 18.04)
 
-Concord-BFT supports two kinds of builds: native and docker.
+Concord-BFT supports two kinds of builds: native and docker. At present both builds are supported on Ubuntu Linux 18.04. 
 
 The docker build is **strongly recommended**.
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -14,22 +14,22 @@ WGET_FLAGS="--https-only"
 echo ca_certificate=/etc/ssl/certs/ca-certificates.crt > ~/.wgetrc
 
 # Install tools
-apt-get update && apt-get ${APT_GET_FLAGS} install \
+sudo apt-get update && sudo apt-get ${APT_GET_FLAGS} install \
     autoconf \
     automake \
     libtool \
     build-essential \
     ccache \
-    clang-9 \
-    clang-format-10 \
-    clang-tidy-10 \
+    clang \
+    clang-format \
+    clang-tidy \
     curl \
     gdb \
     gdbserver \
     git \
     iptables \
     less \
-    llvm-9 \
+    llvm \
     lzip \
     net-tools \
     parallel \
@@ -43,21 +43,13 @@ apt-get update && apt-get ${APT_GET_FLAGS} install \
     iproute2 \
     wget
 
-update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-9/bin/clang 100
-update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-9/bin/clang++ 100
-update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
-update-alternatives --install /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff-10 100
-update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-10 100
-update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/lib/llvm-9/bin/llvm-symbolizer 100
-update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/lib/llvm-9/bin/llvm-profdata 100
-update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/lib/llvm-9/bin/llvm-cov 100
 
 # Install 3rd parties
-apt-get ${APT_GET_FLAGS} install \
-    libboost-filesystem1.65-dev \
-    libboost-system1.65-dev \
-    libboost-program-options1.65-dev \
-    libboost1.65-dev \
+sudo apt-get ${APT_GET_FLAGS} install \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libboost-program-options-dev \
+    libboost-dev \
     libbz2-dev \
     liblz4-dev \
     libs3-dev \


### PR DESCRIPTION
* **Problem Overview**  
  The native build was failing due to incorrect commands in the install_deps.sh. Additionally, the CMakeLists.txt used GCC for compiling  the code and not Clang. Both of these have been corrected. I have also updated the README.txt to reflect that the builds are supported on Ubuntu 18.04. 

* **Testing Done**  
Manual testing was done.

[install_deps.log.txt](https://github.com/vmware/concord-bft/files/9215277/install_deps.log.txt)

[make.log.txt](https://github.com/vmware/concord-bft/files/9215313/make.log.txt)

[make_test.log.txt](https://github.com/vmware/concord-bft/files/9215316/make_test.log.txt)

Failing tests are not compatible with native build execution style; i.e., they assume that docker is being used for running the tests and paths used in the tests are inconsistent with those in the native build.
