### PR TITLE
BC-23627 : TLS Client Key Rotation Fix 

### DIFF
--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -58,12 +58,16 @@ class StateControl {
   }
 
   const std::string getEventTypeAsString(const EventType& et) {
+    std::string str;
     switch (et) {
       case EventType::TLS_COMM:
-        return "TLS_COMM";
+        str = "TLS_COMM";
+        break;
       case EventType::THIN_REPLICA_SERVER:
-        return "THIN_REPLICA_SERVER";
+        str = "THIN_REPLICA_SERVER";
+        break;
     }
+    return str;
   }
   void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { get_peer_pub_key_ = std::move(m); }
 

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -28,7 +28,7 @@ struct EnumHash {
 
 class StateControl {
  public:
- using CallbackRegistry = concord::util::CallbackRegistry<uint32_t>;
+  using CallbackRegistry = concord::util::CallbackRegistry<uint32_t>;
   enum class EventType { TLS_COMM, THIN_REPLICA_SERVER };
 
   static StateControl& instance() {
@@ -81,9 +81,8 @@ class StateControl {
   }
 
   std::mutex lock_comm_;
-  //keeping function template to be void(uint32_t) for uniformity
-  std::unordered_map<const EventType, std::unique_ptr<CallbackRegistry>, EnumHash>
-      event_registry_;
+  // keeping function template to be void(uint32_t) for uniformity
+  std::unordered_map<const EventType, std::unique_ptr<CallbackRegistry>, EnumHash> event_registry_;
   std::function<std::string(uint32_t)> get_peer_pub_key_;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -21,6 +21,7 @@ class StateControl {
     static StateControl instance_;
     return instance_;
   }
+
   void lockComm() { lock_comm_.lock(); }
   bool tryLockComm() { return lock_comm_.try_lock(); }
   void unlockComm() { lock_comm_.unlock(); }
@@ -30,11 +31,15 @@ class StateControl {
   }
 
   void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
+
+  void restartThinReplicaServer(uint32_t id) {restartComm(id);}
+
   void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { get_peer_pub_key_ = std::move(m); }
   std::string getPeerPubKey(uint32_t id) {
     if (get_peer_pub_key_) return get_peer_pub_key_(id);
     return std::string();
   }
+
 
  private:
   std::mutex lock_comm_;

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -43,17 +43,17 @@ class StateControl {
   void unlockComm() { lock_comm_.unlock(); }
 
   // Added/retained these methods to act as facade
-  void setCommRestartCallBack(std::function<void(uint32_t)> cb, const EventType& et = EventType::TLS_COMM) {
-    registerCallback(et, cb);
+  void setCommRestartCallBack(std::function<void(uint32_t)>&& cb, const EventType& et = EventType::TLS_COMM) {
+    registerCallback(et, std::move(cb));
   }
 
   void restartComm(uint32_t id, const EventType& et = EventType::TLS_COMM) { invokeCallback(et, id); }
 
-  void setTlsRestartCallBack(std::function<void(uint32_t)> cb, const EventType& et = EventType::THIN_REPLICA_SERVER) {
-    registerCallback(et, cb);
+  void setTrsRestartCallBack(std::function<void(uint32_t)>&& cb, const EventType& et = EventType::THIN_REPLICA_SERVER) {
+    registerCallback(et, std::move(cb));
   }
 
-  void restartThinReplicaServer(uint32_t id, const EventType& et = EventType::THIN_REPLICA_SERVER) {
+  void restartThinReplicaServer(uint32_t id = 0, const EventType& et = EventType::THIN_REPLICA_SERVER) {
     invokeCallback(et, id);
   }
 
@@ -79,7 +79,7 @@ class StateControl {
  private:
   StateControl() : logger_(logging::getLogger("concord-bft.comm.state_control")) {}
 
-  void registerCallback(const EventType& et, std::function<void(uint32_t)> cb) {
+  void registerCallback(const EventType& et, std::function<void(uint32_t)>&& cb) {
     ConcordAssert(cb != nullptr);
     if (event_registry_.find(et) == event_registry_.end()) {
       event_registry_.insert({et, std::make_unique<CallbackRegistry>()});

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -14,9 +14,23 @@
 #include <functional>
 #include <utility>
 #include "callback_registry.hpp"
+#include <unordered_map>
+#include <variant>
+#include <memory>
+
 namespace bft::communication {
+struct EnumHash {
+  template <typename T>
+  size_t operator()(T t) const {
+    return static_cast<size_t>(t);
+  }
+};
+
 class StateControl {
  public:
+ using CallbackRegistry = concord::util::CallbackRegistry<uint32_t>;
+  enum class EventType { TLS_COMM, THIN_REPLICA_SERVER };
+
   static StateControl& instance() {
     static StateControl instance_;
     return instance_;
@@ -26,24 +40,50 @@ class StateControl {
   bool tryLockComm() { return lock_comm_.try_lock(); }
   void unlockComm() { lock_comm_.unlock(); }
 
-  void setCommRestartCallBack(std::function<void(uint32_t)> cb) {
-    if (cb != nullptr) comm_restart_cb_registry_.add(cb);
+  // Added/retained these methods to act as facade
+  void setCommRestartCallBack(std::function<void(uint32_t)> cb, const EventType& et = EventType::TLS_COMM) {
+    registerCallback(et, cb);
   }
 
-  void restartComm(uint32_t id) { comm_restart_cb_registry_.invokeAll(id); }
+  void restartComm(uint32_t id, const EventType& et = EventType::TLS_COMM) { invokeCallback(et, id); }
 
-  void restartThinReplicaServer(uint32_t id) {restartComm(id);}
+  void setTlsRestartCallBack(std::function<void(uint32_t)> cb, const EventType& et = EventType::THIN_REPLICA_SERVER) {
+    registerCallback(et, cb);
+  }
+
+  void restartThinReplicaServer(uint32_t id, const EventType& et = EventType::THIN_REPLICA_SERVER) {
+    invokeCallback(et, id);
+  }
 
   void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { get_peer_pub_key_ = std::move(m); }
+
   std::string getPeerPubKey(uint32_t id) {
     if (get_peer_pub_key_) return get_peer_pub_key_(id);
     return std::string();
   }
 
-
  private:
+  void registerCallback(const EventType& et, std::function<void(uint32_t)> cb) {
+    if (cb != nullptr) {
+      if (event_registry_.find(et) == event_registry_.end()) {
+        event_registry_.insert({et, std::make_unique<CallbackRegistry>()});
+      }
+      event_registry_[et]->add(cb);
+    }
+  }
+
+  void invokeCallback(const EventType& et, uint32_t id) {
+    if (event_registry_.find(et) != event_registry_.end()) {
+      event_registry_[et]->invokeAll(id);
+    } else {
+      throw std::invalid_argument{"invokeCallback called with an invalid eventType"};
+    }
+  }
+
   std::mutex lock_comm_;
-  concord::util::CallbackRegistry<uint32_t> comm_restart_cb_registry_;
+  //keeping function template to be void(uint32_t) for uniformity
+  std::unordered_map<const EventType, std::unique_ptr<CallbackRegistry>, EnumHash>
+      event_registry_;
   std::function<std::string(uint32_t)> get_peer_pub_key_;
 };
 }  // namespace bft::communication

--- a/communication/include/communication/StateControl.hpp
+++ b/communication/include/communication/StateControl.hpp
@@ -18,6 +18,7 @@
 #include <variant>
 #include <memory>
 #include "Logger.hpp"
+#include "assertUtils.hpp"
 
 namespace bft::communication {
 struct EnumHash {
@@ -62,8 +63,6 @@ class StateControl {
         return "TLS_COMM";
       case EventType::THIN_REPLICA_SERVER:
         return "THIN_REPLICA_SERVER";
-      default:
-        return "Invalid Type";
     }
   }
   void setGetPeerPubKeyMethod(std::function<std::string(uint32_t)> m) { get_peer_pub_key_ = std::move(m); }
@@ -74,15 +73,14 @@ class StateControl {
   }
 
  private:
-  StateControl() : logger_(logging::getLogger("concord-bft.comm.StetControl")) {}
+  StateControl() : logger_(logging::getLogger("concord-bft.comm.state_control")) {}
 
   void registerCallback(const EventType& et, std::function<void(uint32_t)> cb) {
-    if (cb != nullptr) {
-      if (event_registry_.find(et) == event_registry_.end()) {
-        event_registry_.insert({et, std::make_unique<CallbackRegistry>()});
-      }
-      event_registry_[et]->add(cb);
+    ConcordAssert(cb != nullptr);
+    if (event_registry_.find(et) == event_registry_.end()) {
+      event_registry_.insert({et, std::make_unique<CallbackRegistry>()});
     }
+    event_registry_[et]->add(cb);
   }
 
   void invokeCallback(const EventType& et, uint32_t id) {

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -469,6 +469,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* received_cer
   out.close();
   BIO_free(outbio);
   LOG_INFO(logger_, "new certificate has been updated on local storage, peer: " << peerId);
+  bft::communication::StateControl::instance().restartThinReplicaServer(0);
   return std::make_pair(res, peerId);
 }
 

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -469,6 +469,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* received_cer
   out.close();
   BIO_free(outbio);
   LOG_INFO(logger_, "new certificate has been updated on local storage, peer: " << peerId);
+  // calling the TRS restart callback with dummy parameter 0
   bft::communication::StateControl::instance().restartThinReplicaServer(0);
   return std::make_pair(res, peerId);
 }

--- a/communication/src/AsyncTlsConnection.cpp
+++ b/communication/src/AsyncTlsConnection.cpp
@@ -469,8 +469,7 @@ std::pair<bool, NodeNum> AsyncTlsConnection::checkCertificate(X509* received_cer
   out.close();
   BIO_free(outbio);
   LOG_INFO(logger_, "new certificate has been updated on local storage, peer: " << peerId);
-  // calling the TRS restart callback with dummy parameter 0
-  bft::communication::StateControl::instance().restartThinReplicaServer(0);
+  bft::communication::StateControl::instance().restartThinReplicaServer();
   return std::make_pair(res, peerId);
 }
 


### PR DESCRIPTION
Problem Description :
BC-23627 : [TLS Client Key Rotation] Daml ledger api restarts after Client key exchange
When client key exchange request is fired via operator, its observed that daml ledge api restarts after client key exchange.

Fix: 
  After reproducing the issue its observed that client service is not able to connect to Thin replica server. After key exchange, client and replica nodes changes certificates, but thin replica server is still running on old certificates, as no notification is sent. Current grpc implementation doesn't allow dynamic loading of certificates, hence servers needs to shutdown and then restart again.
To fix this, we have registered a callback to restart TRS if any key-exchange event occurs.

* **Testing Done**  
This fix is tested on castor deployment via IMAGE_TAG: 0.0.1.0.1177. we simulated the scenario and found that after key exchange, TRS is successfully restarted. Also ran DAML sanity.
Replica Logs attached for reference. 
(2022-10-12T12:22:58,832,+0000|INFO ||concord.thin_replica||||||main.cpp:670|Calling Shutdown to Thin Replica Server)
[tls_rotation_client_fix_image_1177.txt](https://github.com/vmware/concord-bft/files/9766693/tls_rotation_client_fix_image_1177.txt)
