### PR TITLE
Add skeleton of a utt wallet command-line application

### DIFF
--- a/utt/CMakeLists.txt
+++ b/utt/CMakeLists.txt
@@ -176,6 +176,7 @@ enable_testing()
 add_subdirectory(libutt)
 add_subdirectory(libxassert)
 add_subdirectory(libxutils)
+add_subdirectory(wallet-cli)
 
 set(newutt_src 
     libutt/src/api/UTTParams.cpp

--- a/utt/wallet-cli/CMakeLists.txt
+++ b/utt/wallet-cli/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_subdirectory("proto")
+
+set(utt-wallet-cli-src
+    src/main.cpp
+)
+
+add_executable(utt-wallet-cli ${utt-wallet-cli-src})
+
+target_link_libraries(utt-wallet-cli PUBLIC
+  utt-wallet-api-proto
+)

--- a/utt/wallet-cli/README.md
+++ b/utt/wallet-cli/README.md
@@ -1,0 +1,3 @@
+# UTT Wallet Command-Line Application
+
+A command-line application for a UTT wallet. Uses gRPC to talk to a wallet service, for which we provide the interface in [proto/api/v1/api.proto](proto/api/v1/api.proto). The actual implementation of a wallet service is not provided.

--- a/utt/wallet-cli/proto/CMakeLists.txt
+++ b/utt/wallet-cli/proto/CMakeLists.txt
@@ -1,0 +1,15 @@
+find_package(Protobuf REQUIRED)
+find_package(GRPC REQUIRED)
+
+include_directories(${GRPC_INCLUDE_DIR})
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+  api/v1/api.proto
+)
+grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
+  api/v1/api.proto
+)
+
+add_library(utt-wallet-api-proto STATIC ${PROTO_SRCS} ${GRPC_SRCS})
+target_link_libraries(utt-wallet-api-proto PRIVATE protobuf::libprotobuf gRPC::grpc++)
+target_include_directories(utt-wallet-api-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/utt/wallet-cli/proto/api/v1/api.proto
+++ b/utt/wallet-cli/proto/api/v1/api.proto
@@ -1,0 +1,187 @@
+// Copyright 2021 VMware, all rights reserved
+//
+// UTT Wallet's api
+
+syntax = "proto3";
+// [TODO-UTT] Condense this package identifier into fewer tokens?
+package vmware.concord.utt.wallet.api.v1; 
+
+// Test
+// [TODO-UTT] Remove TestService
+service TestService {
+    rpc reverseString(ReverseStringRequest) returns (ReverseStringResponse);
+}
+
+message ReverseStringRequest {
+    optional string input = 1;
+}
+
+message ReverseStringResponse {
+    optional string output = 1;
+}
+
+// UTT Wallet Service Interface
+// This interface follows the UTT contract interface as close as possible.
+// [TODO-UTT] Consider if we should use a simplified version of this api that assumes synchronous requests
+// - This would mean that a request will receive a response only when signatures are computed.
+service UTTWalletService {
+    rpc registerUser(RegisterUserRequest) returns (RegisterUserResponse);
+    rpc getUserRegistration(GetUserRegistrationRequest) returns (GetUserRegistrationResponse);
+
+    // Note: creating a public budget is done by an administrator
+    rpc getLatestPublicBudget(GetLatestPublicBudgetRequest) returns (GetLatestPublicBudgetResponse);
+
+    // [TODO-UTT] Consider if we need to get the budget sig alone.
+    // Here is the problem: only one budget coin can exist for a user at the any time, but the signature
+    // is not ready at the same time as the budget coin.
+    // If we call getLatestPublicBudget and get back both a budget coin and a sig then we can use the coin.
+    // If we get just the budget coin the sig is still pending.
+    // But when we get the sig eventually we're not guaranteed that its for the same budget coin.
+    // Concurrently some administrator may have created a new budget coin.
+    // The safest bet is to call getLatestPublicBudgetSig until you get both a budget coin and a sig.
+    // Otherwise we need to verify that the coin and sig match and if not - request the coin and/or sig until they do.
+    rpc getLatestPublicBudgetSig(GetLatestPublicBudgetSigRequest) returns (GetLatestPublicBudgetSigResponse);
+
+    rpc transfer(TransferRequest) returns (TransferResponse);
+
+    // Note: mint is supposed to convert public funds (Ether, ERC-20 tokens, etc.) to private funds (UTT tokens).
+    // Here we make an assumption that the wallet service keeps track of our public funds but in reality
+    // we need a way to use one or more Ethereum accounts representing the public funds of the user.
+    rpc mint(MintRequest) returns (MintResponse);
+
+    // Note: burn is supposed to convert private funds (UTT tokens) to public funds (Ether, ERC-20 tokens, etc.).
+    // Here we make an assumption that the wallet service keeps track of our public funds but in reality
+    // we need a way to use one or more Ethereum accounts representing the public funds of the user.
+    rpc burn(BurnRequest) returns (BurnResponse);
+
+    // Same as getNumOfLastAddedTranscation from spec
+    rpc getLastAddedTxNumber(GetLastAddedTxNumberRequest) returns (GetLastAddedTxNumberResponse);
+
+    // Same as getNumOfLastSignedTranscation from spec
+    rpc getLastSignedTxNumber(GetLastSignedTxNumberRequest) returns (GetLastSignedTxNumberResponse);
+
+    rpc getTransaction(GetTransactionRequest) returns (GetTransactionResponse);
+
+    rpc getTransactionSig(GetTransactionSigRequest) returns (GetTransactionSigResponse);
+}
+
+message RegisterUserRequest {
+    optional string user_id = 1;    
+    optional bytes input_rcm = 2;   // The user's input registration commitment
+    optional bytes user_pk = 3;     // The user's public key
+}
+
+// [TODO-UTT] Consider if we should include the complete result in the response
+// instead of indicating success and then periodically requesting the registration data
+message RegisterUserResponse {
+    // [TODO-UTT] Replace flag with error enum indicating the exact error.
+    optional bool success = 1;      // Indicates if the registration was accepted by the service
+}
+
+message GetUserRegistrationRequest {
+    optional string user_id = 1;
+}
+
+message GetUserRegistrationResponse {
+    optional string user_id = 1;    
+    optional bytes user_pk = 2;     // User's public key
+    optional bytes s2 = 3;          // System-generated part of the user's PRF key (used for nullifiers)
+    optional bytes rs = 4;          // A signature on the full registration commitment
+}
+
+message GetLatestPublicBudgetRequest {
+    optional string user_id = 1;
+}
+
+message GetLatestPublicBudgetResponse {
+    optional bytes budget_coin = 1;
+    // [TODO-UTT] Consider returning the signature in the same response as the budget coin,
+    // optional bytes signature = 2; // Could be empty
+}
+
+message GetLatestPublicBudgetSigRequest {
+    optional string user_id = 1;
+}
+
+message GetLatestPublicBudgetSigResponse {
+    optional bytes signature = 1;
+}
+
+message TransferRequest {
+    optional TransferTx transfer = 1;
+}
+
+message TransferResponse {
+    optional uint64 tx_number = 1;
+}
+
+message MintRequest {
+    optional string user_id = 1;
+    optional uint64 value = 2;
+}
+
+message MintResponse {
+    optional uint64 tx_number = 1;
+}
+
+message BurnRequest {
+    optional string user_id = 1;
+    optional bytes burn_tx = 2;
+    optional uint64 value = 3;
+}
+
+message BurnResponse {
+    optional uint64 tx_number = 1;
+}
+
+message GetLastAddedTxNumberRequest {
+}
+
+message GetLastAddedTxNumberResponse {
+    optional uint64 tx_number = 1;
+}
+
+message GetLastSignedTxNumberRequest {
+}
+
+message GetLastSignedTxNumberResponse {
+    optional uint64 tx_number = 1;
+}
+
+message GetTransactionRequest {
+    optional uint64 tx_number = 1;
+}
+
+message GetTransactionResponse {
+    optional uint64 tx_number = 1;
+    oneof tx {
+        TransferTx transfer = 2;
+        MintTx mint = 3;
+        BurnTx burn = 4;
+      }
+}
+
+message TransferTx {
+    // [TODO-UTT] What else is in a transfer tx?
+    // -- should be mostly represented as bytes since this is an anonymous tx.
+    optional bytes tx = 1;
+}
+
+message MintTx {
+    // [TODO-UTT] What else is in a mint tx?
+    optional bytes tx = 1;
+}
+
+message BurnTx {
+    // [TODO-UTT] What else is in a burn tx?
+    optional bytes tx = 1;
+}
+
+message GetTransactionSigRequest {
+    optional uint64 tx_number = 1;
+}
+
+message GetTransactionSigResponse {
+    optional uint64 tx_number = 1;
+    repeated bytes signatures = 2;
+}

--- a/utt/wallet-cli/src/main.cpp
+++ b/utt/wallet-cli/src/main.cpp
@@ -1,0 +1,107 @@
+#include <iostream>
+
+#include <grpcpp/grpcpp.h>
+#include "api.grpc.pb.h"  // Generated from utt/wallet/proto/api
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  std::cout << "UTT Wallet CLI Application.\n";
+  // [TODO-UTT] The wallet should use the UTT Client Library for UTT requests.
+  // [TODO-UTT] The wallet should use RocksDB to store UTT assets.
+  // [TODO-UTT] The wallet should use some RSA cryptography to generate public/private
+  // keys (used by the UTT Client Library)
+
+  // [TODO-UTT] Initial registration
+  // Upon first launch (no records in RocksDB) the wallet asks the user to register
+  // > Choose a unique user identifier:
+  // After this prompt the wallet sends a registration request and waits for the response
+  // Upon successfull registration the user can use any of the following commands.
+
+  // [TODO-UTT] Startup Sequence
+  // A. Confirm registration -- check that the user is registered, otherwise go to "Initial registration".
+  // B. Synchronize
+  // 1) Ask about the latest signed transaction number and compare with
+  // the latest executed transaction in the wallet. Determine the range of tx numbers to be retrieved.
+  // 2) For each tx number to execute request the transaction and signature (can be combined)
+  // 3) Apply the transaction to the wallet state
+  //  a. If it's a burn or a mint transaction matching our user-id
+  //  b. IF it's an anonymous tx that we can claim outputs from or slash spent coins (check the nullifiers)
+  // [TODO-UTT] Synchronization can be optimized to require fewer requests by batching tx requests and/or filtering by
+  // user-id for burns and mints
+
+  // [TODO-UTT] Periodic synchronization
+  // We need to periodically sync with the wallet service - we can either detect this when we send requests
+  // (we see that there are multiple transactions that happened before ours) or we do it periodically or before
+  // attempt an operation.
+
+  // Note: Limited recovery from liveness issues
+  // In a single machine demo setting liveness issues will not be created due to the network,
+  // so we don't need to implement the full range of precautions to handle liveness issues
+  // such as timeouts.
+
+  // [TODO-UTT] Commands:
+  // mint <amount> -- convert some amount of public funds (ERC20 tokens) to private funds (UTT tokens)
+  // burn <amount> -- convert some amount of private funds (UTT tokens) to public funds (ERC20 tokens)
+  // transfer <amount> <user-id> -- transfers anonymously some amount of private funds (UTT tokens) to another user
+  // public balance -- print the number of ERC20 tokens the user has (needs a gRPC method to retrieve this value from
+  // the wallet service) private balance -- print the number of UTT tokens the user has currently (compute locally)
+  // budget -- print the currently available anonymity budget (a budget is created in advance for each user)
+
+  // gRPC
+  try {
+    std::string grpcServerAddr = "127.0.0.1:49000";
+
+    std::cout << "Connecting to gRPC server at " << grpcServerAddr << " ...\n";
+
+    using namespace vmware::concord::utt::wallet::api::v1;
+
+    auto chan = grpc::CreateChannel(grpcServerAddr, grpc::InsecureChannelCredentials());
+
+    if (!chan) {
+      throw std::runtime_error("Failed to create gRPC channel.");
+    }
+    auto timeoutSec = std::chrono::seconds(5);
+    if (chan->WaitForConnected(std::chrono::system_clock::now() + timeoutSec)) {
+      std::cout << "Connected.\n";
+    } else {
+      throw std::runtime_error("Failed to connect to gRPC server after " + std::to_string(timeoutSec.count()) +
+                               " seconds.");
+    }
+
+    auto stub = TestService::NewStub(chan);
+    if (!stub) {
+      throw std::runtime_error("Failed to create gRPC client stub.");
+    }
+
+    while (true) {
+      std::cout << "Enter ASCII string to be reversed (Ctr-D to quit):\n > ";
+      std::string input;
+      std::cin >> input;
+
+      if (std::cin.eof()) {
+        std::cout << "Quitting...\n";
+        break;
+      }
+
+      if (!input.empty()) {
+        grpc::ClientContext ctx;
+
+        ReverseStringRequest req;
+        req.set_input(input);
+
+        ReverseStringResponse resp;
+        stub->reverseString(&ctx, req, &resp);
+
+        std::cout << " > Response: " << resp.output() << '\n';
+      }
+    }
+
+  } catch (const std::runtime_error& e) {
+    std::cout << "Error (exception): " << e.what() << '\n';
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
* **Problem Overview**  
  We need a simple C++ wallet command-line application for the initial development of the UTT-Ethereum framework. This wallet is a placeholder and will use the UTT Client Library to create UTT requests. The requests are sent to a gRPC wallet service that handles web3 functionality and UTT Ethereum contract calls. There is no direct dependency on Ethereum in this wallet app project, everything is handled through a generic gRPC interface.
* **Testing Done**  
  The wallet-cli app was built and a simple gRPC request/response was tested with a running gRPC server.
