### PR TITLE
Check request service's health status when updating aggregate health

### DIFF
--- a/client/clientservice/src/health_service.cpp
+++ b/client/clientservice/src/health_service.cpp
@@ -102,6 +102,9 @@ void HealthCheckServiceImpl::updateAggregateHealth() {
   bool aggregate_health = true;  // reports healthy iff all services are healthy
   for (auto& [k, v] : status_map_) {
     if (k == "") continue;
+    if (k == kRequestService) {
+      v = getRequeserviceHealthStatus();
+    }
     aggregate_health = aggregate_health && (v == HealthCheckResponse::SERVING);
   }
   status_map_[""] = aggregate_health ? HealthCheckResponse::SERVING : HealthCheckResponse::NOT_SERVING;


### PR DESCRIPTION
Previously, the health status reported for aggregate health queries, i.e., queries which didn't specify any service name, was the last known aggregate health status.
With this change, when queried for aggregate health, request service's health will be checked in real time to retrieve the most up-to-date health status of the service.

This change has been tested using end-to-end test.