### PR TITLE
Thin replica improve metrics and logs

### DIFF
--- a/client/clientservice/include/client/clientservice/event_service.hpp
+++ b/client/clientservice/include/client/clientservice/event_service.hpp
@@ -23,8 +23,8 @@ struct EventServiceMetrics {
   EventServiceMetrics()
       : metrics_component_{"EventService", std::make_shared<concordMetrics::Aggregator>()},
         total_num_writes{metrics_component_.RegisterCounter("total_num_writes", 0)},
-        update_processing_dur{metrics_component_.RegisterGauge("update_processing_dur", 0)},
-        write_dur{metrics_component_.RegisterGauge("write_dur", 0)} {
+        update_processing_duration{metrics_component_.RegisterGauge("update_processing_duration", 0)},
+        write_duration{metrics_component_.RegisterGauge("write_duration", 0)} {
     metrics_component_.Register();
   }
 
@@ -42,9 +42,9 @@ struct EventServiceMetrics {
   concordMetrics::CounterHandle total_num_writes;
   // time taken to process an update (time between when an update is received by the event service from the update queue
   // until it is written to the stream)
-  concordMetrics::GaugeHandle update_processing_dur;
+  concordMetrics::GaugeHandle update_processing_duration;
   // time taken to write an update to the gRPC stream
-  concordMetrics::GaugeHandle write_dur;
+  concordMetrics::GaugeHandle write_duration;
 };
 
 class EventServiceImpl final : public vmware::concord::client::event::v1::EventService::Service {

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -116,7 +116,7 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
       // update write duration metric
       end_processing = std::chrono::steady_clock::now();
       auto duration_write = std::chrono::duration_cast<std::chrono::microseconds>(end_processing - start_write);
-      metrics_.write_dur.Get().Set(duration_write.count());
+      metrics_.write_duration.Get().Set(duration_write.count());
     } else if (std::holds_alternative<cc::Update>(*update)) {
       auto& legacy_event_in = std::get<cc::Update>(*update);
       Events proto_events;
@@ -139,14 +139,14 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
       // update write duration metric
       end_processing = std::chrono::steady_clock::now();
       auto duration_write = std::chrono::duration_cast<std::chrono::microseconds>(end_processing - start_write);
-      metrics_.write_dur.Get().Set(duration_write.count());
+      metrics_.write_duration.Get().Set(duration_write.count());
     } else {
       LOG_ERROR(logger_, "Got unexpected update type from TRC. This should never happen!");
     }
     // update processing duration metric
-    auto update_processing_dur =
+    auto update_processing_duration =
         std::chrono::duration_cast<std::chrono::microseconds>(end_processing - start_processing);
-    metrics_.update_processing_dur.Get().Set(update_processing_dur.count());
+    metrics_.update_processing_duration.Get().Set(update_processing_duration.count());
 
     // update metrics aggregator every second
     auto metrics_aggregator_dur =

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -11,6 +11,8 @@
 
 #include <chrono>
 #include <iostream>
+#include <chrono>
+
 #include <opentracing/tracer.h>
 
 #include "client/clientservice/event_service.hpp"
@@ -30,8 +32,11 @@ using concord::client::concordclient::UpdateNotFound;
 using concord::client::concordclient::OutOfRangeSubscriptionRequest;
 using concord::client::concordclient::SubscriptionExists;
 using concord::client::concordclient::InternalError;
+using std::chrono::steady_clock;
+using std::chrono::duration_cast;
 
 using namespace std::chrono_literals;
+using namespace std;
 
 namespace cc = concord::client::concordclient;
 
@@ -64,7 +69,7 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
 
   // TODO: Return UNAVAILABLE as documented in event.proto if ConcordClient is unhealthy
   auto status = grpc::Status::OK;
-  std::chrono::steady_clock::time_point start_aggregator_timer = std::chrono::steady_clock::now();
+  steady_clock::time_point start_aggregator_timer = steady_clock::now();
   while (!context->IsCancelled()) {
     SubscribeResponse response;
     std::unique_ptr<EventVariant> update;
@@ -96,7 +101,7 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
     if (not update) {
       continue;
     }
-    std::chrono::steady_clock::time_point start_processing = std::chrono::steady_clock::now(), end_processing;
+    steady_clock::time_point start_processing = steady_clock::now(), end_processing;
 
     if (std::holds_alternative<cc::EventGroup>(*update)) {
       auto& event_group_in = std::get<cc::EventGroup>(*update);
@@ -110,12 +115,12 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
                                                     event_group_in.trace_context.end()};
 
       *response.mutable_event_group() = proto_event_group;
-      std::chrono::steady_clock::time_point start_write = std::chrono::steady_clock::now();
+      steady_clock::time_point start_write = steady_clock::now();
       stream->Write(response);
       metrics_.total_num_writes++;
       // update write duration metric
-      end_processing = std::chrono::steady_clock::now();
-      auto duration_write = std::chrono::duration_cast<std::chrono::microseconds>(end_processing - start_write);
+      end_processing = steady_clock::now();
+      auto duration_write = duration_cast<chrono::microseconds>(end_processing - start_write);
       metrics_.write_duration.Get().Set(duration_write.count());
     } else if (std::holds_alternative<cc::Update>(*update)) {
       auto& legacy_event_in = std::get<cc::Update>(*update);
@@ -131,29 +136,27 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
       // TODO: Set trace context
 
       *response.mutable_events() = proto_events;
-      std::chrono::steady_clock::time_point start_write = std::chrono::steady_clock::now();
+      steady_clock::time_point start_write = steady_clock::now();
       stream->Write(response);
       const auto block_id = legacy_event_in.block_id;
       LOG_DEBUG(logger_, "Done write subscribe response:" << KVLOG(block_id));
       metrics_.total_num_writes++;
       // update write duration metric
-      end_processing = std::chrono::steady_clock::now();
-      auto duration_write = std::chrono::duration_cast<std::chrono::microseconds>(end_processing - start_write);
+      end_processing = steady_clock::now();
+      auto duration_write = duration_cast<chrono::microseconds>(end_processing - start_write);
       metrics_.write_duration.Get().Set(duration_write.count());
     } else {
       LOG_ERROR(logger_, "Got unexpected update type from TRC. This should never happen!");
     }
     // update processing duration metric
-    auto update_processing_duration =
-        std::chrono::duration_cast<std::chrono::microseconds>(end_processing - start_processing);
+    auto update_processing_duration = duration_cast<chrono::microseconds>(end_processing - start_processing);
     metrics_.update_processing_duration.Get().Set(update_processing_duration.count());
 
     // update metrics aggregator every second
-    auto metrics_aggregator_dur =
-        std::chrono::duration_cast<std::chrono::seconds>(end_processing - start_aggregator_timer);
-    if (metrics_aggregator_dur >= std::chrono::seconds(1)) {
+    auto metrics_aggregator_dur = duration_cast<chrono::seconds>(end_processing - start_aggregator_timer);
+    if (metrics_aggregator_dur >= chrono::seconds(1)) {
       metrics_.updateAggregator();
-      start_aggregator_timer = std::chrono::steady_clock::now();
+      start_aggregator_timer = steady_clock::now();
     }
   }
 

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -17,6 +17,9 @@
 
 #include "client/clientservice/event_service.hpp"
 #include "client/concordclient/concord_client.hpp"
+#include "throughput.hpp"
+#include "diagnostics.h"
+#include "performance_handler.h"
 
 using grpc::Status;
 using grpc::ServerContext;
@@ -32,8 +35,8 @@ using concord::client::concordclient::UpdateNotFound;
 using concord::client::concordclient::OutOfRangeSubscriptionRequest;
 using concord::client::concordclient::SubscriptionExists;
 using concord::client::concordclient::InternalError;
-using std::chrono::steady_clock;
-using std::chrono::duration_cast;
+using concord::diagnostics::RegistrarSingleton;
+using concord::util::DurationTracker;
 
 using namespace std::chrono_literals;
 using namespace std;
@@ -45,19 +48,20 @@ namespace concord::client::clientservice {
 Status EventServiceImpl::Subscribe(ServerContext* context,
                                    const SubscribeRequest* proto_request,
                                    ServerWriter<SubscribeResponse>* stream) {
-  LOG_INFO(logger_, "");
   cc::SubscribeRequest request;
+  static const auto historgram_log_duration_microsec{std::chrono::microseconds(300s).count()};
+  static const auto metrics_update_duration_microsec{std::chrono::microseconds(1s).count()};
 
   if (proto_request->has_event_groups()) {
     cc::EventGroupRequest eg_request;
     eg_request.event_group_id = proto_request->event_groups().event_group_id();
     request.request = eg_request;
-
+    LOG_INFO(logger_, KVLOG(eg_request.event_group_id));
   } else if (proto_request->has_events()) {
     cc::LegacyEventRequest ev_request;
     ev_request.block_id = proto_request->events().block_id();
     request.request = ev_request;
-
+    LOG_INFO(logger_, KVLOG(ev_request.block_id));
   } else {
     // No other request type is possible; the gRPC server should catch this.
     ConcordAssert(false);
@@ -69,7 +73,8 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
 
   // TODO: Return UNAVAILABLE as documented in event.proto if ConcordClient is unhealthy
   auto status = grpc::Status::OK;
-  steady_clock::time_point start_aggregator_timer = steady_clock::now();
+  DurationTracker<chrono::microseconds> aggregator_dt("aggregator_dt", true);
+  DurationTracker<chrono::microseconds> histogram_snapshot_dt("histogram_snapshot_dt", true);
   while (!context->IsCancelled()) {
     SubscribeResponse response;
     std::unique_ptr<EventVariant> update;
@@ -101,64 +106,76 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
     if (not update) {
       continue;
     }
-    steady_clock::time_point start_processing = steady_clock::now(), end_processing;
 
-    if (std::holds_alternative<cc::EventGroup>(*update)) {
-      auto& event_group_in = std::get<cc::EventGroup>(*update);
-      EventGroup proto_event_group;
-      proto_event_group.set_id(event_group_in.id);
-      for (auto& event : event_group_in.events) {
-        proto_event_group.add_events(std::move(event));
+    {  // scoped timer 1 start
+      concord::diagnostics::TimeRecorder processing_duration_scoped_timer(*histograms_.processing_duration);
+      DurationTracker<chrono::microseconds> processing_dt("processing_dt", true);
+      if (std::holds_alternative<cc::EventGroup>(*update)) {
+        auto& event_group_in = std::get<cc::EventGroup>(*update);
+        EventGroup proto_event_group;
+        proto_event_group.set_id(event_group_in.id);
+        for (auto& event : event_group_in.events) {
+          proto_event_group.add_events(std::move(event));
+        }
+        *proto_event_group.mutable_record_time() = event_group_in.record_time;
+        *proto_event_group.mutable_trace_context() = {event_group_in.trace_context.begin(),
+                                                      event_group_in.trace_context.end()};
+        *response.mutable_event_group() = proto_event_group;
+        DurationTracker<chrono::microseconds> write_dt("write_dt", true);
+        {  // for scoped time
+          concord::diagnostics::TimeRecorder write_duration_scoped_timer(*histograms_.write_duration);
+          stream->Write(response);
+        }
+        const auto total_duration = write_dt.totalDuration();
+        metrics_.write_duration.Get().Set(total_duration);
+        const auto event_group_id = event_group_in.id;
+        LOG_DEBUG(logger_, "Done write subscribe response:" << KVLOG(event_group_id, total_duration));
+        metrics_.total_num_writes++;
+      } else if (std::holds_alternative<cc::Update>(*update)) {
+        auto& legacy_event_in = std::get<cc::Update>(*update);
+        Events proto_events;
+        proto_events.set_block_id(legacy_event_in.block_id);
+        for (auto& [key, value] : legacy_event_in.kv_pairs) {
+          Event proto_event;
+          *proto_event.mutable_event_key() = std::move(key);
+          *proto_event.mutable_event_value() = std::move(value);
+          *proto_events.add_events() = proto_event;
+        }
+        proto_events.set_correlation_id(legacy_event_in.correlation_id_);
+        // TODO: Set trace context
+
+        *response.mutable_events() = proto_events;
+        DurationTracker<chrono::microseconds> write_dt("write_dt", true);
+        {  // for scoped time
+          concord::diagnostics::TimeRecorder write_duration_scoped_timer(*histograms_.write_duration);
+          stream->Write(response);
+        }
+        const auto total_duration = write_dt.totalDuration();
+        metrics_.write_duration.Get().Set(total_duration);
+        const auto block_id = legacy_event_in.block_id;
+        LOG_DEBUG(logger_, "Done write subscribe response:" << KVLOG(block_id, total_duration));
+        metrics_.total_num_writes++;
+      } else {
+        LOG_ERROR(logger_, "Got unexpected update type from TRC. This should never happen!");
       }
-      *proto_event_group.mutable_record_time() = event_group_in.record_time;
-      *proto_event_group.mutable_trace_context() = {event_group_in.trace_context.begin(),
-                                                    event_group_in.trace_context.end()};
-
-      *response.mutable_event_group() = proto_event_group;
-      steady_clock::time_point start_write = steady_clock::now();
-      stream->Write(response);
-      metrics_.total_num_writes++;
-      // update write duration metric
-      end_processing = steady_clock::now();
-      auto duration_write = duration_cast<chrono::microseconds>(end_processing - start_write);
-      metrics_.write_duration.Get().Set(duration_write.count());
-    } else if (std::holds_alternative<cc::Update>(*update)) {
-      auto& legacy_event_in = std::get<cc::Update>(*update);
-      Events proto_events;
-      proto_events.set_block_id(legacy_event_in.block_id);
-      for (auto& [key, value] : legacy_event_in.kv_pairs) {
-        Event proto_event;
-        *proto_event.mutable_event_key() = std::move(key);
-        *proto_event.mutable_event_value() = std::move(value);
-        *proto_events.add_events() = proto_event;
-      }
-      proto_events.set_correlation_id(legacy_event_in.correlation_id_);
-      // TODO: Set trace context
-
-      *response.mutable_events() = proto_events;
-      steady_clock::time_point start_write = steady_clock::now();
-      stream->Write(response);
-      const auto block_id = legacy_event_in.block_id;
-      LOG_DEBUG(logger_, "Done write subscribe response:" << KVLOG(block_id));
-      metrics_.total_num_writes++;
-      // update write duration metric
-      end_processing = steady_clock::now();
-      auto duration_write = duration_cast<chrono::microseconds>(end_processing - start_write);
-      metrics_.write_duration.Get().Set(duration_write.count());
-    } else {
-      LOG_ERROR(logger_, "Got unexpected update type from TRC. This should never happen!");
-    }
-    // update processing duration metric
-    auto update_processing_duration = duration_cast<chrono::microseconds>(end_processing - start_processing);
-    metrics_.update_processing_duration.Get().Set(update_processing_duration.count());
+      // update processing duration metric
+      metrics_.update_processing_duration.Get().Set(processing_dt.totalDuration());
+    }  // scoped timer 1 end
 
     // update metrics aggregator every second
-    auto metrics_aggregator_dur = duration_cast<chrono::seconds>(end_processing - start_aggregator_timer);
-    if (metrics_aggregator_dur >= chrono::seconds(1)) {
+    if (aggregator_dt.totalDuration() >= metrics_update_duration_microsec) {
       metrics_.updateAggregator();
-      start_aggregator_timer = steady_clock::now();
+      aggregator_dt.start(true);
     }
-  }
+
+    // write report to log once in 5 minutes
+    if (histogram_snapshot_dt.totalDuration() >= historgram_log_duration_microsec) {
+      auto& registrar = RegistrarSingleton::getInstance();
+      registrar.perf.snapshot("clientservice_event_service");
+      LOG_INFO(logger_, registrar.perf.toString(registrar.perf.get("clientservice_event_service")));
+      histogram_snapshot_dt.start(true);
+    }
+  }  //  while (!context->IsCancelled())
 
   client_->unsubscribe();
   return status;

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -192,6 +192,13 @@ class ConcordClient {
   // TODO: Allow multiple subscriptions
   std::atomic_bool active_subscription_{false};
 
+  concordMetrics::Component metrics_component_;
+  struct Metrics {
+    concordMetrics::GaugeHandle principal_id;
+    concordMetrics::GaugeHandle participant_id_decimal_sum;  // used to represent the participant_id as a number
+    concordMetrics::StatusHandle participant_id;
+  } metrics_;
+
   std::vector<std::shared_ptr<::client::concordclient::GrpcConnection>> grpc_connections_;
   std::unique_ptr<::client::thin_replica_client::ThinReplicaClient> trc_;
   std::unique_ptr<::client::replica_state_snapshot_client::ReplicaStateSnapshotClient> rss_;

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -187,7 +187,7 @@ class ConcordClient {
 
   logging::Logger logger_;
   const ConcordClientConfig& config_;
-  std::shared_ptr<concordMetrics::Aggregator> metrics_;
+  std::shared_ptr<concordMetrics::Aggregator> aggregator_;
 
   // TODO: Allow multiple subscriptions
   std::atomic_bool active_subscription_{false};

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -46,7 +46,7 @@ ConcordClient::ConcordClient(const ConcordClientConfig& config, std::shared_ptr<
       } {
   LOG_INFO(logger_, "");
   ConcordClientPoolConfig client_pool_config = createClientPoolStruct(config);
-  client_pool_ = std::make_unique<concord::concord_client_pool::ConcordClientPool>(client_pool_config, metrics_);
+  client_pool_ = std::make_unique<concord::concord_client_pool::ConcordClientPool>(client_pool_config, aggregator_);
   while (client_pool_->HealthStatus() == concord::concord_client_pool::PoolStatus::NotServing) {
     LOG_INFO(logger_, "Waiting for client pool to connect");
     std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -191,7 +191,7 @@ void ConcordClient::subscribe(const SubscribeRequest& sub_req,
 
   auto trc_config = std::make_unique<ThinReplicaClientConfig>(
       config_.subscribe_config.id, queue, config_.topology.f_val, grpc_connections_);
-  trc_ = std::make_unique<ThinReplicaClient>(std::move(trc_config), metrics_);
+  trc_ = std::make_unique<ThinReplicaClient>(std::move(trc_config), aggregator_);
 
   if (std::holds_alternative<EventGroupRequest>(sub_req.request)) {
     ::client::thin_replica_client::SubscribeRequest trc_request;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -52,7 +52,7 @@ ConcordClient::ConcordClient(const ConcordClientConfig& config, std::shared_ptr<
     std::this_thread::sleep_for(std::chrono::seconds(2));
   }
   createGrpcConnections();
-  
+
   int sum = std::accumulate(config_.subscribe_config.id.begin(), config_.subscribe_config.id.end(), 0);
   metrics_.participant_id_decimal_sum.Get().Set(sum);
   metrics_component_.UpdateAggregator();

--- a/client/thin-replica-client/include/client/thin-replica-client/grpc_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/grpc_connection.hpp
@@ -87,7 +87,10 @@ class GrpcConnection {
         client_id_(client_id),
         data_timeout_(std::chrono::seconds(data_operation_timeout_seconds)),
         hash_timeout_(std::chrono::seconds(hash_operation_timeout_seconds)),
-        snapshot_timeout_(std::chrono::seconds(snapshot_operation_timeout_seconds)) {}
+        snapshot_timeout_(std::chrono::seconds(snapshot_operation_timeout_seconds)) {
+    LOG_INFO(logger_,
+             KVLOG(data_operation_timeout_seconds, hash_operation_timeout_seconds, snapshot_operation_timeout_seconds));
+  }
 
   virtual ~GrpcConnection() { this->disconnect(); }
 

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -131,8 +131,9 @@ struct ThinReplicaClientMetrics {
         current_queue_size{metrics_component_.RegisterGauge("current_queue_size", 0)},
         last_verified_block_id{metrics_component_.RegisterGauge("last_verified_block_id", 0)},
         last_verified_event_group_id{metrics_component_.RegisterGauge("last_verified_event_group_id", 0)},
-        update_dur_us{metrics_component_.RegisterGauge("update_dur_us", 0)},
-        num_updates_processed{metrics_component_.RegisterCounter("num_updates_processed", 0)} {
+        update_duration_microsec{metrics_component_.RegisterGauge("update_duration_microsec", 0)},
+        num_updates_processed{metrics_component_.RegisterCounter("num_updates_processed", 0)},
+        num_events_processed{metrics_component_.RegisterGauge("num_events_processed", 0)} {
     metrics_component_.Register();
   }
 
@@ -161,12 +162,14 @@ struct ThinReplicaClientMetrics {
   // last_verified_*_id - block or event group ID of the latest update verified by TRC
   concordMetrics::GaugeHandle last_verified_block_id;
   concordMetrics::GaugeHandle last_verified_event_group_id;
-  // update_dur_us - duration of time (microseconds) between when an update is received by
+  // update_duration_microsec - duration of time (microseconds) between when an update is received by
   // the TRC, to when it is pushed to the update queue for consumption by the
   // application using TRC
-  concordMetrics::GaugeHandle update_dur_us;
-  // number of updates pushed by TRC to the update queue per second
+  concordMetrics::GaugeHandle update_duration_microsec;
+  // number of updates pushed by TRC to the update queue
   concordMetrics::CounterHandle num_updates_processed;
+  // number of events pushed by TRC to the update queue
+  concordMetrics::GaugeHandle num_events_processed;
 };
 
 struct SubscribeRequest {

--- a/client/thin-replica-client/src/grpc_connection.cpp
+++ b/client/thin-replica-client/src/grpc_connection.cpp
@@ -129,6 +129,7 @@ GrpcConnection::Result GrpcConnection::openDataStream(const SubscriptionRequest&
   });
   auto status = stream.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     data_context_->TryCancel();
     stream.wait();
     data_context_.reset();
@@ -158,6 +159,7 @@ void GrpcConnection::cancelDataStream() {
     return;
   }
   ConcordAssertNE(data_context_, nullptr);
+  LOG_WARN(logger_, KVLOG(address_, client_id_));
   data_context_->TryCancel();
   data_context_.reset();
   data_stream_.reset();
@@ -172,6 +174,7 @@ GrpcConnection::Result GrpcConnection::readData(Data* data) {
   auto result = async(launch::async, [this, data] { return data_stream_->Read(data); });
   auto status = result.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     data_context_->TryCancel();
     result.wait();
     data_context_.reset();
@@ -203,6 +206,7 @@ GrpcConnection::Result GrpcConnection::openStateStream(const ReadStateRequest& r
   });
   auto status = stream.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     state_context_->TryCancel();
     stream.wait();
     state_context_.reset();
@@ -231,6 +235,7 @@ void GrpcConnection::cancelStateStream() {
     return;
   }
   ConcordAssertNE(state_context_, nullptr);
+  LOG_WARN(logger_, KVLOG(address_, client_id_));
   state_context_->TryCancel();
   state_context_.reset();
   state_stream_.reset();
@@ -246,6 +251,7 @@ GrpcConnection::Result GrpcConnection::closeStateStream() {
   auto result = async(launch::async, [this] { return state_stream_->Finish(); });
   auto status = result.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     state_context_->TryCancel();
     result.wait();
     state_context_.reset();
@@ -277,6 +283,7 @@ GrpcConnection::Result GrpcConnection::readState(Data* data) {
   auto result = async(launch::async, [this, data] { return state_stream_->Read(data); });
   auto status = result.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     state_context_->TryCancel();
     result.wait();
     state_context_.reset();
@@ -300,6 +307,7 @@ GrpcConnection::Result GrpcConnection::readStateHash(const ReadStateHashRequest&
   });
   auto status = result.wait_for(hash_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     context.TryCancel();
     result.wait();
     return Result::kTimeout;
@@ -335,6 +343,7 @@ GrpcConnection::Result GrpcConnection::openHashStream(SubscriptionRequest& reque
   });
   auto status = stream.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     hash_context_->TryCancel();
     stream.wait();
     hash_context_.reset();
@@ -364,6 +373,7 @@ void GrpcConnection::cancelHashStream() {
     return;
   }
   ConcordAssertNE(hash_context_, nullptr);
+  LOG_WARN(logger_, KVLOG(address_, client_id_));
   hash_context_->TryCancel();
   hash_context_.reset();
   hash_stream_.reset();
@@ -378,6 +388,7 @@ GrpcConnection::Result GrpcConnection::readHash(Hash* hash) {
   auto result = async(launch::async, [this, hash] { return hash_stream_->Read(hash); });
   auto status = result.wait_for(hash_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     hash_context_->TryCancel();
     result.wait();
     hash_context_.reset();
@@ -412,6 +423,7 @@ GrpcConnection::Result GrpcConnection::openStateSnapshotStream(
   });
   auto status = stream.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
+    LOG_WARN(logger_, KVLOG(address_, client_id_));
     snapshot_context->TryCancel();
     stream.wait();
     snapshot_context.reset();
@@ -450,6 +462,7 @@ void GrpcConnection::cancelStateSnapshotStream(RequestId request_id) {
         return;
       }
       ConcordAssertNE((it->second).first, nullptr);
+      LOG_WARN(logger_, KVLOG(address_, client_id_));
       (it->second).first->TryCancel();
       (it->second).first.reset();
       (it->second).second.reset();
@@ -470,6 +483,7 @@ void GrpcConnection::cancelAllStateSnapshotStreams() {
         continue;
       }
       ConcordAssertNE(c.second.first, nullptr);
+      LOG_WARN(logger_, KVLOG(address_, client_id_));
       c.second.first->TryCancel();
       c.second.first.reset();
       c.second.second.reset();
@@ -503,6 +517,7 @@ GrpcConnection::Result GrpcConnection::readStateSnapshot(
       ReadLock read_lock(rss_streams_mutex_);
       auto it = rss_streams_.find(request_id);
       if (it != rss_streams_.end()) {
+        LOG_WARN(logger_, KVLOG(address_, client_id_));
         ((it->second).first)->TryCancel();
         result.wait();
         ((it->second).first).reset();

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -11,15 +11,17 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include "client/thin-replica-client/thin_replica_client.hpp"
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <chrono>
+#include <vector>
 
 #include <opentracing/propagation.h>
 #include <opentracing/span.h>
 #include <opentracing/tracer.h>
-#include <memory>
-#include <numeric>
-#include <sstream>
 
+#include "client/thin-replica-client/thin_replica_client.hpp"
 #include "client/thin-replica-client/trace_contexts.hpp"
 #include "client/thin-replica-client/trc_hash.hpp"
 #include "client/thin-replica-client/grpc_connection.hpp"

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -723,6 +723,9 @@ void ThinReplicaClient::pushUpdateToUpdateQueue(std::unique_ptr<EventVariant> up
 
   // push update to the update queue for consumption by the application using
   // TRC
+  const auto& block_id = std::get<Update>(*update).block_id;
+  auto num_events = std::get<Update>(*update).kv_pairs.size();
+  LOG_TRACE(logger_, "Pushing events to UpdateQueue:" << KVLOG(block_id, num_events));
   config_->update_queue->push(std::move(update));
 
   // update metrics

--- a/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
+++ b/kvbc/src/kvbc_app_filter/kvbc_app_filter.cpp
@@ -556,6 +556,8 @@ string KvbAppFilter::readBlockHash(BlockId block_id) {
     throw KvbReadError(msg.str());
   }
   KvbFilteredUpdate filtered_update{block_id, cid, filterKeyValuePairs(*events)};
+  auto num_events = filtered_update.kv_pairs.size();
+  LOG_DEBUG(logger_, "Sending updates (history, hash)" << KVLOG(client_id_, block_id, num_events));
   return hashUpdate(filtered_update);
 }
 

--- a/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/thin_replica_impl.hpp
@@ -29,18 +29,18 @@
 #include <stdexcept>
 #include <string>
 #include <fstream>
+
 #include "Logger.hpp"
 #include "Metrics.hpp"
-
 #include "db_interfaces.h"
 #include "kv_types.hpp"
 #include "kvbc_app_filter/kvbc_app_filter.h"
 #include "kvbc_app_filter/kvbc_key_types.h"
-
 #include "thin_replica.grpc.pb.h"
 #include "subscription_buffer.hpp"
 #include "trs_metrics.hpp"
-#include <util/filesystem.hpp>
+#include "util/filesystem.hpp"
+#include "hex_tools.h"
 
 using google::protobuf::util::TimeUtil;
 using namespace std::chrono_literals;
@@ -1168,7 +1168,8 @@ class ThinReplicaImpl {
     com::vmware::concord::thin_replica::Hash hash;
     hash.mutable_events()->set_block_id(block_id);
     hash.mutable_events()->set_hash(update_hash);
-    LOG_DEBUG(logger_, "COMPARE SendHash block_id " << block_id << " update_hash " << update_hash);
+    concordUtils::HexPrintBuffer update_hash_buff{update_hash.data(), update_hash.size()};
+    LOG_DEBUG(logger_, "COMPARE SendHash block_id " << block_id << " update_hash " << update_hash_buff);
     if (!stream->Write(hash)) {
       throw StreamClosed("Hash stream closed");
     }


### PR DESCRIPTION
Problem Overview
This PR aims to improve visibility and debuggability in thin replica client-server and some parts of client service (e.g events service). This is done by fixing, adding improving logs, metrics, and histograms.
In addition, minimal (opportunistic) refactoring is done.
Commits:

Thin-Replica, event_service: add additional logs to improve debugging
thin_replica_client,event_service,concord_client: rename, add and modify metrics
concord_client: fix wrong variable name
thin_replica_impl: fix bug in ThinReplicaImpl::sendHash
clientservice, trc: refactor (shorten) use of std::chrono members
event_service: refactor metrics, and had histograms (snapshots)
Testing Done
Maestro manual test to check for stability, and that all logs apear as expected.