### PR TITLE
Increase max_reply_size

### DIFF
--- a/client/bftclient/include/bftclient/config.h
+++ b/client/bftclient/include/bftclient/config.h
@@ -76,7 +76,7 @@ struct ClientConfig {
 struct RequestConfig {
   bool pre_execute = false;
   uint64_t sequence_number = 0;
-  uint32_t max_reply_size = 64 * 1024;
+  uint32_t max_reply_size = 1024 * 1024;
   std::chrono::milliseconds timeout = 5s;
   std::string correlation_id = "";
   std::string span_context = "";


### PR DESCRIPTION
* **Problem Overview**  
We need larger replies in some ethereum workloads (UTT for example)
* **Testing Done**  
Maestro runs with the new size
Manual test with larger requests and replies.
