### PR TITLE
Merged debug logs from Preprocessor,AsyncTlsConnection and changed IN…

### DIFF
--- a/bftengine/src/bftengine/DbCheckpointManager.cpp
+++ b/bftengine/src/bftengine/DbCheckpointManager.cpp
@@ -371,7 +371,7 @@ void DbCheckpointManager::updateMetrics() {
     lastDbCheckpointSizeInMb_.Get().Set(lastDbCheckpointSize / (1024 * 1024));
     metrics_.UpdateAggregator();
     LOG_INFO(getLogger(), "rocksdb check point id:" << it->first << ", size: " << HumanReadable{lastDbCheckpointSize});
-    LOG_INFO(GL, "-- RocksDb checkpoint metrics dump--" + metrics_.ToJson());
+    LOG_DEBUG(GL, "-- RocksDb checkpoint metrics dump--" + metrics_.ToJson());
   }
 }
 void DbCheckpointManager::updateLastCmdInfo(const SeqNum& seqNum, const std::optional<Timestamp>& timestamp) {

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -710,9 +710,6 @@ bool PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
   const NodeIdType &clientId = clientMsg->clientProxyId();
   const ReqId &reqSeqNum = clientMsg->requestSeqNum();
   const auto &reqCid = clientMsg->getCid();
-  LOG_DEBUG(
-      logger(),
-      "Handle Request:" << KVLOG(batchCid, reqSeqNum, reqCid, clientId, senderId, arrivedInBatch, reqOffsetInBatch));
 
   bool registerSucceeded = false;
   {
@@ -744,8 +741,9 @@ bool PreProcessor::handleSingleClientRequestMessage(ClientPreProcessReqMsgUnique
     return true;
   }
   LOG_DEBUG(logger(),
-            "ClientPreProcessRequestMsg" << KVLOG(batchCid, reqSeqNum, reqCid, clientId, senderId)
-                                         << " is ignored because request is old/duplicated");
+            "ClientPreProcessRequestMsg"
+                << KVLOG(batchCid, reqSeqNum, reqCid, clientId, senderId, arrivedInBatch, reqOffsetInBatch)
+                << " is ignored because request is old/duplicated");
   preProcessorMetrics_.preProcReqIgnored++;
   return false;
 }

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -238,7 +238,6 @@ void AsyncTlsConnection::write(std::shared_ptr<OutgoingMsg> msg) {
     LOG_ERROR(logger_, "write_msg_ already in use by other thread, msg pushed to the write queue.");
     return;
   }
-  LOG_DEBUG(logger_, "Writing" << KVLOG(write_msg_->msg.size()));
 
   // We don't want to include tcp transmission time.
   histograms_.send_time_in_queue->recordAtomic(durationInMicros(write_msg_->send_time));
@@ -270,7 +269,7 @@ void AsyncTlsConnection::write(std::shared_ptr<OutgoingMsg> msg) {
         write_msg_used_ = false;
         write(write_queue_.pop());
       }));
-  LOG_DEBUG(logger_, "Write:" << KVLOG(peer_id_.value()));
+  LOG_DEBUG(logger_, "Write:" << KVLOG(peer_id_.value(), write_msg_->msg.size()));
   startWriteTimer();
 }
 


### PR DESCRIPTION
…FO to DEBUG in DbCheckpointManager

1. Found 2 logs in PreProcessor.cpp under handleSingleClientRequestMessage method, which were printing debug logs for client request handling hence merged them.
2. Similarly in AsyncTlsConnection.cpp under write, merged 2 debug logs. 
3. Under DbCheckpointManager.cpp changed 1 INFO log to DEBUG.
