### PR TITLE
BC-23268 Fix : Decreased the log level from INFO to DEBUG.

### DIFF
--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -529,10 +529,10 @@ std::optional<categorization::Value> KeyValueBlockchain::getValueFromUpdate(
 std::optional<categorization::Value> KeyValueBlockchain::get(const std::string &category_id,
                                                              const std::string &key,
                                                              BlockId block_id) const {
-  LOG_INFO(V4_BLOCK_LOG,
-           "Explicit get on key " << std::hash<std::string>{}(key) << " from version " << block_id << " category_id "
-                                  << category_id << " key is hex " << concordUtils::bufferToHex(key.data(), key.size())
-                                  << " raw key " << key);
+  LOG_DEBUG(V4_BLOCK_LOG,
+            "Explicit get on key " << std::hash<std::string>{}(key) << " from version " << block_id << " category_id "
+                                   << category_id << " key is hex " << concordUtils::bufferToHex(key.data(), key.size())
+                                   << " raw key " << key);
   auto updates_in_block = block_chain_.getBlockUpdates(block_id);
   if (!updates_in_block) {
     return std::nullopt;


### PR DESCRIPTION
 Author:    anshubit5516 <anshubit5516@gmail.com>
 Date:      Mon Sep 5 03:16:13 2022 -0700
 Committer: root <root@sc2-10-187-131-143.nimbus.eng.vmware.com>


[BC-23268] : Junk characters "��3��`���(U� �K}s" observed in concord logs of Ethereum VMBC

Since that log was added just to debug purpose, hence corrected  the log level to debug only.

