### PR TITLE
Add custom health service for clientservice

### DIFF
--- a/client/clientservice/include/client/clientservice/client_service.hpp
+++ b/client/clientservice/include/client/clientservice/client_service.hpp
@@ -17,6 +17,7 @@
 #include "event_service.hpp"
 #include "request_service.hpp"
 #include "state_snapshot_service.hpp"
+#include "health_service.hpp"
 #include "Logger.hpp"
 #include "client/concordclient/concord_client.hpp"
 
@@ -29,7 +30,8 @@ class ClientService {
       : logger_(logging::getLogger("concord.client.clientservice")),
         client_(std::move(client)),
         event_service_(std::make_unique<EventServiceImpl>(client_, aggregator)),
-        state_snapshot_service_(std::make_unique<StateSnapshotServiceImpl>(client_)){};
+        state_snapshot_service_(std::make_unique<StateSnapshotServiceImpl>(client_)),
+        health_service_(std::make_unique<HealthCheckServiceImpl>(client_)){};
 
   void start(const std::string& addr, unsigned num_async_threads, uint64_t max_receive_msg_size);
 
@@ -58,6 +60,7 @@ class ClientService {
   // Synchronous services
   std::unique_ptr<EventServiceImpl> event_service_;
   std::unique_ptr<StateSnapshotServiceImpl> state_snapshot_service_;
+  std::unique_ptr<HealthCheckServiceImpl> health_service_;
 
   // Asynchronous services
   vmware::concord::client::request::v1::RequestService::AsyncService request_service_;
@@ -65,6 +68,7 @@ class ClientService {
   std::vector<std::unique_ptr<grpc::ServerCompletionQueue>> cqs_;
   std::vector<std::thread> server_threads_;
   std::unique_ptr<grpc::Server> clientservice_server_;
+  grpc::HealthCheckServiceInterface* health_;
 };
 
 }  // namespace concord::client::clientservice

--- a/client/clientservice/include/client/clientservice/health_service.hpp
+++ b/client/clientservice/include/client/clientservice/health_service.hpp
@@ -45,6 +45,10 @@ class HealthCheckServiceImpl : public grpc::health::v1::Health::Service {
   // atleast one client in the client pool is ready to serve requests
   HealthCheckResponse_ServingStatus getRequeserviceHealthStatus();
 
+  // updates the overall clientservice health, i.e., reports healthy
+  // iff all the services in clientservice are healthy
+  void updateAggregateHealth();
+
  public:
   const std::string kRequestService{"vmware.concord.client.request.v1.RequestService"};
   const std::string kEventService{"vmware.concord.client.event.v1.EventService"};

--- a/client/clientservice/include/client/clientservice/health_service.hpp
+++ b/client/clientservice/include/client/clientservice/health_service.hpp
@@ -1,0 +1,79 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include <map>
+#include <mutex>
+
+#include <grpcpp/server_context.h>
+#include <grpcpp/support/status.h>
+#include "client/concordclient/concord_client.hpp"
+
+#include <health.grpc.pb.h>
+
+namespace concord::client::clientservice {
+
+using grpc::health::v1::HealthCheckRequest;
+using grpc::health::v1::HealthCheckResponse;
+using grpc::health::v1::HealthCheckResponse_ServingStatus;
+
+// A sync implementation of the health checking service.
+class HealthCheckServiceImpl : public grpc::health::v1::Health::Service {
+ public:
+  HealthCheckServiceImpl(std::shared_ptr<concord::client::concordclient::ConcordClient> client)
+      : logger_(logging::getLogger("concord.client.clientservice.event")), client_(client){};
+  grpc::Status Check(grpc::ServerContext* context,
+                     const HealthCheckRequest* request,
+                     HealthCheckResponse* response) override;
+  grpc::Status Watch(grpc::ServerContext* context,
+                     const HealthCheckRequest* request,
+                     grpc::ServerWriter<HealthCheckResponse>* writer) override;
+  void SetStatus(const std::string& service_name, HealthCheckResponse::ServingStatus status);
+  void SetAll(HealthCheckResponse::ServingStatus status);
+
+  void Shutdown();
+
+ private:
+  // Queries the health status of the client_pool via the concord client and returns true if
+  // atleast one client in the client pool is ready to serve requests
+  HealthCheckResponse_ServingStatus getRequeserviceHealthStatus();
+
+ public:
+  const std::string kRequestService{"vmware.concord.client.request.v1.RequestService"};
+  const std::string kEventService{"vmware.concord.client.event.v1.EventService"};
+  const std::string kStateSnapshotService{"vmware.concord.client.statesnapshot.v1.StateSnapshotService"};
+
+ private:
+  logging::Logger logger_;
+  std::mutex mtx_;
+  bool shutdown_ = false;
+  std::shared_ptr<concord::client::concordclient::ConcordClient> client_;
+  std::map<const std::string, HealthCheckResponse::ServingStatus> status_map_;
+};
+
+class HealthCheckService : public grpc::HealthCheckServiceInterface {
+ public:
+  explicit HealthCheckService(HealthCheckServiceImpl* impl) : impl_(impl) {
+    impl_->SetStatus("", HealthCheckResponse::SERVING);
+  }
+  void SetServingStatus(const std::string& service_name, bool serving) override {
+    impl_->SetStatus(service_name, serving ? HealthCheckResponse::SERVING : HealthCheckResponse::NOT_SERVING);
+  }
+
+  void SetServingStatus(bool serving) override {
+    impl_->SetAll(serving ? HealthCheckResponse::SERVING : HealthCheckResponse::NOT_SERVING);
+  }
+
+  void Shutdown() override { impl_->Shutdown(); }
+
+ private:
+  std::shared_ptr<HealthCheckServiceImpl> impl_;  // not owned
+};
+}  // namespace concord::client::clientservice

--- a/client/clientservice/src/health_service.cpp
+++ b/client/clientservice/src/health_service.cpp
@@ -1,0 +1,92 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License"). You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "client/clientservice/health_service.hpp"
+
+namespace concord::client::clientservice {
+
+grpc::Status HealthCheckServiceImpl::Check(grpc::ServerContext* /*context*/,
+                                           const HealthCheckRequest* request,
+                                           HealthCheckResponse* response) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  auto iter = status_map_.find(request->service());
+  if (iter == status_map_.end()) {
+    return grpc::Status(grpc::StatusCode::NOT_FOUND, "");
+  }
+  if (iter->first == kRequestService) {
+    response->set_status(getRequeserviceHealthStatus());
+    return grpc::Status::OK;
+  }
+  response->set_status(iter->second);
+  return grpc::Status::OK;
+}
+
+grpc::Status HealthCheckServiceImpl::Watch(grpc::ServerContext* context,
+                                           const HealthCheckRequest* request,
+                                           grpc::ServerWriter<HealthCheckResponse>* writer) {
+  auto last_state = HealthCheckResponse::UNKNOWN;
+  while (!context->IsCancelled()) {
+    {
+      std::lock_guard<std::mutex> lock(mtx_);
+      HealthCheckResponse response;
+      auto iter = status_map_.find(request->service());
+      if (iter == status_map_.end()) {
+        response.set_status(response.SERVICE_UNKNOWN);
+      } else if (iter->first == kRequestService) {
+        response.set_status(getRequeserviceHealthStatus());
+      } else {
+        response.set_status(iter->second);
+      }
+      if (response.status() != last_state) {
+        writer->Write(response, grpc::WriteOptions());
+        last_state = response.status();
+      }
+    }
+    gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC), gpr_time_from_minutes(1, GPR_TIMESPAN)));
+  }
+  return grpc::Status::OK;
+}
+
+void HealthCheckServiceImpl::SetStatus(const std::string& service_name, HealthCheckResponse::ServingStatus status) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (shutdown_) {
+    status = HealthCheckResponse::NOT_SERVING;
+  }
+  status_map_[service_name] = status;
+}
+
+void HealthCheckServiceImpl::SetAll(HealthCheckResponse::ServingStatus status) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (shutdown_) {
+    return;
+  }
+  for (auto iter = status_map_.begin(); iter != status_map_.end(); ++iter) {
+    iter->second = status;
+  }
+}
+
+void HealthCheckServiceImpl::Shutdown() {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (shutdown_) {
+    return;
+  }
+  shutdown_ = true;
+  for (auto iter = status_map_.begin(); iter != status_map_.end(); ++iter) {
+    iter->second = HealthCheckResponse::NOT_SERVING;
+  }
+}
+
+HealthCheckResponse_ServingStatus HealthCheckServiceImpl::getRequeserviceHealthStatus() {
+  if (!client_) return HealthCheckResponse::NOT_SERVING;
+  return (client_->isClientPoolHealthy()) ? HealthCheckResponse::SERVING : HealthCheckResponse::NOT_SERVING;
+}
+
+}  // namespace concord::client::clientservice

--- a/client/concordclient/include/client/concordclient/concord_client.hpp
+++ b/client/concordclient/include/client/concordclient/concord_client.hpp
@@ -180,6 +180,10 @@ class ConcordClient {
   // Get subscription id.
   std::string getSubscriptionId() const { return config_.subscribe_config.id; }
 
+  // Get client-pool health status
+  // The caller has the responsibility of making sure that client_pool_ object exists before the method is called.
+  bool isClientPoolHealthy();
+
  private:
   config_pool::ConcordClientPoolConfig createClientPoolStruct(const ConcordClientConfig& config);
   void createGrpcConnections();

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -232,4 +232,10 @@ void ConcordClient::getSnapshot(const StateSnapshotRequest& request, std::shared
   rss_->readSnapshotStream(rss_request, remote_queue);
 }
 
+bool ConcordClient::isClientPoolHealthy() {
+  ConcordAssertNE(client_pool_, nullptr);
+  if (client_pool_->HealthStatus() == concord::concord_client_pool::PoolStatus::NotServing) return false;
+  return true;
+}
+
 }  // namespace concord::client::concordclient

--- a/client/proto/CMakeLists.txt
+++ b/client/proto/CMakeLists.txt
@@ -7,12 +7,14 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   request/v1/request.proto
   event/v1/event.proto
   state_snapshot/v1/state_snapshot.proto
+  health/v1/health.proto
   ../concordclient/proto/concord_client_request/v1/concord_client_request.proto
 )
 grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
   request/v1/request.proto
   event/v1/event.proto
   state_snapshot/v1/state_snapshot.proto
+  health/v1/health.proto
   ../concordclient/proto/concord_client_request/v1/concord_client_request.proto
 )
 

--- a/client/proto/health/v1/health.proto
+++ b/client/proto/health/v1/health.proto
@@ -1,0 +1,63 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  // If the requested service is unknown, the call will fail with status
+  // NOT_FOUND.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status.  It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}


### PR DESCRIPTION
This PR adds a custom health service, specifically custom Check/Watch methods for request service. This PR also adds the necessary code that would be easy to extend for event and stat-snapshot services' health. Please see individual commits for more detail.

Testing is done via grpcurl -
`grpcurl -plaintext -d '{"service":"vmware.concord.client.request.v1.RequestService"}' --proto health.proto <clientservice-ip>:50505 grpc.health.v1.Health/Check` and 
`grpcurl -plaintext -d '{"service":"vmware.concord.client.request.v1.RequestService"}' --proto health.proto <clientservice-ip>:50505 grpc.health.v1.Health/Watch`

Will add end-to-end tests once this PR gets merged.