### PR TITLE
Save and load genesis block id from storage

### DIFF
--- a/kvbc/src/v4blockchain/detail/latest_keys.cpp
+++ b/kvbc/src/v4blockchain/detail/latest_keys.cpp
@@ -488,9 +488,9 @@ bool LatestKeys::LKCompactionFilter::Filter(int /*level*/,
   auto ts_slice = ::rocksdb::Slice(val.data() + val.size() - VERSION_SIZE, VERSION_SIZE);
   auto key_version = concordUtils::fromBigEndianBuffer<uint64_t>(ts_slice.data());
   if (key_version >= concord::kvbc::v4blockchain::detail::Blockchain::global_genesis_block_id) return false;
-  LOG_INFO(V4_BLOCK_LOG,
-           "Filtering key with version " << key_version << " genesis is "
-                                         << concord::kvbc::v4blockchain::detail::Blockchain::global_genesis_block_id);
+  LOG_DEBUG(V4_BLOCK_LOG,
+            "Filtering key with version " << key_version << " genesis is "
+                                          << concord::kvbc::v4blockchain::detail::Blockchain::global_genesis_block_id);
   return true;
 }
 

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -40,9 +40,6 @@ KeyValueBlockchain::KeyValueBlockchain(
           "numOfBlocksDeleted", block_chain_.getGenesisBlockId() > 0 ? (block_chain_.getGenesisBlockId() - 1) : 0)},
       deleted_keys_{v4_metrics_comp_.RegisterCounter("numOfKeysDeleted", 0)},
       immutables_reads_{v4_metrics_comp_.RegisterCounter("numOfimmutableReads", 0)} {
-  if (native_client_->createColumnFamilyIfNotExisting(v4blockchain::detail::MISC_CF)) {
-    LOG_INFO(V4_BLOCK_LOG, "Created [" << v4blockchain::detail::MISC_CF << "] column family");
-  }
   if (!link_st_chain) return;
   // Mark version of blockchain
   native_client_->put(v4blockchain::detail::MISC_CF, kvbc::keyTypes::blockchain_version, kvbc::V4Version());


### PR DESCRIPTION
* **Problem Overview**  
 After pruning, finding the genesis block using RocksDB iterators took a significant duration since RocksDB iterates over the whole range, which can be millions of blocks, to find the first key that is not deleted.
The fix is that when pruning is performed, save the genesis id in storage, and on load, first look for the key, if it exists, load the genesis from it.

* **Testing Done**  
  Unit test that covers all paths that set and load the genesis
