### PR TITLE
Reducing the severity of log message in CRE

### DIFF
--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -80,7 +80,7 @@ void ReplicaForStateTransfer::start() {
             auto latestHandledUpdate = cre_->getLatestKnownUpdateBlock();
             auto latestReconfUpdates = pbc->getStateUpdate(succ);
             if (!succ) {
-              LOG_ERROR(GL, "unable to get the latest reconfiguration updates");
+              LOG_WARN(GL, "unable to get the latest reconfiguration updates");
             }
             for (const auto &update : latestReconfUpdates) {
               if (update.blockid > latestHandledUpdate) {


### PR DESCRIPTION

* **Problem Overview**  
  A replica in state transfer continuously polls for reconfiguration
update from other non-ST replicas. If there is a loss of quorum due to
view change or any other reason, state transfer cre client won't be able
to get the updates from replica. We are reducing severity of this
message as this is a side effect of a more critical problem i.e. loss of
system's liveness.
* **Testing Done**  
  GHA test
