### PR TITLE
Disabling test until stabilized.

### DIFF
--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -492,6 +492,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
 
             await bft_network.wait_for_replicas_to_reach_at_least_view(replicas_ids=bft_network.all_replicas(), expected_view=view, timeout=20 + timeouts)
 
+    @unittest.skip("Unstable")
     @with_trio
     @with_bft_network(start_replica_cmd, selected_configs=lambda n, f, c: c == 0, rotate_keys=True)
     @verify_linearizability()


### PR DESCRIPTION
Test test_stop_primary_during_initiated_view_change is failing. We need to stabilize it before re-enabling back.

* **Problem Overview**  
Test test_stop_primary_during_initiated_view_change is failing.
We need to stabilize it before re-enabling back.
* **Testing Done**  
N/A
