### PR TITLE
Added histograms for 99.9999 and 99.99999.

### DIFF
--- a/diagnostics/include/performance_handler.h
+++ b/diagnostics/include/performance_handler.h
@@ -284,13 +284,16 @@ struct HistogramValues {
     pct_99_9 = hdr_value_at_percentile(h, 99.9);
     pct_99_99 = hdr_value_at_percentile(h, 99.99);
     pct_99_999 = hdr_value_at_percentile(h, 99.999);
+    pct_99_9999 = hdr_value_at_percentile(h, 99.9999);
+    pct_99_99999 = hdr_value_at_percentile(h, 99.99999);
   }
 
   bool operator==(const HistogramValues& other) const {
     return count == other.count && min == other.min && max == other.max && pct_10 == other.pct_10 &&
            pct_25 == other.pct_25 && pct_50 == other.pct_50 && pct_75 == other.pct_75 && pct_90 == other.pct_90 &&
            pct_95 == other.pct_95 && pct_99 == other.pct_99 && pct_99_9 == other.pct_99 &&
-           pct_99_99 == other.pct_99_99 && pct_99_999 == other.pct_99_999;
+           pct_99_99 == other.pct_99_99 && pct_99_999 == other.pct_99_999 && pct_99_9999 == other.pct_99_9999 &&
+           pct_99_99999 == other.pct_99_99999;
   }
   bool operator!=(const HistogramValues& other) const { return !(*this == other); }
 
@@ -308,6 +311,8 @@ struct HistogramValues {
   int64_t pct_99_9 = 0;
   int64_t pct_99_99 = 0;
   int64_t pct_99_999 = 0;
+  int64_t pct_99_9999 = 0;
+  int64_t pct_99_99999 = 0;
 };
 
 struct HistogramData {

--- a/diagnostics/src/performance_handler.cpp
+++ b/diagnostics/src/performance_handler.cpp
@@ -156,6 +156,8 @@ std::ostream& operator<<(std::ostream& os, const HistogramValues& values) {
   os << "  99.9: " << values.pct_99_9 << std::endl;
   os << "  99.99: " << values.pct_99_99 << std::endl;
   os << "  99.999: " << values.pct_99_999 << std::endl;
+  os << "  99.9999: " << values.pct_99_9999 << std::endl;
+  os << "  99.99999: " << values.pct_99_99999 << std::endl;
   return os;
 }
 


### PR DESCRIPTION
Additional histograms for tracking rare cases
of high deviation in LRT tests.

* **Problem Overview**  
  We need to be able to track rare events of high deviations in LRT-s where we accumulate a lot of data.
* **Testing Done**  
 CI
