### PR TITLE
Fix for intermittent failure of apollo test test_wedge_command_with_state_transfer

### DIFF
--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -17,6 +17,7 @@ from typing import Set, Optional, Callable
 
 import trio
 import difflib
+import random
 
 from util.test_base import ApolloTest, parameterize
 from util import skvbc as kvbc
@@ -841,11 +842,54 @@ class SkvbcReconfigurationTest(ApolloTest):
         for r in late_replicas:
             await bft_network.wait_for_state_transfer_to_stop(initial_prim,
                                                               r,
-                                                              stop_on_stable_seq_num=False)
-        await self.try_to_unwedge(bft_network=bft_network, bft=False, restart=False)
+                                                              stop_on_stable_seq_num=True)
         for i in range(100):
             await skvbc.send_write_kv_set()
 
+    @with_trio
+    @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)
+    async def test_wedge_command_with_state_transfer_with_write(self, bft_network):
+        """
+            This test checks that a replica that received client writes via the state transfer mechanism (after wedge and unwedge commands)
+            is able to take fast path on subsequent client writes.
+            The test does the following:
+            1. Start all replicas but 1
+            2. A client sends a wedge command
+            3. Validate that all started replicas reached to the next next checkpoint
+            4. Perform client writes
+            5. Start the late replica
+            6. Validate that the late replica completed the state transfer
+            7. Validate that subsequent writes are completed using fast paths
+        """
+        initial_primary_replica = 0
+        late_replica = random.choice(bft_network.all_replicas(without={initial_primary_replica}))
+        on_time_replicas = bft_network.all_replicas(without={late_replica})
+        bft_network.start_replicas(on_time_replicas)
+
+        skvbc = kvbc.SimpleKVBCProtocol(bft_network)
+        await skvbc.wait_for_liveness()
+
+        initial_fast_path_count = await bft_network.get_metric(initial_primary_replica, bft_network, "Counters", "totalFastPaths")
+        client = bft_network.random_client()
+        # We increase the default request timeout because we need to have around 300 consensuses which occasionally may take more than 5 seconds
+        client.config._replace(req_timeout_milli=10000)
+        op = operator.Operator(bft_network.config, client,  bft_network.builddir)
+        await op.wedge()
+        await self.validate_stop_on_wedge_point(bft_network=bft_network, skvbc=skvbc, fullWedge=False)
+        await self.try_to_unwedge(bft_network=bft_network, bft=True, restart=False)
+
+        for _ in range(300):
+            await skvbc.send_write_kv_set()
+
+        bft_network.start_replica(late_replica)
+        await bft_network.wait_for_state_transfer_to_stop(initial_primary_replica,
+                                                          late_replica,
+                                                          stop_on_stable_seq_num=False)
+        for _ in range(300):
+            await skvbc.send_write_kv_set()
+
+        final_fast_path_count = await bft_network.get_metric(initial_primary_replica, bft_network, "Counters", "totalFastPaths")
+        self.assertGreater(final_fast_path_count, initial_fast_path_count)
 
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: n == 7, publish_master_keys=True)


### PR DESCRIPTION
The apollo test test_wedge_command_with_state_transfer has failed intermittently with the following error:

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/concord-bft/tests/apollo/util/bft.py", line 218, in wrapper
await test_with_bft_network()
File "/concord-bft/tests/apollo/util/test_base.py", line 82, in wrapper
raise e
File "/concord-bft/tests/apollo/util/test_base.py", line 73, in wrapper
await async_fn(*args, **kwargs)
File "/concord-bft/tests/apollo/util/bft.py", line 217, in test_with_bft_network
await async_fn(*args, **kwargs, bft_network=bft_network)
File "/concord-bft/tests/apollo/test_skvbc_reconfiguration.py", line 844, in test_wedge_command_with_state_transfer
stop_on_stable_seq_num=False)
File "/concord-bft/tests/apollo/util/bft.py", line 1284, in wait_for_state_transfer_to_stop
await trio.sleep(0.5)
File "/usr/lib/python3.6/contextlib.py", line 99, in _exit_
self.gen.throw(type, value, traceback)
File "/usr/local/lib/python3.6/dist-packages/trio/_timeouts.py", line 108, in fail_at
raise TooSlowError
trio.TooSlowError


Fix:

Modify the test case to change the logic of wait_for_state_transfer_to_stop to validate stable checkpoint rather than last executed checkpoint. Also, eliminate the unwedge command after State Transfer.
In addition to this test case, we would add one more test case similar to this test where KV writes are done before State Transfer starts.

