### PR TITLE
Fix a race in PreProcessor between release of expired requests and preeparation of the PreProcessReplyMsg message

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1848,7 +1848,6 @@ void PreProcessor::handleReqPreProcessedByNonPrimary(uint16_t clientId,
                                                      const std::string &reqCid,
                                                      OperationResult preProcessResult) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.handlePreProcessedReqByNonPrimary);
-  setPreprocessingRightNow(clientId, reqOffsetInBatch, false);
   const auto status = (preProcessResult == OperationResult::SUCCESS) ? STATUS_GOOD : STATUS_FAILED;
   auto replyMsg = make_shared<PreProcessReplyMsg>(myReplicaId_,
                                                   clientId,
@@ -1867,6 +1866,7 @@ void PreProcessor::handleReqPreProcessedByNonPrimary(uint16_t clientId,
   } else {
     releaseReqAndSendReplyMsg(replyMsg);
   }
+  setPreprocessingRightNow(clientId, reqOffsetInBatch, false);
 }
 
 void PreProcessor::handleReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,


### PR DESCRIPTION
* **Problem Overview**  
There was recently observed a new type of core dump on a non-primary replica. It was caused by a race condition between two async processes: preparation of the PreProcessReplyMsg to be sent back to the primary replica and cancellation of the expired request. As the memory used for the pre-executed result hash creation is allocated from the raw memory pool, it gets released after request cancellation and we have a crash trying to access it. The solution is to avoid the cancellation of requests that are in the middle of sending replies.
* **Testing Done**  
Regression test using Maestro.
