### PR TITLE
Reorganize ethereum transaction log

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_key_types.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_key_types.h
@@ -25,7 +25,8 @@ const char kKvbKeyEthCode = 0x04;
 const char kKvbKeyEthStorage = 0x05;
 const char kKvbKeyEthNonce = 0x06;
 const char kKvbKeyEthBlockHash = 0x07;
-
+const char kKvbKeyEthEventLog = 0x08;
+ 
 // Unused 0x10 - 0x1f
 
 // Concord 0x20 - 0x2f


### PR DESCRIPTION
* **Problem Overview**  
Currently ethereum transaction logs are stored within transaction structure. For flexibility and improved processing reorganize transaction logs onto its own key space within ethereum block. 

* **Testing Done**  
Regressed with test suites. 