### PR TITLE
Add ability to create budget from admin cli

### DIFF
--- a/utt/admin-cli/include/admin.hpp
+++ b/utt/admin-cli/include/admin.hpp
@@ -38,5 +38,5 @@ class Admin {
   /// @brief Request the creation of a privacy budget. The amount of the budget is predetermined by the deployed app.
   /// This operation could be performed entirely by an administrator, but we add it in the admin
   /// for demo purposes.
-  static void createPrivacyBudget(Channel& chan);
+  static void createPrivacyBudget(Channel& chan, const std::string& user, uint64_t value);
 };

--- a/utt/admin-cli/proto/api/v1/api.proto
+++ b/utt/admin-cli/proto/api/v1/api.proto
@@ -23,12 +23,12 @@ message DeployPrivacyAppResponse {
 
 message CreatePrivacyBudgetRequest {
     optional string user_id = 1;
+    optional uint64 expiration_date = 2;
+    optional uint64 value = 3;
 }
 
 message CreatePrivacyBudgetResponse {
-    optional string err = 1;
-    optional bytes budget = 2;
-    optional bytes signature = 3;
+    optional string status = 1;
 }
 
 message AdminRequest {

--- a/utt/admin-cli/src/admin.cpp
+++ b/utt/admin-cli/src/admin.cpp
@@ -70,26 +70,18 @@ bool Admin::deployApp(Channel& chan) {
   return true;
 }
 
-void Admin::createPrivacyBudget(Channel& chan) {
-  (void)chan;
-  // [TODO-UTT] Create budget is done locally, should be done by the system
-  // grpc::ClientContext ctx;
+void Admin::createPrivacyBudget(Channel& chan, const std::string& user, uint64_t value) {
+  AdminRequest req;
+  auto& budgerReq = *req.mutable_create_budget();
+  budgerReq.set_user_id(user);
+  budgerReq.set_expiration_date(1919241632);
+  budgerReq.set_value(value);
+  chan->Write(req);
 
-  // CreatePrivacyBudgetRequest req;
-  // req.set_user_id(userId_);
+  std::cout << "Budget request for user: " << user << " value: " << value << " was sent to the privacy app\n";
 
-  // CreatePrivacyBudgetResponse resp;
-  // conn->createPrivacyBudget(&ctx, req, &resp);
-
-  // if (resp.has_err()) {
-  //   std::cout << "Failed to create privacy budget:" << resp.err() << '\n';
-  // } else {
-  //   utt::PrivacyBudget budget = std::vector<uint8_t>(resp.budget().begin(), resp.budget().end());
-  //   utt::RegistrationSig sig = std::vector<uint8_t>(resp.signature().begin(), resp.signature().end());
-
-  //   std::cout << "Got budget " << budget.size() << " bytes.\n";
-  //   std::cout << "Got budget sig " << sig.size() << " bytes.\n";
-
-  //   user_->updatePrivacyBudget(budget, sig);
-  // }
+  AdminResponse resp;
+  chan->Read(&resp);
+  if (!resp.has_create_budget()) throw std::runtime_error("Expected create_budget response from admin service!");
+  std::cout << "response: " << resp.create_budget().status() << '\n';
 }

--- a/utt/admin-cli/src/main.cpp
+++ b/utt/admin-cli/src/main.cpp
@@ -63,19 +63,17 @@ struct CLIApp {
   }
 
   void createBudgetCmd(const std::vector<std::string>& cmdTokens) {
-    (void)cmdTokens;
-    //[TODO-UTT] Create by sending a request to the system
-    // if (cmdTokens.size() != 2) {
-    //   std::cout << "Usage: create-budget <user-id>\n";
-    //   return;
-    // }
-    // auto admin = getAdmin(cmdTokens[1]);
-    // if (!admin) {
-    //   std::cout << "No admin for '" << cmdTokens[1] << "'\n";
-    //   return;
-    // }
-
-    // admin->createPrivacyBudgetLocal(config, 10000);
+    if (cmdTokens.size() != 3) {
+      std::cout << "Usage: create-budget <user-id> <amount>\n";
+      return;
+    }
+    const auto& user = cmdTokens[1];
+    int amount = std::atoi(cmdTokens[2].c_str());
+    if (amount <= 0) {
+      std::cout << "Expected a positive mint amount!\n";
+      return;
+    }
+    Admin::createPrivacyBudget(chan, user, (uint64_t)amount);
   }
 };
 

--- a/utt/include/budget.hpp
+++ b/utt/include/budget.hpp
@@ -53,7 +53,8 @@ class Budget {
          const types::CurvePoint& snHash,
          const types::CurvePoint& pidHash,
          uint64_t val,
-         uint64_t exp_date);
+         uint64_t exp_date,
+         bool finalize = true);
   Budget() {}
 
   /**

--- a/utt/libutt/src/api/budget.cpp
+++ b/utt/libutt/src/api/budget.cpp
@@ -33,13 +33,14 @@ Budget::Budget(const UTTParams& d,
                const types::CurvePoint& snHash,
                const types::CurvePoint& pidHash,
                uint64_t val,
-               uint64_t exp_date) {
+               uint64_t exp_date,
+               bool finalize) {
   Fr fr_val;
   fr_val.set_ulong(val);
   Fr fr_expdate;
   fr_expdate.set_ulong(exp_date);
   coin_ = libutt::api::Coin(
-      d, snHash, fr_val.to_words(), pidHash, libutt::api::Coin::Type::Budget, fr_expdate.to_words(), false);
+      d, snHash, fr_val.to_words(), pidHash, libutt::api::Coin::Type::Budget, fr_expdate.to_words(), finalize);
 }
 libutt::api::Coin& Budget::getCoin() { return coin_; }
 const libutt::api::Coin& Budget::getCoin() const { return coin_; }

--- a/utt/tests/TestUttNewApi.cpp
+++ b/utt/tests/TestUttNewApi.cpp
@@ -195,10 +195,10 @@ TEST_F(ibe_based_test_system, test_budget_creation_by_replicas) {
                       .to_words();  // Assume each replica can compute the same sn using some common execution state
     for (size_t i = 0; i < banks.size(); i++) {
       // Each replica creates its own version of the budget coin and sign it. We expect to have deterministic coin here
-      auto budget = Budget(d, snHash, c.getPidHash(), 1000, 123456789);
+      auto budget = Budget(d, snHash, c.getPidHash(), 1000, 123456789, false);
       rsigs.push_back(banks[i]->sign(budget).front());
     }
-    auto budget = Budget(d, snHash, c.getPidHash(), 1000, 123456789);
+    auto budget = Budget(d, snHash, c.getPidHash(), 1000, 123456789, false);
     auto sbs = getSubset((uint32_t)n, (uint32_t)thresh);
     std::map<uint32_t, std::vector<uint8_t>> sigs;
     for (auto i : sbs) {

--- a/utt/wallet-cli/include/wallet.hpp
+++ b/utt/wallet-cli/include/wallet.hpp
@@ -76,6 +76,7 @@ class Wallet {
   /// @brief Sync up to the last known tx number. If the last known tx number is zero (or not provided) the
   /// last signed transaction number will be fetched from the system
   void syncState(Channel& chan, uint64_t lastKnownTxNum = 0);
+  void updateBudget(Channel& chan);
 
   struct DummyUserStorage : public utt::client::IUserStorage {};
 

--- a/utt/wallet-cli/proto/api/v1/api.proto
+++ b/utt/wallet-cli/proto/api/v1/api.proto
@@ -45,11 +45,11 @@ message RegisterUserResponse {
     repeated uint64 s2 = 3; // Second part of the user's nullifier key 
 }
 
-message CreatePrivacyBudgetRequest {
+message GetPrivacyBudgetRequest {
     optional string user_id = 1;
 }
 
-message CreatePrivacyBudgetResponse {
+message GetPrivacyBudgetResponse {
     optional string err = 1;
     optional bytes budget = 2;
     optional bytes signature = 3;
@@ -138,6 +138,8 @@ message WalletRequest {
         GetPublicBalanceRequest get_public_balance = 6;
         GetLastAddedTxNumberRequest get_last_added_tx_number = 7;
         GetSignedTransactionRequest get_signed_tx = 8;
+
+        GetPrivacyBudgetRequest get_privacy_budget = 9;
     }
 }
 
@@ -155,5 +157,7 @@ message WalletResponse {
         GetPublicBalanceResponse get_public_balance = 7;
         GetLastAddedTxNumberResponse get_last_added_tx_number = 8;
         GetSignedTransactionResponse get_signed_tx = 9;
+
+        GetPrivacyBudgetResponse get_privacy_budget = 10;
     }
 }


### PR DESCRIPTION
Enable a command for the admin to create a budget for users.
Wallet tries to get a new budget coin when its budget is 0; it also keeps a set of budget nullifiers to identify budget coins already polled from the server.
