### PR TITLE
Replica imp and state transfer  bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ test-range: ## Run all tests in the range [START,END], inclusive: `make test-ran
 .PHONY: test-single-suite
 test-single-suite: SHELL:=/bin/bash
 test-single-suite: ## Run a single test `make test-single-suite TEST_NAME=<test name> NUM_REPEATS=<number of repeats,default=1,optional> BREAK_ON_FAILURE=<TRUE|FALSE,optional>`. Example: `make test-single-suite TEST_NAME=timers_tests BREAK_ON_FAILURE=TRUE NUM_REPEATS=3`
+	@if [ -z ${TEST_NAME} ]; then echo "Error: please set the TEST_NAME environment variable!"; exit 1; fi
 	num_failures=0; \
 	for (( i=1; i<=${NUM_REPEATS__}; i++ )); do \
 		echo "=== Starting iteration $${i}/${NUM_REPEATS__}"; \
@@ -313,8 +314,8 @@ test-single-suite: ## Run a single test `make test-single-suite TEST_NAME=<test 
 
 .PHONY: test-single-apollo-case
 test-single-apollo-case: ## Run a single Apollo test case: `make test-single-apollo-case TEST_FILE_NAME=<test file name> TEST_CASE_NAME=<test case name> NUM_REPEATS=<number of repeats,default=1,optional> BREAK_ON_FAILURE=<TRUE|FALSE,optional>`. Test suite file name should come without *.py. Test case is expected without a class name, and must be unique. Example: `make test-single-apollo-case BREAK_ON_FAILURE=TRUE NUM_REPEATS=100 TEST_FILE_NAME=test_skvbc_reconfiguration TEST_CASE_NAME=test_tls_exchange_client_replica_with_st`
-	@if [ -z ${TEST_FILE_NAME} ]; then echo "Error: TEST_FILE_NAME is mandatory"; exit 1; fi
-	@if [ -z ${TEST_CASE_NAME} ]; then echo "Error: TEST_CASE_NAME is mandatory"; exit 1; fi
+	@if [ -z ${TEST_FILE_NAME} ]; then echo "Error: please set the TEST_FILE_NAME environment variable!"; exit 1; fi
+	@if [ -z ${TEST_CASE_NAME} ]; then echo "Error: please set the TEST_CASE_NAME environment variable!"; exit 1; fi
 	$(eval PREFIX := $(shell docker run ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c \
 		"mkdir -p ${CONCORD_BFT_CORE_DIR} && \
@@ -325,8 +326,8 @@ test-single-apollo-case: ## Run a single Apollo test case: `make test-single-apo
 		"python3 scripts/apollo_list_tests.py \
 		${CONCORD_BFT_TARGET_SOURCE_PATH}/tests/apollo/ f | grep ${TEST_FILE_NAME} | grep -w ${TEST_CASE_NAME}"))
 	@if [ -z "${PREFIX}" ] || [ -z "${POSTFIX}" ]; then \
-		echo "Error: Failed to start test, check if TEST_FILE_NAME=${TEST_FILE_NAME}" \
-			"or TEST_CASE_NAME=${TEST_CASE_NAME} exist."; exit 1;\
+		echo "Error: Failed to start test, please check if TEST_FILE_NAME=${TEST_FILE_NAME}" \
+			"or TEST_CASE_NAME=${TEST_CASE_NAME} environment variables exist!"; exit 1;\
 	fi
 	@docker run ${BASIC_RUN_PARAMS} \
 		${CONCORD_BFT_CONTAINER_SHELL} -c "cd tests/apollo/; \
@@ -334,8 +335,8 @@ test-single-apollo-case: ## Run a single Apollo test case: `make test-single-apo
 
 .PHONY: test-single-gtest-case
 test-single-gtest-case: ## Run a single GoogleTest test case: `make test-single-gtest-case TEST_NAME=<test suite name> TEST_CASE_FILTER=<test case name> NUM_REPEATS=<number of repeats,default=1,optional> BREAK_ON_FAILURE=<TRUE|FALSE,optional>`. Call `make lists-tests` to get test suite name. The test case STRING is a filter used with --gtest_filter=*<STRING>*. Example: `make test-single-gtest-case BREAK_ON_FAILURE=TRUE NUM_REPEATS=10 TEST_NAME=bcstatetransfer_tests TEST_CASE_FILTER=srcHandleAskForCheckpointSummariesMsg`
-	@if [ -z ${TEST_NAME} ]; then echo "Error: TEST_NAME is mandatory"; exit 1; fi
-	@if [ -z ${TEST_CASE_FILTER} ]; then echo "Error: TEST_CASE_FILTER is mandatory"; exit 1; fi
+	@if [ -z ${TEST_NAME} ]; then echo "Error: please set the TEST_NAME environment variable!"; exit 1; fi
+	@if [ -z ${TEST_CASE_FILTER} ]; then echo "Error: please set the TEST_CASE_FILTER environment variable!"; exit 1; fi
 	$(eval PREFIX := $(shell docker run ${BASIC_RUN_PARAMS} \
 			${CONCORD_BFT_CONTAINER_SHELL} -c "cd ${CONCORD_BFT_BUILD_DIR} && find . -iname ${TEST_NAME}"))
 	@if [ '${BREAK_ON_FAILURE__}' = 'TRUE' ]; then break_on_failure_opt="--gtest_throw_on_failure"; fi; \

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1029,7 +1029,7 @@ void BCStateTran::finalizeCycle() {
   DataStoreTransaction::Guard g(psd_->beginTransaction());
   LOG_TRACE(logger_, "Finalizing cycle");
 
-  const DataStore::CheckpointDesc &cp = targetCheckpointDesc_;
+  uint64_t checkpointNum{targetCheckpointDesc_.checkpointNum};
   metrics_.on_transferring_complete_++;
   cycleEndSummary();
   stReset(g.txn());
@@ -1039,10 +1039,10 @@ void BCStateTran::finalizeCycle() {
   // TODO - This next line should be integrated as a callback into on_transferring_complete_cb_registry_.
   // on_fetching_state_change_cb_registry_ should be removed
   auto size = on_fetching_state_change_cb_registry_.size();
-  LOG_INFO(logger_,
-           "Starting to invoke all registered calls (on_fetching_state_change_cb_registry_):" << KVLOG(
-               size, cp.checkpointNum));
-  on_fetching_state_change_cb_registry_.invokeAll(cp.checkpointNum);
+  LOG_INFO(
+      logger_,
+      "Starting to invoke all registered calls (on_fetching_state_change_cb_registry_):" << KVLOG(size, checkpointNum));
+  on_fetching_state_change_cb_registry_.invokeAll(checkpointNum);
   LOG_INFO(logger_, "Done invoking all registered calls (on_fetching_state_change_cb_registry_)");
 }
 

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -393,6 +393,7 @@ void BCStateTran::initImpl(uint64_t maxNumOfRequiredStoredCheckpoints,
       LOG_INFO(logger_, "Starting state is " << stateName(fs));
       if (isActiveDestination(fs)) {
         LOG_INFO(logger_, "State Transfer cycle continues");
+        setExternalCollectingState(true);
         startCollectingStats();
         if ((fs == FetchingState::GettingMissingBlocks) || (fs == FetchingState::GettingMissingResPages)) {
           setAllReplicasAsPreferred();
@@ -413,6 +414,8 @@ void BCStateTran::initImpl(uint64_t maxNumOfRequiredStoredCheckpoints,
             totalBlocksLeftToCollectInCycle_ = maxBlockIdToCollectInCycle_ - minBlockIdToCollectInCycle_ + 1;
           }
         }
+      } else {
+        setExternalCollectingState(false);
       }
       loadMetrics();
     } else {
@@ -421,6 +424,7 @@ void BCStateTran::initImpl(uint64_t maxNumOfRequiredStoredCheckpoints,
         DataStoreTransaction::Guard g(psd_->beginTransaction());
         stReset(g.txn(), true, true, true);
       }
+      setExternalCollectingState(false);
       ConcordAssertGE(maxNumOfRequiredStoredCheckpoints, 2);
       ConcordAssertLE(maxNumOfRequiredStoredCheckpoints, kMaxNumOfStoredCheckpoints);
       ConcordAssertGE(numberOfRequiredReservedPages, 2);
@@ -484,6 +488,7 @@ void BCStateTran::stopRunningImpl() {
     DataStoreTransaction::Guard g(psd_->beginTransaction());
     stReset(g.txn(), true, false, false);
   }
+  setExternalCollectingState(false);
   replicaForStateTransfer_ = nullptr;
   LOG_TRACE(logger_, "Done stopRunningImpl");
 }
@@ -917,12 +922,26 @@ void BCStateTran::startCollectingStateInternal() {
   startCollectingStateImpl();
 }
 
-void BCStateTran::startCollectingStateImpl() {
+void BCStateTran::setExternalCollectingState(bool newVal) {
+  if (newVal == externalCollectingState_) {
+    LOG_WARN(logger_, "Trying to set into an already existing state:" << KVLOG(newVal, externalCollectingState_));
+    return;
+  }
+  externalCollectingState_ = newVal;
+  LOG_INFO(logger_, std::boolalpha << KVLOG(externalCollectingState_));
+}
+
+void BCStateTran::startCollectingStateExternal() {
   ConcordAssert(running_);
-  if (psd_->getIsFetchingState()) {
+  if (isCollectingState()) {
     LOG_WARN(logger_, "Already in State Transfer, ignore call...");
     return;
   }
+  setExternalCollectingState(true);
+  startCollectingStateImpl();
+}
+
+void BCStateTran::startCollectingStateImpl() {
   ++cycleCounter_;
   auto internalCycleCounter = metrics_.internal_cycle_counter.Get().Get();
   LOG_INFO(logger_, "State Transfer cycle started:" << KVLOG(cycleCounter_, internalCycleCounter));
@@ -1026,17 +1045,24 @@ void BCStateTran::onTimerImpl() {
 }
 
 void BCStateTran::finalizeCycle() {
-  DataStoreTransaction::Guard g(psd_->beginTransaction());
-  LOG_TRACE(logger_, "Finalizing cycle");
-
   uint64_t checkpointNum{targetCheckpointDesc_.checkpointNum};
-  metrics_.on_transferring_complete_++;
-  cycleEndSummary();
-  stReset(g.txn());
-  g.txn()->setIsFetchingState(false);
-  ConcordAssertEQ(getFetchingState(), FetchingState::NotFetching);
+  {
+    DataStoreTransaction::Guard g(psd_->beginTransaction());
+    LOG_TRACE(logger_, "Finalizing cycle");
 
-  // TODO - This next line should be integrated as a callback into on_transferring_complete_cb_registry_.
+    metrics_.on_transferring_complete_++;
+    cycleEndSummary();
+    stReset(g.txn());
+    g.txn()->setIsFetchingState(false);
+    ConcordAssertEQ(getFetchingState(), FetchingState::NotFetching);
+  }  // guard destroyed, ST marked as completed also in dataStore
+
+  // Mark ST final completion to "outside world" - After this call any incoming messages are not dropped.
+  setExternalCollectingState(false);
+
+  // Now after external state have changed, invoke the 2nd group of registered callbacks
+  // TODO - This next line should be converted to an internal message. There is no need for a callback here. ST is done.
+  // worst case we will have some few incoming messages dropped, until key-exchange is done.
   // on_fetching_state_change_cb_registry_ should be removed
   auto size = on_fetching_state_change_cb_registry_.size();
   LOG_INFO(

--- a/bftengine/src/bcstatetransfer/BCStateTranInterface.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTranInterface.cpp
@@ -61,12 +61,12 @@ void BCStateTran::bindInterfaceHandlers() {
 
   startCollectingStateHandler_ = (config_.runInSeparateThread) ?
     static_cast<decltype(startCollectingStateHandler_)>([this]() {
-      DEBUG_PRINT(logger_, "Before startCollectingStateImpl");
+      DEBUG_PRINT(logger_, "Before startCollectingStateExternal");
       MARK_START_TIME;
-      incomingEventsQ_->push(std::bind(&BCStateTran::startCollectingStateImpl, this));
+      incomingEventsQ_->push(std::bind(&BCStateTran::startCollectingStateExternal, this));
       CALC_DURATION;
-      DEBUG_PRINT(logger_, "After startCollectingStateImpl" << KVLOG(jobDuration)); }) :
-    std::bind(&BCStateTran::startCollectingStateImpl, this);
+      DEBUG_PRINT(logger_, "After startCollectingStateExternal" << KVLOG(jobDuration)); }) :
+    std::bind(&BCStateTran::startCollectingStateExternal, this);
 
   initHandler_ = (config_.runInSeparateThread) ?
     static_cast<decltype(initHandler_)>([this](uint64_t maxNumOfRequiredStoredCheckpoints,

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -3374,7 +3374,6 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
     if (ps_) {
       ps_->endWriteTran(config_.getsyncOnUpdateOfMetadata());
     }
-    setCollectingState(false);
     return;
   }
   lastExecutedSeqNum = newCheckpointSeqNum;
@@ -3440,8 +3439,6 @@ void ReplicaImp::onTransferringCompleteImp(uint64_t newStateCheckpoint) {
     LOG_INFO(GL, "tryToEnterView after State Transfer finished ...");
     tryToEnterView();
   }
-
-  setCollectingState(false);
 }
 
 void ReplicaImp::onSeqNumIsSuperStable(SeqNum superStableSeqNum) {
@@ -4461,8 +4458,6 @@ ReplicaImp::ReplicaImp(bool firstTime,
 
   ConcordAssert(firstTime || ((replicasInfo != nullptr) && (viewsMgr != nullptr) && (sigManager != nullptr)));
 
-  // Assigning and not initializing isCollectingState_ in order to get a unitifed log print (with thread ID)
-  setCollectingState(stateTransfer->isCollectingState())
   LOG_INFO(GL, "Initialising Replica" << KVLOG(firstTime));
 
   onViewNumCallbacks_.add(viewChangeCallBack);
@@ -4481,6 +4476,8 @@ ReplicaImp::ReplicaImp(bool firstTime,
         KeyExchangeManager::instance().sendInitialKey(this, lastExecutedSeqNum);
         LOG_INFO(GL, "Send initial key exchange after completing state transfer " << KVLOG(lastExecutedSeqNum));
       }
+    } else {
+      LOG_WARN(GL, "State Transfer is still collecting! Initial key exchange cannot yet be initiated!");
     }
   });
   registerMsgHandlers();
@@ -5319,7 +5316,6 @@ void ReplicaImp::updateLimitsAndMetrics(PrePrepareMsg *ppMsg) {
 }
 
 void ReplicaImp::startCollectingState(std::string &&reason) {
-  setCollectingState(true);
   LOG_INFO(GL, "Start Collecting State" << KVLOG(reason));
   time_in_state_transfer_.start();
   clientsManager->clearAllPendingRequests();  // to avoid entering a new view on old request timeout

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -77,7 +77,6 @@ using concordMetrics::StatusHandle;
 
 class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
  protected:
-  std::atomic_bool isCollectingState_;
   const bool viewChangeProtocolEnabled;
   const bool autoPrimaryRotationEnabled;
 
@@ -374,7 +373,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // InternalReplicaApi
   bool isCollectingState() const override {
     LOG_TRACE(GL, "Thread ID: " << std::this_thread::get_id());
-    return isCollectingState_;
+    return stateTransfer->isCollectingState();
   }
   void startCollectingState(std::string&& reason = "");
   bool isValidClient(NodeIdType clientId) const override { return clientsManager->isValidClient(clientId); }
@@ -389,12 +388,6 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   }
   bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const override {
     return clientsManager->isClientRequestInProcess(clientId, reqSeqNum);
-  }
-  inline void setCollectingState(bool newState) {
-    LOG_INFO(GL,
-             std::boolalpha << "Setting CollectingState to" << KVLOG(newState)
-                            << " Thread ID: " << std::this_thread::get_id());
-    isCollectingState_ = newState;
   }
   SeqNum getPrimaryLastUsedSeqNum() const override { return primaryLastUsedSeqNum; }
   uint64_t getRequestsInQueue() const override { return requestsQueueOfPrimary.size(); }

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -390,7 +390,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   bool isClientRequestInProcess(NodeIdType clientId, ReqId reqSeqNum) const override {
     return clientsManager->isClientRequestInProcess(clientId, reqSeqNum);
   }
-  inline void setIsCollectingState(bool newState) {
+  inline void setCollectingState(bool newState) {
     LOG_INFO(GL,
              std::boolalpha << "Setting CollectingState to" << KVLOG(newState)
                             << " Thread ID: " << std::this_thread::get_id());

--- a/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
+++ b/bftengine/tests/bcstatetransfer/bcstatetransfer_tests.cpp
@@ -2013,7 +2013,7 @@ TEST_F(BcStTest, dstSetNewPrefferedReplicasOnFetchBlocksMsgRejection) {
                                    testState_.maxRequiredBlockId));
 }
 
-// This test checks that replica enters a new internal cycle when reserved pages reuqest is rejected.
+// This test checks that replica enters a new internal cycle when reserved pages request is rejected.
 TEST_F(BcStTest, dstEnterInternalCycleOnFetchReservedPagesRejection) {
   ASSERT_NFF(initialize());
 
@@ -2038,7 +2038,7 @@ TEST_F(BcStTest, dstEnterInternalCycleOnFetchReservedPagesRejection) {
 
 // This test makes sure that current primary is not modified during GettingCheckpointSummaries
 // Its doing so by checking the value of currentPrimary in source selector.
-// It sends 2 cycles of preprepare messages that in any other St state whould have triggerred a new primary awarness.
+// It sends 2 cycles of pre prepare messages that in any other ST state would have triggered a new primary awareness.
 // Since they are sent during GettingCheckpointSummaries, they are being  ignored.
 TEST_F(BcStTest, dstTestprimaryAwarnessduringAskForCheckpointSummariesMsg) {
   ASSERT_NFF(initialize());


### PR DESCRIPTION
* **Problem Overview**  
Fixing a critical and minor bug  here. The critical bug is caused by a race condition between consensus thread and St thread, leading to a corruption of State Transfer state and for replica to stay out of the network forever.
Here we introduce state transfer "external state" in order to solve this issue once and for all.

* **Testing Done**  
All regular tests pass.
Running State Transfer for 48 hours every 2 minutes on high end deployment over 700 TPS. checking that State Transfer always works and there are no race conditions.