### PR TITLE
Move log to INFO.

### DIFF
--- a/client/thin-replica-client/src/thin_replica_client.cpp
+++ b/client/thin-replica-client/src/thin_replica_client.cpp
@@ -1024,7 +1024,7 @@ void ThinReplicaClient::Subscribe(const SubscribeRequest& req) {
 //     - Add logic to pick a different server to send the acknowledgement to if
 //       server 0 is known to be down or faulty.
 void ThinReplicaClient::Unsubscribe() {
-  LOG_DEBUG(logger_, "Unsubscribe");
+  LOG_INFO(logger_, "Unsubscribe");
   stop_subscription_thread_ = true;
   if (subscription_thread_) {
     ConcordAssert(subscription_thread_->joinable());


### PR DESCRIPTION
Move Unsubscribe event to INFO. We don't expect this event to be very frequent.

* **Problem Overview**  
  The unsubscription event can be a valuable information and should not be too frequent.
* **Testing Done**  
  N/A
