### PR TITLE
prevent unwedge on an unewedged system

### DIFF
--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -988,7 +988,7 @@ bool ReconfigurationHandler::handle(const messages::UnwedgeCommand& cmd,
                                     uint32_t,
                                     const std::optional<bftEngine::Timestamp>& ts,
                                     concord::messages::ReconfigurationResponse&) {
-  if (!bftEngine::ControlStateManager::instance().getCheckpointToStopAt().has_value()) {
+  if (!bftEngine::ControlStateManager::instance().isWedged()) {
     LOG_INFO(getLogger(), "replica is already unwedge");
     return true;
   }


### PR DESCRIPTION
* **Problem Overview**  
  If we unwedge an already unwedged (or never wedged) system, we may end up with an inconsistent state
* **Testing Done**  
  CI
