### PR TITLE
Fix metric infra to enable tags in Thin Replica Server

### DIFF
--- a/util/include/Metrics.hpp
+++ b/util/include/Metrics.hpp
@@ -37,6 +37,7 @@ using Counter = BasicCounter<uint64_t>;
 using AtomicGauge = BasicGauge<std::atomic_uint64_t>;
 using AtomicCounter = BasicCounter<std::atomic_uint64_t>;
 using Status = BasicStatus<std::string>;
+using TagsMap = std::unordered_map<std::string, std::string>;
 
 // Forward declarations since Aggregator requires these types.
 class Component;
@@ -153,7 +154,7 @@ struct metric_ {
   std::string component;
   std::string name;
   std::variant<Counter, Gauge, Status, SummaryDescription> value;
-  std::unordered_map<std::string, std::string> tag_map;
+  TagsMap tag_map;
 };
 
 /******************************** Class Values ********************************/
@@ -196,11 +197,11 @@ class Names {
 // during initialization.
 class Tags {
  private:
-  std::vector<std::unordered_map<std::string, std::string>> gauge_tags_;
-  std::vector<std::unordered_map<std::string, std::string>> status_tags_;
-  std::vector<std::unordered_map<std::string, std::string>> counter_tags_;
-  std::vector<std::unordered_map<std::string, std::string>> atomic_tags_;
-  std::vector<std::unordered_map<std::string, std::string>> atomic_gauge_tags_;
+  std::vector<TagsMap> gauge_tags_;
+  std::vector<TagsMap> status_tags_;
+  std::vector<TagsMap> counter_tags_;
+  std::vector<TagsMap> atomic_tags_;
+  std::vector<TagsMap> atomic_gauge_tags_;
 
   friend class Component;
   friend class Aggregator;
@@ -256,16 +257,10 @@ class Component {
 
   // Create a Gauge, add it to the component and return a reference to the
   // gauge.
-  Handle<Gauge> RegisterGauge(const std::string& name, const uint64_t val);
-  Handle<Gauge> RegisterGauge(const std::string& name,
-                              const uint64_t val,
-                              const std::unordered_map<std::string, std::string>& tag_map);
+  Handle<Gauge> RegisterGauge(const std::string& name, const uint64_t val, const TagsMap& tag_map = {});
   Handle<Status> RegisterStatus(const std::string& name, const std::string& val);
-  Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val);
-  Handle<Counter> RegisterCounter(const std::string& name,
-                                  const uint64_t val,
-                                  const std::unordered_map<std::string, std::string>& tag_map);
-  Handle<Counter> RegisterCounter(const std::string& name) { return RegisterCounter(name, 0); }
+  Handle<Counter> RegisterCounter(const std::string& name, const uint64_t val, const TagsMap& tag_map = {});
+  Handle<Counter> RegisterCounter(const std::string& name) { return RegisterCounter(name, 0, {}); }
   Handle<AtomicCounter> RegisterAtomicCounter(const std::string& name, const uint64_t val);
   Handle<AtomicCounter> RegisterAtomicCounter(const std::string& name) { return RegisterAtomicCounter(name, 0); }
   Handle<AtomicGauge> RegisterAtomicGauge(const std::string& name, const uint64_t val);

--- a/util/src/Metrics.cpp
+++ b/util/src/Metrics.cpp
@@ -39,15 +39,7 @@ T FindValue(const char* const val_type, const string& val_name, const vector<str
 
 /******************************** Class Component ********************************/
 
-Component::Handle<Gauge> Component::RegisterGauge(const string& name, const uint64_t val) {
-  names_.gauge_names_.emplace_back(name);
-  values_.gauges_.emplace_back(Gauge(val));
-  return Component::Handle<Gauge>(values_.gauges_, values_.gauges_.size() - 1, metricsEnabled_);
-}
-
-Component::Handle<Gauge> Component::RegisterGauge(const string& name,
-                                                  const uint64_t val,
-                                                  const std::unordered_map<std::string, std::string>& tag_map) {
+Component::Handle<Gauge> Component::RegisterGauge(const string& name, const uint64_t val, const TagsMap& tag_map) {
   names_.gauge_names_.emplace_back(name);
   tags_.gauge_tags_.emplace_back(tag_map);
   values_.gauges_.emplace_back(Gauge(val));
@@ -60,15 +52,7 @@ Component::Handle<Status> Component::RegisterStatus(const string& name, const st
   return Component::Handle<Status>(values_.statuses_, values_.statuses_.size() - 1, metricsEnabled_);
 }
 
-Component::Handle<Counter> Component::RegisterCounter(const string& name, const uint64_t val) {
-  names_.counter_names_.emplace_back(name);
-  values_.counters_.emplace_back(Counter(val));
-  return Component::Handle<Counter>(values_.counters_, values_.counters_.size() - 1, metricsEnabled_);
-}
-
-Component::Handle<Counter> Component::RegisterCounter(const string& name,
-                                                      const uint64_t val,
-                                                      const std::unordered_map<std::string, std::string>& tag_map) {
+Component::Handle<Counter> Component::RegisterCounter(const string& name, const uint64_t val, const TagsMap& tag_map) {
   names_.counter_names_.emplace_back(name);
   tags_.counter_tags_.emplace_back(tag_map);
   values_.counters_.emplace_back(Counter(val));
@@ -92,7 +76,7 @@ std::list<Metric> Component::CollectGauges() {
   if (!metricsEnabled_) return list<Metric>();
   std::list<Metric> ret;
   for (size_t i = 0; i < names_.gauge_names_.size(); i++) {
-    if (tags_.gauge_tags_.size() > i) {
+    if (tags_.gauge_tags_[i].size()) {
       ret.emplace_back(Metric{name_, names_.gauge_names_[i], values_.gauges_[i], tags_.gauge_tags_[i]});
     } else {
       ret.emplace_back(Metric{name_, names_.gauge_names_[i], values_.gauges_[i]});
@@ -108,7 +92,7 @@ std::list<Metric> Component::CollectCounters() {
   if (!metricsEnabled_) return list<Metric>();
   std::list<Metric> ret;
   for (size_t i = 0; i < names_.counter_names_.size(); i++) {
-    if (tags_.counter_tags_.size() > i) {
+    if (tags_.counter_tags_[i].size()) {
       ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i], tags_.counter_tags_[i]});
     } else {
       ret.emplace_back(Metric{name_, names_.counter_names_[i], values_.counters_[i]});

--- a/util/test/metric_test.cpp
+++ b/util/test/metric_test.cpp
@@ -101,8 +101,8 @@ TEST(MetricTest, ToJson) {
 TEST(MetricTest, CollectGauges) {
   auto aggregator = std::make_shared<Aggregator>();
   Component c("replica", aggregator);
-  c.RegisterGauge("connected_peers", 3);
-  c.RegisterGauge("total_peers", 4);
+  c.RegisterGauge("connected_peers", 3, {{"key_1", "val_1"}, {"key_2", "val_2"}});
+  c.RegisterGauge("total_peers", 4, {{"key_1", "val_1"}});
   c.Register();
 
   Component c2("state-transfer", aggregator);
@@ -117,13 +117,16 @@ TEST(MetricTest, CollectGauges) {
       if (g.name == "connected_peers") {
         ASSERT_EQ(std::get<Gauge>(g.value).Get(), 3);
         numOfGaugesInReplica++;
+        ASSERT_EQ(g.tag_map.size(), 2);
       } else if (g.name == "total_peers") {
         ASSERT_EQ(std::get<Gauge>(g.value).Get(), 4);
         numOfGaugesInReplica++;
+        ASSERT_EQ(g.tag_map.size(), 1);
       }
     } else if (g.component == "state-transfer") {
       if (g.name == "blocks-remaining") {
         ASSERT_EQ(std::get<Gauge>(g.value).Get(), 5);
+        ASSERT_EQ(g.tag_map.size(), 0);
         numOfGaugesInStateTransfer++;
       }
     }


### PR DESCRIPTION
Fix metric infra to enable tags in Thin Replica Server

* **Problem Overview**  
TRS can start serving live/history updates to any newly subscribed TRC. Wavefront needs to have a mapping from where this information can be derived. This commit would fix bug in metric infra.
* **Testing Done**  
Executed all TRC, TRS tests.