### PR TITLE
Fix unreleased client request batches

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -127,7 +127,8 @@ RequestStateSharedPtr &RequestsBatch::getRequestState(uint16_t reqOffsetInBatch)
 
 void RequestsBatch::increaseNumOfCompletedReqs(uint32_t count) {
   numOfCompletedReqs_ += count;
-  LOG_DEBUG(preProcessor_.logger(), KVLOG(numOfCompletedReqs_));
+  LOG_DEBUG(preProcessor_.logger(),
+            "Increased a number of completed requests" << KVLOG(clientId_, batchCid_, batchSize_, numOfCompletedReqs_));
 }
 
 void RequestsBatch::handlePossiblyExpiredRequests() {
@@ -1483,11 +1484,11 @@ void PreProcessor::releaseClientPreProcessRequestSafe(uint16_t clientId,
 void PreProcessor::releaseClientPreProcessRequest(const RequestStateSharedPtr &reqEntry, PreProcessingResult result) {
   auto &givenReq = reqEntry->reqProcessingStatePtr;
   if (givenReq) {
-    const auto &clientId = givenReq->getClientId();
-    const auto &reqOffsetInBatch = givenReq->getReqOffsetInBatch();
-    const auto &batchCid = givenReq->getBatchCid();
+    const auto clientId = givenReq->getClientId();
+    const auto reqOffsetInBatch = givenReq->getReqOffsetInBatch();
+    const auto batchCid = givenReq->getBatchCid();
     auto reqSeqNum = givenReq->getReqSeqNum();
-    auto &reqCid = givenReq->getReqCid();
+    auto reqCid = givenReq->getReqCid();
     if (result == COMPLETE) {
       if (reqEntry->reqProcessingHistory.size() >= reqEntry->reqProcessingHistoryHeight) {
         auto &removeFromHistoryReq = reqEntry->reqProcessingHistory.front();

--- a/bftengine/src/preprocessor/RequestProcessingState.cpp
+++ b/bftengine/src/preprocessor/RequestProcessingState.cpp
@@ -194,7 +194,8 @@ auto RequestProcessingState::calculateMaxNbrOfEqualHashes(uint16_t &maxNumOfEqua
 bool RequestProcessingState::isReqTimedOut() const {
   if (!clientPreProcessReqMsg_) return false;
 
-  LOG_DEBUG(logger(), KVLOG(preprocessingRightNow_));
+  LOG_DEBUG(logger(),
+            "Check if request timed out" << KVLOG(clientId_, batchCid_, reqSeqNum_, reqCid_, preprocessingRightNow_));
   if (!preprocessingRightNow_) {
     // Check request timeout once an asynchronous pre-execution completed (to not abort the execution thread)
     auto reqProcessingTime = getMonotonicTimeMilli() - entryTime_;


### PR DESCRIPTION
* **Problem Overview**  
  We observe that after a VC, the system performance degrades. One of the issues that caused this degradation is an 
  expired client batch that does not get released and as a result, prevents from the corresponding client accepting new 
  requests. The issue that caused the batch not to be occasionally released is the use of the batchCid variable, defined
  as a reference to the corresponding request field. According to the function logic, the request gets moved and the
  variable becomes empty. The use of the moved variables is undefined, that's why we observed an unstable batch
  release behavior.  
* **Testing Done**  
  Tested on a reserved system doing interruption tests.
