### PR TITLE
Fix clang-tidy: compile wallet-cli proto before clang-tidy checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CONCORD_BFT_UTT_DEMO_CMF_PATHS?=${CONCORD_BFT_TARGET_SOURCE_PATH}/build/tests/ut
 CONCORD_BFT_CLIENT_PROTO_PATH?=${CONCORD_BFT_TARGET_SOURCE_PATH}/build/client/proto
 CONCORD_BFT_THIN_REPLICA_PROTO_PATH?=${CONCORD_BFT_TARGET_SOURCE_PATH}/build/thin-replica-server/proto
 CONCORD_BFT_KVBC_PROTO_PATH?=${CONCORD_BFT_TARGET_SOURCE_PATH}/build/kvbc/proto
+CONCORD_BFT_UTT_WALLET_CLI_PROTO_PATH?=${CONCORD_BFT_TARGET_SOURCE_PATH}/build/utt/wallet-cli/proto
 CONCORD_BFT_CONTAINER_SHELL?=/bin/bash
 CONCORD_BFT_CONTAINER_CC?=clang
 CONCORD_BFT_CONTAINER_CXX?=clang++
@@ -208,6 +209,7 @@ tidy-check: gen_cmake ## Run clang-tidy
 		make -C ${CONCORD_BFT_CLIENT_PROTO_PATH} &> /dev/null && \
 		make -C ${CONCORD_BFT_THIN_REPLICA_PROTO_PATH} &> /dev/null && \
 		make -C ${CONCORD_BFT_KVBC_PROTO_PATH} &> /dev/null && \
+		make -C ${CONCORD_BFT_UTT_WALLET_CLI_PROTO_PATH} &> /dev/null && \
 		${CONCORD_BFT_CLANG_TIDY} -ignore ../.clang-tidy-ignore 2>&1 | tee clang-tidy-report.txt | ( ! grep 'error:\|note:' ) && \
 		../scripts/check-forbidden-usage.sh .." \
 		&& (echo "\nClang-tidy finished successfully.") \


### PR DESCRIPTION
* **Problem Overview**  
  Missing wallet-cli proto generated source code breaks clang-tidy.
* **Testing Done**  
  N/A
