### PR TITLE
Measure the number of storage reads made via TRS and KvbAppFilter

### DIFF
--- a/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_app_filter.h
@@ -223,6 +223,9 @@ class KvbAppFilter {
   // kExecutionEventGroupTagCategory
   static inline const std::string kTagTableKeySeparator{"#"};
 
+  // counter to calculate number of storage reads made by the filter
+  mutable uint64_t num_storage_reads = 0;
+
  private:
   logging::Logger logger_;
   const concord::kvbc::IReader *rostorage_{nullptr};

--- a/kvbc/include/newest_public_event_group_record_time.h
+++ b/kvbc/include/newest_public_event_group_record_time.h
@@ -15,6 +15,7 @@
 
 #include "db_interfaces.h"
 #include "kvbc_app_filter/kvbc_app_filter.h"
+#include "Logger.hpp"
 
 #include <string>
 
@@ -24,9 +25,10 @@ namespace concord::kvbc {
 
 inline std::string newestPublicEventGroupRecordTime(const IReader& reader) {
   using google::protobuf::util::TimeUtil;
-
+  auto logger_ = logging::getLogger("concord.storage.KvbAppFilter");
   auto filter = KvbAppFilter{&reader, ""};
   const auto last_public_event_group = filter.getNewestPublicEventGroup();
+  LOG_DEBUG(logger_, "Total storage reads via newestPublicEventGroupRecordTime: " << filter.num_storage_reads);
   if (!last_public_event_group) {
     // No public events - return epoch.
     return TimeUtil::ToString(TimeUtil::GetEpoch());

--- a/thin-replica-server/include/thin-replica-server/trs_metrics.hpp
+++ b/thin-replica-server/include/thin-replica-server/trs_metrics.hpp
@@ -29,7 +29,8 @@ struct ThinReplicaServerMetrics {
         last_sent_event_group_id{metrics_component_.RegisterGauge(
             "last_sent_event_group_id", 0, {{"stream_type", stream_type}, {"client_id", client_id}})},
         num_skipped_event_groups{metrics_component_.RegisterCounter(
-            "num_skipped_event_groups", 0, {{"stream_type", stream_type}, {"client_id", client_id}})} {
+            "num_skipped_event_groups", 0, {{"stream_type", stream_type}, {"client_id", client_id}})},
+        num_storage_reads{metrics_component_.RegisterCounter("num_storage_reads", 0)} {
     metrics_component_.Register();
   }
 
@@ -53,6 +54,8 @@ struct ThinReplicaServerMetrics {
   concordMetrics::GaugeHandle last_sent_event_group_id;
   // number of event groups skipped after filtering
   concordMetrics::CounterHandle num_skipped_event_groups;
+  // total number of reads from storage made by the TRS
+  concordMetrics::CounterHandle num_storage_reads;
 };
 }  // namespace thin_replica
 }  // namespace concord


### PR DESCRIPTION
This PR adds metrics in TRS and a counter in KvbAppFilter to calculate the number of storage reads made by the components. These metrics are required to monitor storage read activity for performance analysis. 