### PR TITLE
Rvt reports invalid tree bug fix v0.16.x

### DIFF
--- a/bftengine/src/bcstatetransfer/RangeValidationTree.cpp
+++ b/bftengine/src/bcstatetransfer/RangeValidationTree.cpp
@@ -486,6 +486,7 @@ bool RangeValidationTree::validate() const noexcept {
 #ifdef ENABLE_ALL_METRICS
     metrics_.rvt_validation_failures_++;
 #endif
+    return false;
   }
   return true;
 }

--- a/util/include/crypto/openssl/integer.hpp
+++ b/util/include/crypto/openssl/integer.hpp
@@ -68,6 +68,7 @@ class Integer {
     return num;
   }
   void setNegative() { BN_set_negative(num_, 1); }
+  bool isNegative() { return BN_is_negative(num_); }
 
   Integer operator+(const Integer& i) {
     BIGNUM* res = BN_new();
@@ -130,7 +131,10 @@ class Integer {
     return res;
   }
   size_t size() const { return BN_num_bytes(num_); }
-  std::string toHexString() const { return BN_bn2hex(num_); }
+  std::string toHexString(bool add_prefix = false) const {
+    if (add_prefix) return std::string("0x") + BN_bn2hex(num_);
+    return BN_bn2hex(num_);
+  }
   std::string toDecString() const { return BN_bn2dec(num_); }
 
  private:
@@ -141,4 +145,5 @@ inline std::ostream& operator<<(std::ostream& os, const Integer& i) {
   os << i.toHexString();
   return os;
 }
+
 }  // namespace concord::crypto::openssl


### PR DESCRIPTION
Problem Overview
Found CRITICAL bug in angeValidationTree::validate. All validations returned always true. In addition, the behavior of the new openSSL integer is slightly different, had to adapt by converting a NodeVal to positive on some operations due to failures on validation.
in addition, I've improved the way values are printed in this module by overloading operator<< and more.

Testing Done
all ST unittests pass after change, all Apollo tests pass. Added a new NodeValBasicOperators test in RVT_tests to check all new Integer operations.