### PR TITLE
Replace thread_safe_queue with spsc_queue b/w TRC and Event Service

### DIFF
--- a/client/clientservice/include/client/clientservice/event_service.hpp
+++ b/client/clientservice/include/client/clientservice/event_service.hpp
@@ -82,6 +82,7 @@ class EventServiceImpl final : public vmware::concord::client::event::v1::EventS
 
  private:
   logging::Logger logger_;
+  static constexpr size_t kQueueDataSize{10000u};
   std::shared_ptr<concord::client::concordclient::ConcordClient> client_;
   EventServiceMetrics metrics_;
   Recorders histograms_;

--- a/client/clientservice/src/event_service.cpp
+++ b/client/clientservice/src/event_service.cpp
@@ -68,7 +68,7 @@ Status EventServiceImpl::Subscribe(ServerContext* context,
   }
 
   auto span = opentracing::Tracer::Global()->StartSpan("subscribe", {});
-  std::shared_ptr<cc::EventUpdateQueue> update_queue = std::make_shared<cc::BasicEventUpdateQueue>();
+  std::shared_ptr<cc::TrcQueue> update_queue = std::make_shared<cc::TrcQueue>();
   client_->subscribe(request, update_queue, span);
 
   // TODO: Return UNAVAILABLE as documented in event.proto if ConcordClient is unhealthy

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -26,7 +26,7 @@
 #include "bftclient/bft_client.h"
 #include "client/thin-replica-client/thin_replica_client.hpp"
 #include "client/client_pool/concord_client_pool.hpp"
-#include "client/concordclient/event_update.hpp"
+#include "client/concordclient/trc_queue.hpp"
 #include "client/concordclient/snapshot_update.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
 #include "Metrics.hpp"
@@ -166,7 +166,7 @@ class ConcordClient {
 
   // Subscribe to events which are pushed into the given update queue.
   void subscribe(const SubscribeRequest& request,
-                 std::shared_ptr<EventUpdateQueue>& queue,
+                 std::shared_ptr<TrcQueue>& queue,
                  const std::unique_ptr<opentracing::Span>& parent_span);
 
   // Note, if the caller doesn't unsubscribe and no runtime error occurs then resources

--- a/client/concordclient/include/client/concordclient/event_update.hpp
+++ b/client/concordclient/include/client/concordclient/event_update.hpp
@@ -19,8 +19,6 @@
 #include <variant>
 #include <vector>
 
-#include "client/concordclient/thread_safe_queue.hpp"
-
 namespace concord::client::concordclient {
 
 struct EventGroup {
@@ -47,10 +45,5 @@ struct Update {
   std::string correlation_id_;
   std::string span_context;
 };
-
-typedef std::variant<Update, EventGroup> EventVariant;
-
-using EventUpdateQueue = IQueue<EventVariant>;
-using BasicEventUpdateQueue = BasicThreadSafeQueue<EventVariant>;
 
 }  // namespace concord::client::concordclient

--- a/client/concordclient/include/client/concordclient/trc_queue.hpp
+++ b/client/concordclient/include/client/concordclient/trc_queue.hpp
@@ -1,0 +1,112 @@
+// Concord
+//
+// Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <condition_variable>
+#include <boost/lockfree/spsc_queue.hpp>
+#include <list>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <exception>
+#include <chrono>
+#include <variant>
+
+#include "assertUtils.hpp"
+#include "event_update.hpp"
+
+namespace concord::client::concordclient {
+
+typedef std::variant<Update, EventGroup> EventVariant;
+
+class TrcQueue {
+ private:
+  boost::lockfree::spsc_queue<EventVariant*> queue_data_;
+  std::exception_ptr exception_;
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  static constexpr size_t kQueueDataSize{10000u};
+
+ public:
+  // Construct a TrcQueue.
+  TrcQueue() : queue_data_(kQueueDataSize) {}
+
+  // Copying or moving a TrcQueue is explicitly disallowed, as we do not know of a compelling use case
+  // requiring copying or moving TrcQueue, we believe semantics for these operations are likely to be
+  // messy in some cases, and we believe implementation may be non-trivial. We may revisit the decision to disallow
+  // these operations should compelling use cases for them be found in the future.
+  TrcQueue(const TrcQueue& other) = delete;
+  TrcQueue(const TrcQueue&& other) = delete;
+  TrcQueue& operator=(const TrcQueue& other) = delete;
+  TrcQueue& operator=(const TrcQueue&& other) = delete;
+
+  void clear() { queue_data_.reset(); }
+
+  void push(EventVariant* update) {
+    queue_data_.push(std::move(update));
+    condition_.notify_one();
+  }
+
+  std::unique_ptr<EventVariant> getElementFromQueue() {
+    if (queue_data_.read_available()) {
+      EventVariant* update = new EventVariant;
+      queue_data_.pop(update);
+      return std::unique_ptr<EventVariant>(update);
+    }
+    if (exception_) {
+      auto e = exception_;
+      exception_ = nullptr;
+      std::rethrow_exception(e);
+    }
+    return nullptr;
+  }
+
+  std::unique_ptr<EventVariant> popTill(std::chrono::milliseconds timeout) {
+    auto update = getElementFromQueue();
+    if (update) return update;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      auto is_timeout = !condition_.wait_for(
+          lock, timeout, [this]() { return this->exception_ || (queue_data_.read_available() > 0); });
+      if (is_timeout) return nullptr;
+    }
+    return getElementFromQueue();
+  }
+
+  std::unique_ptr<EventVariant> pop() {
+    auto update = getElementFromQueue();
+    if (update) return update;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      while (!exception_ && !(queue_data_.read_available() > 0)) {
+        condition_.wait(lock);
+      }
+      return getElementFromQueue();
+    }
+  }
+
+  std::unique_ptr<EventVariant> tryPop() { return getElementFromQueue(); }
+
+  uint64_t size() { return queue_data_.read_available(); }
+
+  void setException(std::exception_ptr e) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      exception_ = e;
+    }
+    condition_.notify_all();
+  }
+};
+
+}  // namespace concord::client::concordclient

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -179,7 +179,7 @@ void ConcordClient::checkAndReConnectGrpcConnections() {
 }
 
 void ConcordClient::subscribe(const SubscribeRequest& sub_req,
-                              std::shared_ptr<EventUpdateQueue>& queue,
+                              std::shared_ptr<TrcQueue>& queue,
                               const std::unique_ptr<opentracing::Span>& parent_span) {
   bool expected = false;
   if (!active_subscription_.compare_exchange_weak(expected, true)) {

--- a/client/concordclient/test/cc_basic_update_queue_test.cpp
+++ b/client/concordclient/test/cc_basic_update_queue_test.cpp
@@ -11,7 +11,7 @@
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
 
-#include "client/concordclient/event_update.hpp"
+#include "client/concordclient/trc_queue.hpp"
 #include "client/concordclient/thread_safe_queue.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
 

--- a/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/thin_replica_client.hpp
@@ -48,7 +48,7 @@
 #include <condition_variable>
 #include <thread>
 #include "Logger.hpp"
-#include "client/concordclient/event_update.hpp"
+#include "client/concordclient/trc_queue.hpp"
 #include "client/concordclient/concord_client_exceptions.hpp"
 
 namespace client::thin_replica_client {
@@ -94,7 +94,7 @@ struct ThinReplicaClientConfig {
   // ReleaseConsumers, or ReEnableConsumers. Furthermore, a ThinReplicaClient
   // guarantees it will never execute the Clear or Push functions of the queue
   // after that ThinReplicaClient's destructor has returned.
-  std::shared_ptr<concord::client::concordclient::EventUpdateQueue> update_queue;
+  std::shared_ptr<concord::client::concordclient::TrcQueue> update_queue;
   // max_faulty is the maximum number of simultaneously Byzantine-faulty servers
   // that must be tolerated (this is equivalent to the F value for the Concord
   // cluster the servers are from).
@@ -107,7 +107,7 @@ struct ThinReplicaClientConfig {
   std::chrono::seconds no_agreement_warn_duration;
 
   ThinReplicaClientConfig(std::string client_id_,
-                          std::shared_ptr<concord::client::concordclient::EventUpdateQueue> update_queue_,
+                          std::shared_ptr<concord::client::concordclient::TrcQueue> update_queue_,
                           std::size_t max_faulty_,
                           std::vector<std::shared_ptr<client::concordclient::GrpcConnection>>& trs_conns_,
                           std::chrono::seconds no_agreement_warn_duration_ = kNoAgreementWarnDuration)

--- a/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trace_contexts.hpp
@@ -19,7 +19,7 @@
 #include <optional>
 
 #include "thin_replica.pb.h"
-#include "client/concordclient/event_update.hpp"
+#include "client/concordclient/trc_queue.hpp"
 #include "Logger.hpp"
 
 using opentracing::expected;

--- a/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/trc_hash.hpp
@@ -19,7 +19,7 @@
 #include <list>
 #include "openssl_crypto.hpp"
 #include "thin_replica.grpc.pb.h"
-#include "client/concordclient/event_update.hpp"
+#include "client/concordclient/trc_queue.hpp"
 
 namespace client::thin_replica_client {
 

--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -40,7 +40,7 @@ using concord::client::concordclient::Update;
 using concord::client::concordclient::UpdateNotFound;
 using concord::client::concordclient::OutOfRangeSubscriptionRequest;
 using concord::client::concordclient::InternalError;
-using concord::client::concordclient::EventUpdateQueue;
+using concord::client::concordclient::TrcQueue;
 using std::atomic_bool;
 using std::list;
 using std::logic_error;
@@ -719,7 +719,7 @@ void ThinReplicaClient::pushUpdateToUpdateQueue(std::unique_ptr<EventVariant> up
                                                 const std::chrono::steady_clock::time_point& start,
                                                 bool is_event_group) {
   // push update to the update queue for consumption by the application using TRC
-  config_->update_queue->push(std::move(update));
+  config_->update_queue->push(update.release());
   auto update_queue_size = config_->update_queue->size();
   metrics_.current_queue_size.Get().Set(update_queue_size);
 
@@ -948,7 +948,7 @@ void ThinReplicaClient::Subscribe() {
 
   config_->update_queue->clear();
   while (state.size() > 0) {
-    config_->update_queue->push(move(state.front()));
+    config_->update_queue->push(state.front().release());
     state.pop_front();
   }
   latest_verified_block_id_ = block_id;

--- a/client/thin-replica-client/test/trc_byzantine_test.cpp
+++ b/client/thin-replica-client/test/trc_byzantine_test.cpp
@@ -44,8 +44,7 @@ using std::chrono::time_point;
 using std::this_thread::sleep_for;
 using concord::client::concordclient::EventVariant;
 using concord::client::concordclient::Update;
-using concord::client::concordclient::EventUpdateQueue;
-using concord::client::concordclient::BasicEventUpdateQueue;
+using concord::client::concordclient::TrcQueue;
 using client::concordclient::GrpcConnection;
 using client::thin_replica_client::kThinReplicaHashLength;
 using client::thin_replica_client::ThinReplicaClient;
@@ -74,7 +73,7 @@ bool UpdateMatchesExpected(const std::unique_ptr<EventVariant>& update_received,
   return true;
 }
 
-void VerifyInitialState(shared_ptr<EventUpdateQueue>& received_updates,
+void VerifyInitialState(shared_ptr<TrcQueue>& received_updates,
                         const vector<Data>& expected_updates,
                         size_t num_updates,
                         const string& faulty_description) {
@@ -90,7 +89,7 @@ void VerifyInitialState(shared_ptr<EventUpdateQueue>& received_updates,
   }
 }
 
-void VerifyUpdates(shared_ptr<EventUpdateQueue>& received_updates,
+void VerifyUpdates(shared_ptr<TrcQueue>& received_updates,
                    const vector<Data>& expected_updates,
                    const string& faulty_description) {
   for (size_t i = 0; i < expected_updates.size(); ++i) {
@@ -139,7 +138,7 @@ struct ByzantineTestCaseState {
 
   // Objects we anticipate the test case(s) will actually use once the
   // ByzantineTestCaseState is fully set up.
-  shared_ptr<EventUpdateQueue> update_queue_;
+  shared_ptr<TrcQueue> update_queue_;
   vector<shared_ptr<GrpcConnection>> trs_connections_;
   unique_ptr<ThinReplicaClientConfig> trc_config_;
   shared_ptr<concordMetrics::Aggregator> aggregator_;
@@ -164,7 +163,7 @@ struct ByzantineTestCaseState {
         byzantine_behavior_(byzantine_behavior),
         server_preparer_(correct_data_preparer_, correct_hasher_, byzantine_behavior_),
         mock_servers_(CreateByzantineMockServers(num_servers, server_preparer_)),
-        update_queue_(new BasicEventUpdateQueue()),
+        update_queue_(new TrcQueue()),
         trs_connections_(
             CreateTrsConnections<ByzantineMockThinReplicaServerPreparer::ByzantineMockServer>(mock_servers_)),
         trc_config_(new ThinReplicaClientConfig(kTestingClientID, update_queue_, max_faulty, trs_connections_)),

--- a/client/thin-replica-client/test/trc_hash_test.cpp
+++ b/client/thin-replica-client/test/trc_hash_test.cpp
@@ -14,7 +14,7 @@
 #include "gtest/gtest.h"
 
 #include "client/thin-replica-client/trc_hash.hpp"
-#include "client/concordclient/event_update.hpp"
+#include "client/concordclient/trc_queue.hpp"
 #include "kvbc_app_filter/kvbc_app_filter.h"
 
 using com::vmware::concord::thin_replica::Data;

--- a/client/thin-replica-client/test/trc_rpc_use_test.cpp
+++ b/client/thin-replica-client/test/trc_rpc_use_test.cpp
@@ -32,9 +32,9 @@ using std::make_unique;
 using std::shared_ptr;
 using std::string;
 using std::vector;
-using concord::client::concordclient::EventUpdateQueue;
-using concord::client::concordclient::BasicEventUpdateQueue;
+using concord::client::concordclient::TrcQueue;
 using client::thin_replica_client::ThinReplicaClient;
+using concord::client::concordclient::EventVariant;
 using client::thin_replica_client::ThinReplicaClientConfig;
 
 const string kTestingClientID = "mock_client_id";
@@ -57,7 +57,7 @@ TEST(trc_rpc_use_test, test_trc_constructor_and_destructor) {
   uint16_t max_faulty = 1;
   size_t num_replicas = 3 * max_faulty + 1;
 
-  shared_ptr<EventUpdateQueue> update_queue = make_shared<BasicEventUpdateQueue>();
+  shared_ptr<TrcQueue> update_queue = make_shared<TrcQueue>();
   auto record = make_shared<ThinReplicaCommunicationRecord>();
 
   auto server_recorders = CreateMockServerRecorders(num_replicas, stream_preparer, hasher, record);
@@ -89,7 +89,7 @@ TEST(trc_rpc_use_test, test_trc_subscribe) {
   uint16_t max_faulty = 3;
   size_t num_replicas = 3 * max_faulty + 1;
 
-  shared_ptr<EventUpdateQueue> update_queue = make_shared<BasicEventUpdateQueue>();
+  shared_ptr<TrcQueue> update_queue = make_shared<TrcQueue>();
   auto record = make_shared<ThinReplicaCommunicationRecord>();
 
   auto server_recorders = CreateMockServerRecorders(num_replicas, stream_preparer, hasher, record);


### PR DESCRIPTION
The queue b/w TRC and event service is expected to have an update at most times. Additionally event service currently doesn't allow concurrent subscription streams from the same subscriber. Hence, currently we do not expect contention for reading from the queue.
Thus, lockfree queue is a more performant alternative to thread_safe_queue which uses locks.
Note the queue size is set to 10000 by default. Without event groups enabled we haven't see > 20 updates per second in the TRC queue, and with event groups we haven't > 1000 updates per second in the TRC queue, hence, 10k should be a sufficiently large queue size.
    
For testing, unit tests have been updated to reflect the change in queue type. Performance testing is being done in parallel.
