### PR TITLE
Remove unnecessary namespace alias

### DIFF
--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -19,7 +19,6 @@
 #include <variant>
 #include <util/filesystem.hpp>
 #include <fstream>
-namespace fs = std::experimental::filesystem;
 
 namespace concord::client::reconfiguration::handlers {
 


### PR DESCRIPTION
* **Problem Overview** 
The filesystem is now part of the standard library. It should no longer be referred as an experimental feature.
* **Testing Done**
Tested with local runs, where the alias was not used anymore.

