### PR TITLE
Thread pool support for TRC GRPC connections

### DIFF
--- a/client/thin-replica-client/include/client/thin-replica-client/grpc_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/grpc_connection.hpp
@@ -23,6 +23,7 @@
 #include "assertUtils.hpp"
 #include "thin_replica.grpc.pb.h"
 #include "replica_state_snapshot.grpc.pb.h"
+#include "thread_pool.hpp"
 #include "Logger.hpp"
 
 using namespace std::chrono_literals;
@@ -77,17 +78,29 @@ class GrpcConnection {
   // Possible results of RPC operations a GrpcConnection may report.
   enum class Result { kUnknown, kSuccess, kFailure, kTimeout, kOutOfRange, kNotFound, kEndOfStream };
 
+  static const size_t defaultSubscriptionThreadPoolSize = 1;
+  static const size_t maxSubscriptionThreadPoolSize = 8;
+
   GrpcConnection(const std::string& address,
                  const std::string& client_id,
                  uint16_t data_operation_timeout_seconds,
                  uint16_t hash_operation_timeout_seconds,
-                 uint16_t snapshot_operation_timeout_seconds = 5)
+                 uint16_t snapshot_operation_timeout_seconds = 5,
+                 size_t thread_pool_size = defaultSubscriptionThreadPoolSize)
       : logger_(logging::getLogger("concord.client.thin_replica.trscon")),
         address_(address),
         client_id_(client_id),
+        subscription_pool_size(thread_pool_size),
         data_timeout_(std::chrono::seconds(data_operation_timeout_seconds)),
         hash_timeout_(std::chrono::seconds(hash_operation_timeout_seconds)),
         snapshot_timeout_(std::chrono::seconds(snapshot_operation_timeout_seconds)) {
+    if (thread_pool_size > maxSubscriptionThreadPoolSize) {
+      LOG_WARN(logger_,
+               "Setting to maximum allowed worker thread pool size: " << maxSubscriptionThreadPoolSize
+                                                                      << " instead of requested: " << thread_pool_size);
+      subscription_pool_size = maxSubscriptionThreadPoolSize;
+    }
+    subscription_pool_ = std::make_unique<concord::util::ThreadPool>(thread_pool_size);
     LOG_INFO(logger_,
              KVLOG(data_operation_timeout_seconds, hash_operation_timeout_seconds, snapshot_operation_timeout_seconds));
   }
@@ -211,6 +224,11 @@ class GrpcConnection {
       rss_streams_;
   std::shared_mutex rss_streams_mutex_;
   std::atomic_uint64_t current_req_id_{1};
+
+  // Reader threads
+  std::unique_ptr<concord::util::ThreadPool> subscription_pool_;
+  // size of subscription thread pool
+  std::size_t subscription_pool_size;
 
   // gRPC connection
   std::shared_ptr<grpc::Channel> channel_;

--- a/client/thin-replica-client/include/client/thin-replica-client/grpc_connection.hpp
+++ b/client/thin-replica-client/include/client/thin-replica-client/grpc_connection.hpp
@@ -78,29 +78,19 @@ class GrpcConnection {
   // Possible results of RPC operations a GrpcConnection may report.
   enum class Result { kUnknown, kSuccess, kFailure, kTimeout, kOutOfRange, kNotFound, kEndOfStream };
 
-  static const size_t defaultSubscriptionThreadPoolSize = 1;
-  static const size_t maxSubscriptionThreadPoolSize = 8;
-
   GrpcConnection(const std::string& address,
                  const std::string& client_id,
                  uint16_t data_operation_timeout_seconds,
                  uint16_t hash_operation_timeout_seconds,
-                 uint16_t snapshot_operation_timeout_seconds = 5,
-                 size_t thread_pool_size = defaultSubscriptionThreadPoolSize)
+                 uint16_t snapshot_operation_timeout_seconds = 5)
       : logger_(logging::getLogger("concord.client.thin_replica.trscon")),
         address_(address),
         client_id_(client_id),
-        subscription_pool_size(thread_pool_size),
         data_timeout_(std::chrono::seconds(data_operation_timeout_seconds)),
         hash_timeout_(std::chrono::seconds(hash_operation_timeout_seconds)),
         snapshot_timeout_(std::chrono::seconds(snapshot_operation_timeout_seconds)) {
-    if (thread_pool_size > maxSubscriptionThreadPoolSize) {
-      LOG_WARN(logger_,
-               "Setting to maximum allowed worker thread pool size: " << maxSubscriptionThreadPoolSize
-                                                                      << " instead of requested: " << thread_pool_size);
-      subscription_pool_size = maxSubscriptionThreadPoolSize;
-    }
-    subscription_pool_ = std::make_unique<concord::util::ThreadPool>(thread_pool_size);
+    grpc_connection_pool_ = std::make_unique<concord::util::ThreadPool>(1);
+    ConcordAssertNE(grpc_connection_pool_, nullptr);
     LOG_INFO(logger_,
              KVLOG(data_operation_timeout_seconds, hash_operation_timeout_seconds, snapshot_operation_timeout_seconds));
   }
@@ -226,9 +216,7 @@ class GrpcConnection {
   std::atomic_uint64_t current_req_id_{1};
 
   // Reader threads
-  std::unique_ptr<concord::util::ThreadPool> subscription_pool_;
-  // size of subscription thread pool
-  std::size_t subscription_pool_size;
+  std::unique_ptr<concord::util::ThreadPool> grpc_connection_pool_;
 
   // gRPC connection
   std::shared_ptr<grpc::Channel> channel_;

--- a/client/thin-replica-client/src/grpc_connection.cpp
+++ b/client/thin-replica-client/src/grpc_connection.cpp
@@ -33,7 +33,6 @@ using grpc::Status;
 using grpc_connectivity_state::GRPC_CHANNEL_READY;
 
 using std::future_status;
-using std::launch;
 
 using namespace std::chrono_literals;
 
@@ -123,7 +122,7 @@ GrpcConnection::Result GrpcConnection::openDataStream(const SubscriptionRequest&
   data_context_.reset(new grpc::ClientContext());
   data_context_->AddMetadata("client_id", client_id_);
 
-  auto stream = async(launch::async, [this, &request] {
+  auto stream = subscription_pool_->async([this, &request] {
     ReadLock read_lock(channel_mutex_);
     return trc_stub_->SubscribeToUpdates(data_context_.get(), request);
   });
@@ -171,7 +170,7 @@ GrpcConnection::Result GrpcConnection::readData(Data* data) {
   ConcordAssertNE(data_stream_, nullptr);
   ConcordAssertNE(data_context_, nullptr);
 
-  auto result = async(launch::async, [this, data] { return data_stream_->Read(data); });
+  auto result = subscription_pool_->async([this, data] { return data_stream_->Read(data); });
   auto status = result.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
     LOG_WARN(logger_, KVLOG(address_, client_id_));
@@ -200,7 +199,7 @@ GrpcConnection::Result GrpcConnection::openStateStream(const ReadStateRequest& r
   state_context_.reset(new grpc::ClientContext());
   state_context_->AddMetadata("client_id", client_id_);
 
-  auto stream = async(launch::async, [this, &request] {
+  auto stream = subscription_pool_->async([this, &request] {
     ReadLock read_lock(channel_mutex_);
     return trc_stub_->ReadState(state_context_.get(), request);
   });
@@ -248,7 +247,7 @@ GrpcConnection::Result GrpcConnection::closeStateStream() {
   ConcordAssertNE(state_context_, nullptr);
 
   // "state" is not an infite data stream and we expect proper termination
-  auto result = async(launch::async, [this] { return state_stream_->Finish(); });
+  auto result = subscription_pool_->async([this] { return state_stream_->Finish(); });
   auto status = result.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
     LOG_WARN(logger_, KVLOG(address_, client_id_));
@@ -280,7 +279,7 @@ GrpcConnection::Result GrpcConnection::readState(Data* data) {
   ConcordAssertNE(state_stream_, nullptr);
   ConcordAssertNE(state_context_, nullptr);
 
-  auto result = async(launch::async, [this, data] { return state_stream_->Read(data); });
+  auto result = subscription_pool_->async([this, data] { return state_stream_->Read(data); });
   auto status = result.wait_for(data_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
     LOG_WARN(logger_, KVLOG(address_, client_id_));
@@ -301,7 +300,7 @@ GrpcConnection::Result GrpcConnection::readStateHash(const ReadStateHashRequest&
 
   ClientContext context;
   context.AddMetadata("client_id", client_id_);
-  auto result = async(launch::async, [this, &context, &request, hash] {
+  auto result = subscription_pool_->async([this, &context, &request, hash] {
     ReadLock read_lock(channel_mutex_);
     return trc_stub_->ReadStateHash(&context, request, hash);
   });
@@ -337,7 +336,7 @@ GrpcConnection::Result GrpcConnection::openHashStream(SubscriptionRequest& reque
   hash_context_.reset(new grpc::ClientContext());
   hash_context_->AddMetadata("client_id", client_id_);
 
-  auto stream = async(launch::async, [this, &request] {
+  auto stream = subscription_pool_->async([this, &request] {
     ReadLock read_lock(channel_mutex_);
     return trc_stub_->SubscribeToUpdateHashes(hash_context_.get(), request);
   });
@@ -385,7 +384,7 @@ GrpcConnection::Result GrpcConnection::readHash(Hash* hash) {
   ConcordAssertNE(hash_stream_, nullptr);
   ConcordAssertNE(hash_context_, nullptr);
 
-  auto result = async(launch::async, [this, hash] { return hash_stream_->Read(hash); });
+  auto result = subscription_pool_->async([this, hash] { return hash_stream_->Read(hash); });
   auto status = result.wait_for(hash_timeout_);
   if (status == future_status::timeout || status == future_status::deferred) {
     LOG_WARN(logger_, KVLOG(address_, client_id_));
@@ -417,7 +416,7 @@ GrpcConnection::Result GrpcConnection::openStateSnapshotStream(
   std::unique_ptr<grpc::ClientReaderInterface<vmware::concord::replicastatesnapshot::StreamSnapshotResponse>>
       snapshot_stream;
 
-  auto stream = async(launch::async, [this, &request, &snapshot_context] {
+  auto stream = subscription_pool_->async([this, &request, &snapshot_context] {
     ReadLock read_lock(channel_mutex_);
     return rss_stub_->StreamSnapshot(snapshot_context.get(), request);
   });
@@ -506,7 +505,7 @@ bool GrpcConnection::hasStateSnapshotStream(RequestId request_id) {
 
 GrpcConnection::Result GrpcConnection::readStateSnapshot(
     RequestId request_id, vmware::concord::replicastatesnapshot::StreamSnapshotResponse* snapshot_response) {
-  auto result = async(launch::async, [this, snapshot_response, request_id] {
+  auto result = subscription_pool_->async([this, snapshot_response, request_id] {
     ReadLock read_lock(rss_streams_mutex_);
     return (((this->rss_streams_)[request_id]).second)->Read(snapshot_response);
   });


### PR DESCRIPTION
The current TRC GRPC connections (client) spawns new threads using std::async launch on various API flow. This support enables async processing launched on the thread pool threads instead of spawning them dynamically. The size of thread pool can be tuned in future. For meantime the thread pool comprise of single subscription thread.

The update is regressed using current suite of tests. Performance test was performed using this branch with event group feature toggled to validate TPS and other memory resources.