### PR TITLE
Add de/serialization to the new utt API

### DIFF
--- a/utt/include/UTTParams.hpp
+++ b/utt/include/UTTParams.hpp
@@ -14,6 +14,12 @@
 #pragma once
 #include <string>
 #include <memory>
+namespace libutt::api {
+class UTTParams;
+}
+std::ostream& operator<<(std::ostream& out, const libutt::api::UTTParams& params);
+std::istream& operator>>(std::istream& in, libutt::api::UTTParams& params);
+bool operator==(const libutt::api::UTTParams& params1, const libutt::api::UTTParams& params2);
 namespace libutt {
 class Params;
 }
@@ -49,6 +55,9 @@ class UTTParams {
   UTTParams& operator=(const UTTParams& other);
 
  private:
+  friend std::ostream& ::operator<<(std::ostream& out, const libutt::api::UTTParams& params);
+  friend std::istream& ::operator>>(std::istream& in, libutt::api::UTTParams& params);
+  friend bool ::operator==(const libutt::api::UTTParams& params1, const libutt::api::UTTParams& params2);
   std::unique_ptr<libutt::Params> params;
 };
 }  // namespace libutt::api

--- a/utt/include/budget.hpp
+++ b/utt/include/budget.hpp
@@ -18,6 +18,12 @@
 #include "types.hpp"
 #include <string>
 namespace libutt::api::operations {
+class Budget;
+}
+
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Budget& budget);
+std::istream& operator>>(std::istream& in, libutt::api::operations::Budget& budget);
+namespace libutt::api::operations {
 /**
  * @brief
  * The Budget is used for creating an initial budget coin. This can ber viewed as a mint operation for budget coin.
@@ -43,6 +49,7 @@ class Budget {
    * @param exp_date Expiration date, the format is to be determined by an upper level
    */
   Budget(const UTTParams& p, const types::CurvePoint& pidHash, uint64_t val, uint64_t exp_date);
+  Budget() {}
 
   /**
    * @brief Get the Coin object
@@ -61,6 +68,8 @@ class Budget {
   std::string getHashHex() const;
 
  private:
+  friend std::ostream& ::operator<<(std::ostream& out, const libutt::api::operations::Budget& budget);
+  friend std::istream& ::operator>>(std::istream& in, libutt::api::operations::Budget& budget);
   libutt::api::Coin coin_;
 };
 }  // namespace libutt::api::operations

--- a/utt/include/burn.hpp
+++ b/utt/include/burn.hpp
@@ -20,6 +20,13 @@
 namespace libutt {
 class BurnOp;
 }
+
+namespace libutt::api::operations {
+class Burn;
+}
+
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Burn& burn);
+std::istream& operator>>(std::istream& in, libutt::api::operations::Burn& burn);
 namespace libutt::api::operations {
 /**
  * @brief This object represent a Burn operation.
@@ -35,7 +42,9 @@ class Burn {
    * @param coin_to_burn The coin we want to burn
    */
   Burn(const UTTParams& p, const Client& cid, const Coin& coin_to_burn);
-
+  Burn();
+  Burn(const Burn& other);
+  Burn& operator=(const Burn& other);
   /**
    * @brief Get the Nullifier object, to be used by the bank
    *
@@ -53,7 +62,9 @@ class Burn {
  public:
   friend class libutt::api::CoinsSigner;
   friend class libutt::api::Client;
+  friend std::ostream& ::operator<<(std::ostream& out, const libutt::api::operations::Burn& burn);
+  friend std::istream& ::operator>>(std::istream& in, libutt::api::operations::Burn& burn);
   std::unique_ptr<libutt::BurnOp> burn_{nullptr};
-  const Coin& c_;
+  Coin c_;
 };
 }  // namespace libutt::api::operations

--- a/utt/include/coin.hpp
+++ b/utt/include/coin.hpp
@@ -18,10 +18,17 @@
 #include "types.hpp"
 #include <memory>
 #include <optional>
+#include <iostream>
 
 namespace libutt {
 class Coin;
+namespace api {
+class Coin;
 }
+}  // namespace libutt
+
+std::ostream& operator<<(std::ostream& out, const libutt::api::Coin& coin);
+std::istream& operator>>(std::istream& in, libutt::api::Coin& coin);
 namespace libutt::api {
 class Client;
 namespace operations {
@@ -30,7 +37,6 @@ class Mint;
 class Transaction;
 class Budget;
 }  // namespace operations
-
 class Coin {
   /**
    * @brief Represent a UTT coin. A coin can be either a normal value coin or a budget coin. A budget coin is a coin
@@ -38,7 +44,7 @@ class Coin {
    *
    */
  public:
-  enum Type { Normal = 0x0, Budget };
+  enum Type : uint16_t { Normal = 0x0, Budget };
   /**
    * @brief Constructs a new Coin object. This constructor also construct the coin's nullifier. Hence it can be invoked
    * only by the client.
@@ -165,6 +171,8 @@ class Coin {
   friend class operations::Burn;
   friend class operations::Transaction;
   friend class operations::Budget;
+  friend std::ostream& ::operator<<(std::ostream&, const libutt::api::Coin&);
+  friend std::istream& ::operator>>(std::istream&, libutt::api::Coin&);
   std::unique_ptr<libutt::Coin> coin_;
   bool has_sig_{false};
 

--- a/utt/include/commitment.hpp
+++ b/utt/include/commitment.hpp
@@ -26,6 +26,9 @@ namespace libutt::api {
 class Commitment;
 }
 libutt::api::Commitment operator+(libutt::api::Commitment lhs, const libutt::api::Commitment& rhs);
+bool operator==(const libutt::api::Commitment& comm1, const libutt::api::Commitment& comm2);
+std::ostream& operator<<(std::ostream& out, const libutt::api::Commitment& comm);
+std::istream& operator>>(std::istream& in, libutt::api::Commitment& comm);
 namespace libutt::api {
 class Registrator;
 class Client;
@@ -87,6 +90,9 @@ class Commitment {
   friend class Client;
   friend class operations::Burn;
   friend class operations::Transaction;
+  friend std::ostream& ::operator<<(std::ostream& out, const libutt::api::Commitment& comm);
+  friend std::istream& ::operator>>(std::istream& in, libutt::api::Commitment& comm);
+  friend bool ::operator==(const libutt::api::Commitment& comm1, const libutt::api::Commitment& comm2);
   std::unique_ptr<libutt::Comm> comm_;
 };
 }  // namespace libutt::api

--- a/utt/include/mint.hpp
+++ b/utt/include/mint.hpp
@@ -17,6 +17,12 @@
 #include <vector>
 #include "coin.hpp"
 #include "UTTParams.hpp"
+
+namespace libutt::api::operations {
+class Mint;
+}
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Mint& mint);
+std::istream& operator>>(std::istream& in, libutt::api::operations::Mint& mint);
 namespace libutt {
 class MintOp;
 }
@@ -40,6 +46,9 @@ class Mint {
    * @param recipPID The recipient id
    */
   Mint(const std::string& uniqueHash, size_t value, const std::string& recipPID);
+  Mint();
+  Mint(const Mint& other);
+  Mint& operator=(const Mint& other);
   std::string getHash() const;
   uint64_t getVal() const;
   std::string getRecipentID() const;
@@ -47,6 +56,8 @@ class Mint {
  private:
   friend class libutt::api::CoinsSigner;
   friend class libutt::api::Client;
+  friend std::ostream& ::operator<<(std::ostream& out, const libutt::api::operations::Mint& mint);
+  friend std::istream& ::operator>>(std::istream& in, libutt::api::operations::Mint& mint);
   std::unique_ptr<libutt::MintOp> op_;
 };
 }  // namespace libutt::api::operations

--- a/utt/include/serialization.hpp
+++ b/utt/include/serialization.hpp
@@ -1,0 +1,35 @@
+// UTT
+//
+// Copyright (c) 2020-2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#include <iostream>
+#include <vector>
+#include <sstream>
+namespace libutt::api {
+
+template <typename T>
+std::vector<uint8_t> serialize(const T& data) {
+  std::stringstream ss;
+  ss << data;
+  const auto& str_data = ss.str();
+  return std::vector<uint8_t>(str_data.begin(), str_data.end());
+}
+template <typename T>
+T deserialize(const std::vector<uint8_t>& data) {
+  std::stringstream ss;
+  std::string str_data(data.begin(), data.end());
+  ss.str(str_data);
+  T ret;
+  ss >> ret;
+  return ret;
+}
+};  // namespace libutt::api

--- a/utt/include/transaction.hpp
+++ b/utt/include/transaction.hpp
@@ -20,6 +20,14 @@
 #include <memory>
 #include <optional>
 #include <vector>
+
+namespace libutt::api::operations {
+class Transaction;
+}
+
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Transaction& tx);
+std::istream& operator>>(std::istream& in, libutt::api::operations::Transaction& tx);
+
 namespace libutt {
 class Tx;
 class IEncryptor;
@@ -50,6 +58,7 @@ class Transaction {
               const std::optional<Coin>& budget_coin,
               const std::vector<std::tuple<std::string, uint64_t>>& recipients,
               const IEncryptor& encryptor);
+  Transaction();
   /**
    * @brief Get the transaction's nullifiers
    *
@@ -74,6 +83,8 @@ class Transaction {
  private:
   friend class libutt::api::CoinsSigner;
   friend class libutt::api::Client;
+  friend std::ostream& ::operator<<(std::ostream& out, const libutt::api::operations::Transaction& tx);
+  friend std::istream& ::operator>>(std::istream& in, libutt::api::operations::Transaction& tx);
   std::shared_ptr<libutt::Tx> tx_;
   std::vector<Coin> input_coins_;
   std::optional<Coin> budget_coin_;

--- a/utt/libutt/include/utt/BurnOp.h
+++ b/utt/libutt/include/utt/BurnOp.h
@@ -43,7 +43,7 @@ class BurnOp {
          std::optional<RandSigPK> bpk,
          const RegAuthPK& rpk);
   BurnOp(std::istream& in);
-
+  BurnOp() {}
   BurnOp(const BurnOp& o);
 
   virtual ~BurnOp();

--- a/utt/libutt/include/utt/MintOp.h
+++ b/utt/libutt/include/utt/MintOp.h
@@ -42,6 +42,7 @@ class MintOp {
   MintOp(const std::string& uniqueHash, size_t value, const std::string& recipPID);
 
   MintOp(std::istream& in);
+  MintOp() {}
   const std::string& getClientId() const { return clientId; }
   size_t getSize() const { return _fr_size * 3; }
 

--- a/utt/libutt/src/api/UTTParams.cpp
+++ b/utt/libutt/src/api/UTTParams.cpp
@@ -5,6 +5,20 @@
 #include <utt/NtlLib.h>
 #include <utt/Params.h>
 
+std::ostream& operator<<(std::ostream& out, const libutt::api::UTTParams& params) {
+  out << params.getParams();
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::UTTParams& params) {
+  params.params.reset(new libutt::Params());
+  in >> *(params.params);
+  return in;
+}
+bool operator==(const libutt::api::UTTParams& params1, const libutt::api::UTTParams& params2) {
+  if (!params1.params && !params2.params) return true;
+  if (!params1.params || !params2.params) return false;
+  return *(params1.params) == *(params2.params);
+}
 namespace libutt::api {
 using Fr = typename libff::default_ec_pp::Fp_type;
 struct GpInitData {

--- a/utt/libutt/src/api/budget.cpp
+++ b/utt/libutt/src/api/budget.cpp
@@ -5,6 +5,15 @@
 #include <utt/PolyCrypto.h>
 #include <utt/Serialization.h>
 
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Budget& budget) {
+  out << budget.coin_;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::operations::Budget& budget) {
+  in >> budget.coin_;
+  return in;
+}
+
 namespace libutt::api::operations {
 Budget::Budget(const UTTParams& d, const libutt::api::Client& cid, uint64_t val, uint64_t exp_date) {
   Fr fr_val;
@@ -32,7 +41,6 @@ Budget::Budget(const UTTParams& d, const types::CurvePoint& pidHash, uint64_t va
                             libutt::api::Coin::Type::Budget,
                             fr_expdate.to_words());
 }
-
 libutt::api::Coin& Budget::getCoin() { return coin_; }
 const libutt::api::Coin& Budget::getCoin() const { return coin_; }
 std::string Budget::getHashHex() const {

--- a/utt/libutt/src/api/burn.cpp
+++ b/utt/libutt/src/api/burn.cpp
@@ -6,7 +6,20 @@
 #include <utt/Params.h>
 #include <utt/Serialization.h>
 #include <utt/RegAuth.h>
+#include <ostream>
 
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Burn& burn) {
+  out << *(burn.burn_) << std::endl;
+  out << burn.c_ << std::endl;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::operations::Burn& burn) {
+  in >> *(burn.burn_);
+  libff::consume_OUTPUT_NEWLINE(in);
+  in >> burn.c_;
+  libff::consume_OUTPUT_NEWLINE(in);
+  return in;
+}
 namespace libutt::api::operations {
 Burn::Burn(const UTTParams& d, const Client& cid, const Coin& coin) : c_{coin} {
   Fr fr_pidhash;
@@ -19,6 +32,13 @@ Burn::Burn(const UTTParams& d, const Client& cid, const Coin& coin) : c_{coin} {
   auto& rpk = *(cid.rpk_);
   burn_.reset(new libutt::BurnOp(
       d.getParams(), fr_pidhash, cid.getPid(), *(rcm.first.comm_), rcm_sig, prf, *(coin.coin_), *(cid.bpk_), rpk));
+}
+Burn::Burn() { burn_.reset(new libutt::BurnOp()); }
+Burn::Burn(const Burn& other) : Burn() { *(burn_) = *(other.burn_); }
+Burn& Burn::operator=(const Burn& other) {
+  if (&other == this) return *this;
+  *(burn_) = *(other.burn_);
+  return *this;
 }
 std::string Burn::getNullifier() const { return burn_->getNullifier(); }
 const Coin& Burn::getCoin() const { return c_; }

--- a/utt/libutt/src/api/coin.cpp
+++ b/utt/libutt/src/api/coin.cpp
@@ -3,6 +3,22 @@
 #include <utt/Params.h>
 #include <utt/Serialization.h>
 #include <utt/RandSig.h>
+#include <ostream>
+
+std::ostream& operator<<(std::ostream& out, const libutt::api::Coin& coin) {
+  out << coin.has_sig_ << std::endl;
+  out << *(coin.coin_) << std::endl;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::Coin& coin) {
+  coin.coin_.reset(new libutt::Coin());
+  in >> coin.has_sig_;
+  libff::consume_OUTPUT_NEWLINE(in);
+  in >> *(coin.coin_);
+  libff::consume_OUTPUT_NEWLINE(in);
+  coin.type_ = coin.coin_->isNormal() ? libutt::api::Coin::Type::Normal : libutt::api::Coin::Type::Budget;
+  return in;
+}
 
 namespace libutt::api {
 Coin::Coin(const UTTParams& d,

--- a/utt/libutt/src/api/commitment.cpp
+++ b/utt/libutt/src/api/commitment.cpp
@@ -12,6 +12,20 @@ libutt::api::Commitment operator+(libutt::api::Commitment lhs, const libutt::api
   return lhs;
 }
 
+std::ostream& operator<<(std::ostream& out, const libutt::api::Commitment& comm) {
+  out << *(comm.comm_);
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::Commitment& comm) {
+  in >> *(comm.comm_);
+  return in;
+}
+
+bool operator==(const libutt::api::Commitment& comm1, const libutt::api::Commitment& comm2) {
+  if (!comm1.comm_ && !comm2.comm_) return true;
+  if (!comm1.comm_ || !comm2.comm_) return false;
+  return *(comm1.comm_) == *(comm2.comm_);
+}
 namespace libutt::api {
 const libutt::CommKey& Commitment::getCommitmentKey(const UTTParams& d, Commitment::Type t) {
   switch (t) {

--- a/utt/libutt/src/api/mint.cpp
+++ b/utt/libutt/src/api/mint.cpp
@@ -6,9 +6,29 @@
 #include <utt/Coin.h>
 #include <utt/Serialization.h>
 
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Mint& mint) {
+  out << *(mint.op_);
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::operations::Mint& mint) {
+  in >> *(mint.op_);
+  return in;
+}
+
 namespace libutt::api::operations {
 Mint::Mint(const std::string& uniqueHash, size_t value, const std::string& recipPID) {
   op_.reset(new libutt::MintOp(uniqueHash, value, recipPID));
+}
+Mint::Mint() { op_.reset(new libutt::MintOp()); }
+Mint::Mint(const Mint& other) {
+  op_.reset(new libutt::MintOp());
+  *(op_) = *(other.op_);
+}
+
+Mint& Mint::operator=(const Mint& other) {
+  if (this == &other) return *this;
+  *(op_) = *(other.op_);
+  return *this;
 }
 
 std::string Mint::getHash() const { return op_->getHashHex(); }

--- a/utt/libutt/src/api/transaction.cpp
+++ b/utt/libutt/src/api/transaction.cpp
@@ -6,6 +6,20 @@
 #include <utt/Coin.h>
 #include <utt/Address.h>
 #include <utt/DataUtils.hpp>
+
+std::ostream& operator<<(std::ostream& out, const libutt::api::operations::Transaction& tx) {
+  out << *(tx.tx_) << std::endl;
+  libutt::serializeVector(out, tx.input_coins_);
+  out << tx.budget_coin_;
+  return out;
+}
+std::istream& operator>>(std::istream& in, libutt::api::operations::Transaction& tx) {
+  in >> *(tx.tx_);
+  libff::consume_OUTPUT_NEWLINE(in);
+  libutt::deserializeVector(in, tx.input_coins_);
+  in >> tx.budget_coin_;
+  return in;
+}
 namespace libutt::api::operations {
 Transaction::Transaction(const UTTParams& d,
                          const Client& cid,
@@ -52,6 +66,7 @@ Transaction::Transaction(const UTTParams& d,
                            rpk.vk,
                            encryptor));
 }
+Transaction::Transaction() { tx_.reset(new libutt::Tx()); }
 std::vector<std::string> Transaction::getNullifiers() const { return tx_->getNullifiers(); }
 const std::vector<Coin>& Transaction::getInputCoins() const { return input_coins_; }
 std::optional<Coin> Transaction::getBudgetCoin() const { return budget_coin_; }

--- a/utt/tests/CMakeLists.txt
+++ b/utt/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(newutt_test_sources
     TestBudget.cpp
     TestTransaction.cpp
     TestTransactionWithRsaEncryption.cpp
+    TestSerialization.cpp
 )
 
 foreach(appSrc ${newutt_test_sources})

--- a/utt/tests/TestSerialization.cpp
+++ b/utt/tests/TestSerialization.cpp
@@ -1,0 +1,203 @@
+#include "testUtils.hpp"
+#include "coin.hpp"
+#include "budget.hpp"
+#include "burn.hpp"
+#include "mint.hpp"
+#include "commitment.hpp"
+#include "transaction.hpp"
+#include <utt/Coin.h>
+#include <utt/MintOp.h>
+#include <utt/BurnOp.h>
+#include <utt/DataUtils.hpp>
+#include "serialization.hpp"
+using namespace libutt;
+using namespace libutt::api;
+using namespace libutt::api::operations;
+
+int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+
+  size_t thresh = 3;
+  size_t n = 4;
+  size_t c = 2;
+  auto [d, dkg, rc] = testing::init(n, thresh);
+  auto registrators = testing::GenerateRegistrators(n, rc);
+  auto banks = testing::GenerateCommitters(n, dkg, rc.toPK());
+  auto clients = testing::GenerateClients(c, dkg.getPK(), rc.toPK(), rc);
+  for (auto& c : clients) {
+    testing::registerClient(d, c, registrators, thresh);
+  }
+  std::vector<uint8_t> serialized_params = libutt::api::serialize<libutt::api::UTTParams>(d);
+  auto deserialized_params = libutt::api::deserialize<libutt::api::UTTParams>(serialized_params);
+  assertTrue(deserialized_params == d);
+
+  Commitment rcm = clients[0].getRcm().first;
+  std::vector<uint8_t> serialized_rcm = libutt::api::serialize<libutt::api::Commitment>(rcm);
+  auto deserialized_rcm = libutt::api::deserialize<libutt::api::Commitment>(serialized_rcm);
+  assertTrue(rcm == deserialized_rcm);
+  Fr fr_val;
+  fr_val.set_ulong(100);
+  libutt::api::Coin c1(d,
+                       Fr::random_element().to_words(),
+                       Fr::random_element().to_words(),
+                       fr_val.to_words(),
+                       Fr::random_element().to_words(),
+                       libutt::api::Coin::Type::Normal,
+                       Fr::random_element().to_words());
+  std::vector<uint8_t> c1_serialized = libutt::api::serialize<libutt::api::Coin>(c1);
+  libutt::api::Coin c1_deserialized = libutt::api::deserialize<libutt::api::Coin>(c1_serialized);
+  assertTrue(c1.getNullifier() == c1_deserialized.getNullifier());
+  assertTrue(c1.hasSig() == c1_deserialized.hasSig());
+  assertTrue(c1.getType() == c1_deserialized.getType());
+  assertTrue(c1.getVal() == c1_deserialized.getVal());
+  assertTrue(c1.getSN() == c1_deserialized.getSN());
+  assertTrue(c1.getExpDateAsCurvePoint() == c1_deserialized.getExpDateAsCurvePoint());
+
+  libutt::api::Coin c2(d,
+                       Fr::random_element().to_words(),
+                       fr_val.to_words(),
+                       Fr::random_element().to_words(),
+                       libutt::api::Coin::Type::Normal,
+                       Fr::random_element().to_words());
+  std::vector<uint8_t> c2_serialized = libutt::api::serialize<libutt::api::Coin>(c2);
+  libutt::api::Coin c2_deserialized = libutt::api::deserialize<libutt::api::Coin>(c2_serialized);
+  assertTrue(c2.getNullifier() == c2_deserialized.getNullifier());
+  assertTrue(c2.hasSig() == c2_deserialized.hasSig());
+  assertTrue(c2.getType() == c2_deserialized.getType());
+  assertTrue(c2.getVal() == c2_deserialized.getVal());
+  assertTrue(c2.getSN() == c2_deserialized.getSN());
+  assertTrue(c2.getExpDateAsCurvePoint() == c2_deserialized.getExpDateAsCurvePoint());
+
+  libutt::api::Coin c3(d,
+                       Fr::random_element().to_words(),
+                       fr_val.to_words(),
+                       Fr::random_element().to_words(),
+                       libutt::api::Coin::Type::Budget,
+                       Fr::random_element().to_words());
+  std::vector<uint8_t> c3_serialized = libutt::api::serialize<libutt::api::Coin>(c3);
+  libutt::api::Coin c3_deserialized = libutt::api::deserialize<libutt::api::Coin>(c3_serialized);
+  assertTrue(c3.getNullifier() == c3_deserialized.getNullifier());
+  assertTrue(c3.hasSig() == c3_deserialized.hasSig());
+  assertTrue(c3.getType() == c3_deserialized.getType());
+  assertTrue(c3.getVal() == c3_deserialized.getVal());
+  assertTrue(c3.getSN() == c3_deserialized.getSN());
+  assertTrue(c3.getExpDateAsCurvePoint() == c3_deserialized.getExpDateAsCurvePoint());
+
+  libutt::api::Coin c4(d,
+                       Fr::random_element().to_words(),
+                       Fr::random_element().to_words(),
+                       fr_val.to_words(),
+                       Fr::random_element().to_words(),
+                       libutt::api::Coin::Type::Budget,
+                       Fr::random_element().to_words());
+  std::vector<uint8_t> c4_serialized = libutt::api::serialize<libutt::api::Coin>(c4);
+  libutt::api::Coin c4_deserialized = libutt::api::deserialize<libutt::api::Coin>(c4_serialized);
+  assertTrue(c4.getNullifier() == c4_deserialized.getNullifier());
+  assertTrue(c4.hasSig() == c4_deserialized.hasSig());
+  assertTrue(c4.getType() == c4_deserialized.getType());
+  assertTrue(c4.getVal() == c4_deserialized.getVal());
+  assertTrue(c4.getSN() == c4_deserialized.getSN());
+  assertTrue(c4.getExpDateAsCurvePoint() == c4_deserialized.getExpDateAsCurvePoint());
+
+  libutt::api::operations::Budget b1(d, Fr::random_element().to_words(), 100, 987654321);
+  std::vector<uint8_t> b1_serialized = libutt::api::serialize<libutt::api::operations::Budget>(b1);
+  libutt::api::operations::Budget b1_deserialized =
+      libutt::api::deserialize<libutt::api::operations::Budget>(b1_serialized);
+  assertTrue(b1.getHashHex() == b1_deserialized.getHashHex());
+  const auto b1_coin = b1.getCoin();
+  const auto c1_deserialized_coin = b1_deserialized.getCoin();
+  assertTrue(b1_coin.getNullifier() == c1_deserialized_coin.getNullifier());
+  assertTrue(b1_coin.hasSig() == c1_deserialized_coin.hasSig());
+  assertTrue(b1_coin.getType() == c1_deserialized_coin.getType());
+  assertTrue(b1_coin.getVal() == c1_deserialized_coin.getVal());
+  assertTrue(b1_coin.getSN() == c1_deserialized_coin.getSN());
+  assertTrue(b1_coin.getExpDateAsCurvePoint() == c1_deserialized_coin.getExpDateAsCurvePoint());
+
+  for (auto& c : clients) {
+    std::vector<std::vector<uint8_t>> rsigs;
+    std::string simulatonOfUniqueTxHash = std::to_string(((uint64_t)rand()) * ((uint64_t)rand()) * ((uint64_t)rand()));
+    auto mint = Mint(simulatonOfUniqueTxHash, 100, c.getPid());
+    std::vector<uint8_t> mint_serialized = libutt::api::serialize<libutt::api::operations::Mint>(mint);
+    auto mint_deserialized = libutt::api::deserialize<libutt::api::operations::Mint>(mint_serialized);
+    assertTrue(mint.getHash() == mint_deserialized.getHash());
+    assertTrue(mint.getVal() == mint_deserialized.getVal());
+    assertTrue(mint.getRecipentID() == mint_deserialized.getRecipentID());
+    for (size_t i = 0; i < banks.size(); i++) {
+      rsigs.push_back(banks[i]->sign(mint).front());
+    }
+    auto sbs = testing::getSubset((uint32_t)n, (uint32_t)thresh);
+    std::map<uint32_t, std::vector<uint8_t>> sigs;
+    for (auto i : sbs) {
+      sigs[i] = rsigs[i];
+    }
+    auto blinded_sig = Utils::aggregateSigShares((uint32_t)n, {sigs});
+    auto coin = c.claimCoins(mint, d, {blinded_sig}).front();
+    libutt::api::operations::Burn b_op{d, c, coin};
+    std::vector<uint8_t> burn_serialized = libutt::api::serialize<libutt::api::operations::Burn>(b_op);
+    auto burn_deserialized = libutt::api::deserialize<libutt::api::operations::Burn>(burn_serialized);
+    assertTrue(b_op.getNullifier() == burn_deserialized.getNullifier());
+    const auto& burn_coin = b_op.getCoin();
+    const auto& burn_deserialized_coin = burn_deserialized.getCoin();
+    assertTrue(burn_coin.getNullifier() == burn_deserialized_coin.getNullifier());
+    assertTrue(burn_coin.hasSig() == burn_deserialized_coin.hasSig());
+    assertTrue(burn_coin.getType() == burn_deserialized_coin.getType());
+    assertTrue(burn_coin.getVal() == burn_deserialized_coin.getVal());
+    assertTrue(burn_coin.getSN() == burn_deserialized_coin.getSN());
+    assertTrue(burn_coin.getExpDateAsCurvePoint() == burn_deserialized_coin.getExpDateAsCurvePoint());
+  }
+  const auto& client1 = clients[0];
+  const auto& client2 = clients[1];
+  std::vector<types::Signature> rsigs;
+  std::string simulatonOfUniqueTxHash = std::to_string(((uint64_t)rand()) * ((uint64_t)rand()) * ((uint64_t)rand()));
+  auto mint = Mint(simulatonOfUniqueTxHash, 100, client1.getPid());
+  for (size_t i = 0; i < banks.size(); i++) {
+    rsigs.push_back(banks[i]->sign(mint).front());
+  }
+  auto sbs = testing::getSubset((uint32_t)n, (uint32_t)thresh);
+  std::map<uint32_t, types::Signature> sigs;
+  for (auto i : sbs) {
+    sigs[i] = rsigs[i];
+  }
+  auto blinded_sig = Utils::aggregateSigShares((uint32_t)n, {sigs});
+  auto coin = client1.claimCoins(mint, d, {blinded_sig}).front();
+
+  rsigs.clear();
+  auto budget = Budget(d, client1, 1000, 123456789);
+  for (size_t i = 0; i < banks.size(); i++) {
+    rsigs.push_back(banks[i]->sign(budget).front());
+  }
+  sbs = testing::getSubset((uint32_t)n, (uint32_t)thresh);
+  sigs.clear();
+  for (auto i : sbs) {
+    sigs[i] = rsigs[i];
+  }
+  blinded_sig = Utils::aggregateSigShares((uint32_t)n, {sigs});
+  auto bcoin = client1.claimCoins(budget, d, {blinded_sig}).front();
+  auto encryptor = std::make_shared<libutt::IBEEncryptor>(rc.toPK().mpk);
+  Transaction tx(d, client1, {coin}, {bcoin}, {{client1.getPid(), 50}, {client2.getPid(), 50}}, *(encryptor));
+
+  std::vector<uint8_t> serialized_tx = libutt::api::serialize<libutt::api::operations::Transaction>(tx);
+  auto deserialized_tx = libutt::api::deserialize<libutt::api::operations::Transaction>(serialized_tx);
+  for (size_t i = 0; i < tx.getInputCoins().size(); i++) {
+    const auto& orig_coin = tx.getInputCoins().at(i);
+    const auto& des_coin = deserialized_tx.getInputCoins().at(i);
+    assertTrue(orig_coin.getNullifier() == des_coin.getNullifier());
+    assertTrue(orig_coin.hasSig() == des_coin.hasSig());
+    assertTrue(orig_coin.getType() == des_coin.getType());
+    assertTrue(orig_coin.getVal() == des_coin.getVal());
+    assertTrue(orig_coin.getSN() == des_coin.getSN());
+    assertTrue(orig_coin.getExpDateAsCurvePoint() == des_coin.getExpDateAsCurvePoint());
+  }
+  assertTrue(tx.getNullifiers() == deserialized_tx.getNullifiers());
+  auto orig_bcoin = tx.getBudgetCoin();
+  auto deserialize_bcoin = deserialized_tx.getBudgetCoin();
+  assertTrue(orig_bcoin->getNullifier() == deserialize_bcoin->getNullifier());
+  assertTrue(orig_bcoin->hasSig() == deserialize_bcoin->hasSig());
+  assertTrue(orig_bcoin->getType() == deserialize_bcoin->getType());
+  assertTrue(orig_bcoin->getVal() == deserialize_bcoin->getVal());
+  assertTrue(orig_bcoin->getSN() == deserialize_bcoin->getSN());
+  assertTrue(orig_bcoin->getExpDateAsCurvePoint() == deserialize_bcoin->getExpDateAsCurvePoint());
+
+  return 0;
+}


### PR DESCRIPTION
Adding de/serialization implementation to the new UTT API.
This is required for allowing a UTT execution engine to handle UTT requests