### PR TITLE
Remove leftovers of boost::filesystem usage after switch to std::filesystem

### DIFF
--- a/bftengine/src/bftengine/BFTEngine.cpp
+++ b/bftengine/src/bftengine/BFTEngine.cpp
@@ -31,17 +31,7 @@
 #include <mutex>
 #include <cstdio>
 #include <utility>
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error "Missing filesystem support"
-#endif
-
+#include <util/filesystem.hpp>
 #include <ccron/ticks_generator.hpp>
 
 bftEngine::IReservedPages *bftEngine::ReservedPagesClientBase::res_pages_ = nullptr;

--- a/bftengine/tests/metadataStorage/metadataStorage_test.cpp
+++ b/bftengine/tests/metadataStorage/metadataStorage_test.cpp
@@ -13,7 +13,7 @@
 #include "direct_kv_db_adapter.h"
 #include "storage/direct_kv_key_manipulator.h"
 
-#include <experimental/filesystem>
+#include <util/filesystem.hpp>
 
 using namespace std;
 
@@ -58,7 +58,7 @@ uint8_t *writeInTransaction(const ObjectId &objectId, const uint32_t &dataLen) {
 
 DBMetadataStorage *initiateMetadataStorage(Client *dbClient, const std::string &dbPath, bool remove_old_file) {
   if (remove_old_file) {
-    std::experimental::filesystem::remove_all(dbPath.c_str());
+    fs::remove_all(dbPath.c_str());
   }
   DBMetadataStorage *metadataStorage_ =
       new DBMetadataStorage(dbClient, std::make_unique<concord::storage::v1DirectKeyValue::MetadataKeyManipulator>());

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -16,7 +16,7 @@
 #include "kvstream.h"
 
 #include <variant>
-#include <experimental/filesystem>
+#include <util/filesystem.hpp>
 #include <fstream>
 namespace fs = std::experimental::filesystem;
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -57,7 +57,6 @@ install_build_tools() {
 # Install 3rd parties
 install_third_party_libraries() {
     apt-get ${APT_GET_FLAGS} install \
-        libboost-filesystem1.65-dev \
         libboost-system1.65-dev \
         libboost-program-options1.65-dev \
         libboost1.65-dev \

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required (VERSION 3.2)
 project(libkvbc VERSION 0.1.0.0 LANGUAGES CXX)
 
-find_package(Boost ${MIN_BOOST_VERSION} COMPONENTS filesystem REQUIRED)
-
 add_library(concord_block_update INTERFACE)
 target_include_directories(concord_block_update INTERFACE
   block_update
@@ -78,7 +76,6 @@ if(NOT BUILD_THIRDPARTY)
     find_package(OpenSSL REQUIRED)
 endif()
 target_link_libraries(kvbc PRIVATE OpenSSL::Crypto)
-target_link_libraries(kvbc PRIVATE ${Boost_LIBRARIES})
 
 if (BUILD_TESTING)
     add_subdirectory(test)

--- a/kvbc/tools/object_store_utility/main.cpp
+++ b/kvbc/tools/object_store_utility/main.cpp
@@ -30,8 +30,7 @@ int main(int argc, char** argv) {
   auto checker = std::make_shared<IntegrityChecker>(logger);
   auto restorer = std::make_shared<DBRestore>(checker, logger);
 
-  po::options_description global{boost::dll::program_location().filename().string() +
-                                " MANDATORY_OPTIONS <validate|restore> OPTIONS"};
+  po::options_description global{"object_store_utility MANDATORY_OPTIONS <validate|restore> OPTIONS"};
   global.add_options()("help", "produce a help message");
 
   po::options_description mandatory{"MANDATORY_OPTIONS"};

--- a/storage/include/storage/test/s3_test_common.h
+++ b/storage/include/storage/test/s3_test_common.h
@@ -13,8 +13,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+#include <util/filesystem.hpp>
 
 namespace concord::storage::s3::test {
 

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -35,8 +35,7 @@
 #include "secrets_manager_plain.h"
 
 #include <boost/algorithm/string.hpp>
-#include <experimental/filesystem>
-
+#include <util/filesystem.hpp>
 #include "strategy/StrategyUtils.hpp"
 #include "strategy/ByzantineStrategy.hpp"
 #include "strategy/ShufflePrePrepareMsgStrategy.hpp"
@@ -50,8 +49,6 @@
 #ifdef USE_S3_OBJECT_STORE
 #include "s3/config_parser.hpp"
 #endif
-
-namespace fs = std::experimental::filesystem;
 
 namespace concord::kvbc {
 


### PR DESCRIPTION
* **Problem Overview**  
Remove leftovers of boost::filesystem usage after switch to std::filesystem
* **Testing Done**  
  unit tests
