### PR TITLE
Read Only Replica to export last-executed-seq-num starting with 0

### DIFF
--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -68,7 +68,7 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
   } ro_metrics_;
 
   std::unique_ptr<MetadataStorage> metadataStorage_;
-  std::atomic<SeqNum> last_executed_seq_num_;
+  std::atomic<SeqNum> last_executed_seq_num_{0};
 
  private:
   // This function serves as an ReplicaStatusHandlers alternative for ReadOnlyReplica. The reason to use this function


### PR DESCRIPTION
Read Only Replica to export last-executed-seq-num starting with 0

* **Problem Overview** 
After the deployment, Sequence Number is not 0 for the FCC nodes. It happened as last-executed-seq-num was being used without initialization.
* **Testing Done**  
Did few runs in docker compose environment.