### PR TITLE
Replica: revert convertion of m_metadataStorage raw pointer to smart

### DIFF
--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -244,7 +244,7 @@ class Replica : public IReplica,
   bftEngine::IReplica::IReplicaPtr m_replicaPtr = nullptr;
   std::shared_ptr<ICommandsHandler> m_cmdHandler = nullptr;
   bftEngine::IStateTransfer *m_stateTransfer = nullptr;
-  std::unique_ptr<concord::storage::DBMetadataStorage> m_metadataStorage;
+  concord::storage::DBMetadataStorage *m_metadataStorage = nullptr;
   std::unique_ptr<ReplicaStateSync> replicaStateSync_;
   std::shared_ptr<concordMetrics::Aggregator> aggregator_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_;


### PR DESCRIPTION

* **Problem Overview**  
m_metadataStorage converted to uniq_ptr while there is alrwady a unique_ptr in storage which manage it. This  cause a crash (double free). 

* **Testing Done**  
NA.
