### PR TITLE
Change INFO log to DEBUG log

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -370,7 +370,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   // InternalReplicaApi
   bool isCollectingState() const override {
-    LOG_INFO(GL, "Thread ID: " << std::this_thread::get_id());
+    LOG_DEBUG(GL, "Thread ID: " << std::this_thread::get_id());
     return isCollectingState_;
   }
   void startCollectingState(std::string&& reason = "");


### PR DESCRIPTION
As isCollectingState function is called multiple times, the INFO log was spamming the concord logs. Hence changed it to debug logs.
