### PR TITLE
Pass messages as smart pointers E2E: phase one

### DIFF
--- a/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
+++ b/bftengine/src/bcstatetransfer/AsyncStateTransferCRE.cpp
@@ -29,9 +29,8 @@ class Communication : public ICommunication {
  public:
   Communication(std::shared_ptr<MsgsCommunicator> msgsCommunicator, std::shared_ptr<MsgHandlersRegistrator> msgHandlers)
       : msgsCommunicator_{msgsCommunicator}, repId_{bftEngine::ReplicaConfig::instance().replicaId} {
-    msgHandlers->registerMsgHandler(MsgCode::ClientReply, [&](bftEngine::impl::MessageBase* message) {
+    msgHandlers->registerMsgHandler(MsgCode::ClientReply, [&](std::unique_ptr<bftEngine::impl::MessageBase> message) {
       if (receiver_) receiver_->onNewMessage(message->senderId(), message->body(), message->size());
-      delete message;
     });
   }
 

--- a/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
+++ b/bftengine/src/bftengine/MsgHandlersRegistrator.hpp
@@ -20,13 +20,16 @@
 namespace bftEngine::impl {
 
 template <typename T>
-using CallbackTypeWithPtrArg = std::function<void(T*)>;
+using CallbackTypeWithArg = std::function<void(T)>;
+
+template <typename T>
+using CallbackTypeWithRawPtrArg = std::function<void(T*)>;
 
 template <typename T>
 using CallbackTypeWithRefArg = std::function<void(T&&)>;
 
-using MsgHandlerCallback = CallbackTypeWithPtrArg<MessageBase>;
-using ValidatedMsgHandlerCallback = CallbackTypeWithPtrArg<CarrierMesssage>;
+using MsgHandlerCallback = CallbackTypeWithArg<std::unique_ptr<MessageBase>>;
+using ValidatedMsgHandlerCallback = CallbackTypeWithRawPtrArg<CarrierMesssage>;
 using InternalMsgHandlerCallback = CallbackTypeWithRefArg<InternalMessage>;
 
 // MsgHandlersRegistrator class contains message handling callback functions.

--- a/bftengine/src/bftengine/MsgReceiver.cpp
+++ b/bftengine/src/bftengine/MsgReceiver.cpp
@@ -26,20 +26,17 @@ void MsgReceiver::onNewMessage(NodeNum sourceNode,
                                size_t messageLength,
                                NodeNum endpointNum) {
   if (messageLength > ReplicaConfig::instance().getmaxExternalMessageSize()) {
-    LOG_WARN(GL, "Msg exceeds allowed max msg size, size " << messageLength << " source " << sourceNode);
+    LOG_WARN(GL, "Msg exceeds allowed max msg size" << KVLOG(messageLength, sourceNode));
     return;
   }
   if (messageLength < sizeof(MessageBase::Header)) {
-    LOG_WARN(GL, "Msg length is smaller than expected msg header, size " << messageLength << " source " << sourceNode);
+    LOG_WARN(GL, "Msg length is smaller than expected msg header" << KVLOG(messageLength, sourceNode));
     return;
   }
 
   auto *msgBody = (MessageBase::Header *)std::malloc(messageLength);
   memcpy(msgBody, message, messageLength);
-
-  auto node = sourceNode;
-
-  std::unique_ptr<MessageBase> pMsg(new MessageBase(node, msgBody, messageLength, true));
+  auto pMsg = std::make_unique<MessageBase>(sourceNode, msgBody, messageLength, true);
 
   incomingMsgsStorage_->pushExternalMsg(std::move(pMsg));
 }

--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -42,17 +42,15 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
   void onReportAboutInvalidMessage(MessageBase* msg, const char* reason) override;
 
   template <typename T>
-  void messageHandler(MessageBase* msg) {
-    T* trueTypeObj = new T(msg);
-    delete msg;
-    if (validateMessage(trueTypeObj))
-      onMessage<T>(trueTypeObj);
-    else
-      delete trueTypeObj;
+  void messageHandler(std::unique_ptr<MessageBase> msg) {
+    auto trueTypeObj = std::make_unique<T>(msg.release());
+    if (validateMessage(trueTypeObj.get())) {
+      onMessage<T>(std::move(trueTypeObj));
+    }
   }
 
   template <class T>
-  void onMessage(T*);
+  void onMessage(std::unique_ptr<T>);
 
   void executeReadOnlyRequest(concordUtils::SpanWrapper& parent_span, const ClientRequestMsg& m);
   void persistCheckpointDescriptor(const SeqNum&, const CheckpointInfo<false>&);
@@ -72,8 +70,8 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
 
  private:
   // This function serves as an ReplicaStatusHandlers alternative for ReadOnlyReplica. The reason to use this function
-  // is that regular and read-only replcias expose differen metrics and the status handlers are not interchangable. The
-  // read-only replica also hasn't got an implementation for InternalMessages which are used by the
+  // is that regular and read-only replicas expose different metrics and the status handlers are not interchangeable.
+  // The read-only replica also hasn't got an implementation for InternalMessages which are used by the
   // ReplicaStatusHandler.
   void registerStatusHandlers();
 };

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -116,13 +116,11 @@ void ReplicaForStateTransfer::stop() {
 }
 
 template <>
-void ReplicaForStateTransfer::onMessage(std::unique_ptr<StateTransferMsg> m) {
+void ReplicaForStateTransfer::onMessage(std::unique_ptr<StateTransferMsg> msg) {
   metric_received_state_transfers_++;
   const size_t h = sizeof(MessageBase::Header);
-  stateTransfer->handleStateTransferMessage(m->body() + h, m->size() - h, m->senderId());
-  auto msg = m.release();
+  stateTransfer->handleStateTransferMessage(msg->body() + h, msg->size() - h, msg->senderId());
   msg->releaseOwnership();
-  delete msg;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -116,12 +116,13 @@ void ReplicaForStateTransfer::stop() {
 }
 
 template <>
-void ReplicaForStateTransfer::onMessage(StateTransferMsg *m) {
+void ReplicaForStateTransfer::onMessage(std::unique_ptr<StateTransferMsg> m) {
   metric_received_state_transfers_++;
-  size_t h = sizeof(MessageBase::Header);
+  const size_t h = sizeof(MessageBase::Header);
   stateTransfer->handleStateTransferMessage(m->body() + h, m->size() - h, m->senderId());
-  m->releaseOwnership();
-  delete m;
+  auto msg = m.release();
+  msg->releaseOwnership();
+  delete msg;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -57,17 +57,15 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
   }
 
   template <typename T>
-  void messageHandler(MessageBase* msg) {
-    T* trueTypeObj = new T(msg);
-    delete msg;
-    if (validateMessage(trueTypeObj))
-      onMessage<T>(static_cast<T*>(trueTypeObj));
-    else
-      delete trueTypeObj;
+  void messageHandler(std::unique_ptr<MessageBase> msg) {
+    auto trueTypeObj = std::make_unique<T>(msg.release());
+    if (validateMessage(trueTypeObj.get())) {
+      onMessage<T>(std::move(trueTypeObj));
+    }
   }
 
   template <class T>
-  void onMessage(T*);
+  void onMessage(std::unique_ptr<T>);
 
  protected:
   std::unique_ptr<bftEngine::IStateTransfer> stateTransfer;

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -174,44 +174,34 @@ void ReplicaImp::registerMsgHandlers() {
 }
 
 template <typename T>
-void ReplicaImp::messageHandler(MessageBase *msg) {
-  T *trueTypeObj = new T(msg);
+void ReplicaImp::messageHandler(std::unique_ptr<MessageBase> msg) {
+  auto trueTypeObj = std::make_unique<T>(msg.release());
   if (isCollectingState()) {
     // Extract only required information and handover to ST thread
-    if (validateMessage(trueTypeObj)) {
-      peekConsensusMessage<T>(msg);
+    if (validateMessage(trueTypeObj.get())) {
+      peekConsensusMessage<T>(trueTypeObj.get());
     }
   }
-  delete msg;
-
   if (bftEngine::ControlStateManager::instance().getPruningProcessStatus()) {
     if constexpr (!std::is_same_v<T, ClientRequestMsg>) {
       LOG_INFO(GL, "Received protocol message while pruning, ignoring the message");
-      delete trueTypeObj;
       return;
     }
   }
-
   if constexpr (std::is_same_v<T, PrePrepareMsg>) {
     if (getReplicaConfig().prePrepareFinalizeAsyncEnabled) {
       if (!isCollectingState()) {
-        validatePrePrepareMsg(trueTypeObj);
-        return;
-      } else {
-        delete trueTypeObj;
-        return;
+        validatePrePrepareMsg(std::move(trueTypeObj));
       }
+      return;
     }
   }
-
   if constexpr (std::is_same_v<T, StateTransferMsg>) {
-    if (validateMessage(trueTypeObj))
-      onMessage<T>(trueTypeObj);
-    else
-      delete trueTypeObj;
+    if (validateMessage(trueTypeObj.get())) {
+      onMessage<T>(std::move(trueTypeObj));
+    }
     return;
   }
-
   if (!isCollectingState()) {
     // The message validation of few messages require time-consuming processes like
     // digest calculation, signature verification etc. Such messages are identified
@@ -224,16 +214,15 @@ void ReplicaImp::messageHandler(MessageBase *msg) {
     // prePrepareFinalizeAsyncEnabled flag will be removed in 1.7, when this entire
     // async behaviour will be assumed to be default for the chosen messages.
     if (getReplicaConfig().prePrepareFinalizeAsyncEnabled && trueTypeObj->shouldValidateAsync()) {
-      asyncValidateMessage<T>(trueTypeObj);
+      asyncValidateMessage<T>(std::move(trueTypeObj));
       return;
     } else {
-      if (validateMessage(trueTypeObj)) {
-        onMessage<T>(trueTypeObj);
+      if (validateMessage(trueTypeObj.get())) {
+        onMessage<T>(std::move(trueTypeObj));
         return;
       }
     }
   }
-  delete trueTypeObj;
 }
 
 /**
@@ -250,9 +239,9 @@ void ReplicaImp::validatedMessageHandler(CarrierMesssage *msg) {
   // to itself without going through the network stack (as an internal message).
   // So the carrier message is quickly reinterpreted and used instead of fresh memory allocation.
   // So this reinterpret_cast is intended.
-  ValidatedMessageCarrierInternalMsg<T> *validatedTrueTyeObj =
+  ValidatedMessageCarrierInternalMsg<T> *validatedTrueTypeObj =
       reinterpret_cast<ValidatedMessageCarrierInternalMsg<T> *>(msg);
-  T *trueTypeObj = validatedTrueTyeObj->returnMessageToOwner();
+  T *trueTypeObj = validatedTrueTypeObj->returnMessageToOwner();
   delete msg;
 
   if (bftEngine::ControlStateManager::instance().getPruningProcessStatus()) {
@@ -262,13 +251,13 @@ void ReplicaImp::validatedMessageHandler(CarrierMesssage *msg) {
       return;
     }
   }
-
   if (!isCollectingState()) {
-    onMessage<T>(trueTypeObj);
+    onMessage<T>(std::make_unique<T>(trueTypeObj));
   } else {
     delete trueTypeObj;
   }
 }
+
 /**
  * validateMessage This is synchronous validate message.
  *
@@ -298,7 +287,7 @@ bool ReplicaImp::validateMessage(MessageBase *msg) {
  * @return : returns nothing
  */
 template <typename MSG>
-void ReplicaImp::asyncValidateMessage(MSG *msg) {
+void ReplicaImp::asyncValidateMessage(std::unique_ptr<MSG> msg) {
   // The thread pool is initialized once and kept with this function.
   // This function is called in a single thread as the queue by dispatcher will not allow multiple threads together.
   try {
@@ -316,12 +305,11 @@ void ReplicaImp::asyncValidateMessage(MSG *msg) {
             return;
           }
         },
-        msg,
+        msg.release(),
         repsInfo,
-        &(getIncomingMsgsStorage()));
+        &getIncomingMsgsStorage());
   } catch (std::out_of_range &ex) {
     LOG_ERROR(GL, "The request threadpool selector is selecting some non-existent threadpool");
-    delete msg;
     return;
   }
 }
@@ -334,7 +322,7 @@ void ReplicaImp::asyncValidateMessage(MSG *msg) {
  * to get handled.
  * @return : returns nothing
  */
-void ReplicaImp::validatePrePrepareMsg(PrePrepareMsg *&ppm) {
+void ReplicaImp::validatePrePrepareMsg(std::unique_ptr<PrePrepareMsg> ppm) {
   // The thread pool is initialized once and kept with this function.
   // This function is called in a single thread as the queue by dispatcher will not allow multiple threads together.
   try {
@@ -358,13 +346,12 @@ void ReplicaImp::validatePrePrepareMsg(PrePrepareMsg *&ppm) {
             return;
           }
         },
-        ppm,
+        ppm.release(),
         repsInfo,
-        &(getIncomingMsgsStorage()),
+        &getIncomingMsgsStorage(),
         getCurrentView());
   } catch (std::out_of_range &ex) {
     LOG_ERROR(GL, "The request threadpool selector is selecting some non-existent threadpool");
-    delete ppm;
     return;
   }
 }
@@ -395,32 +382,34 @@ void ReplicaImp::onReportAboutInvalidMessage(MessageBase *msg, const char *reaso
 }
 
 template <>
-void ReplicaImp::onMessage<StateTransferMsg>(StateTransferMsg *m) {
+void ReplicaImp::onMessage<StateTransferMsg>(std::unique_ptr<StateTransferMsg> msg) {
   if (activeExecutions_ > 0) {
-    pushDeferredMessage(m);
+    pushDeferredMessage(msg.release());
     return;
   } else {
-    ReplicaForStateTransfer::onMessage<StateTransferMsg>(m);
+    ReplicaForStateTransfer::onMessage<StateTransferMsg>(std::move(msg));
   }
 }
 
 template <>
-void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
+void ReplicaImp::onMessage<ClientRequestMsg>(std::unique_ptr<ClientRequestMsg> m) {
   metric_received_client_requests_++;
   const NodeIdType senderId = m->senderId();
   const NodeIdType clientId = m->clientProxyId();
   const bool readOnly = m->isReadOnly();
   const ReqId reqSeqNum = m->requestSeqNum();
   const uint64_t flags = m->flags();
+  const auto &cid = m->getCid();
 
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
-  SCOPED_MDC_CID(m->getCid());
+  SCOPED_MDC_CID(cid);
   LOG_DEBUG(CNSUS, KVLOG(clientId, reqSeqNum, senderId) << " flags: " << std::bitset<sizeof(uint64_t) * 8>(flags));
 
-  const auto &span_context = m->spanContext<std::remove_pointer<decltype(m)>::type>();
+  auto msg = m.release();
+  const auto &span_context = msg->spanContext<std::remove_pointer<decltype(msg)>::type>();
   auto span = concordUtils::startChildSpanFromContext(span_context, "bft_client_request");
   span.setTag("rid", config_.getreplicaId());
-  span.setTag("cid", m->getCid());
+  span.setTag("cid", cid);
   span.setTag("seq_num", reqSeqNum);
 
   // Drop external msgs off:
@@ -431,7 +420,7 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
       (!KeyExchangeManager::instance().clientKeysPublished() && repsInfo->isIdOfClientProxy(senderId))) {
     if (!(flags & KEY_EXCHANGE_FLAG) && !(flags & CLIENTS_PUB_KEYS_FLAG)) {
       LOG_INFO(KEY_EX_LOG, "Didn't complete yet, dropping msg");
-      delete m;
+      delete msg;
       return;
     }
   }
@@ -451,23 +440,23 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
   if (invalidClient || sentFromReplicaToNonPrimary) {
     std::ostringstream oss("ClientRequestMsg is invalid. ");
     oss << KVLOG(invalidClient, sentFromReplicaToNonPrimary);
-    onReportAboutInvalidMessage(m, oss.str().c_str());
-    delete m;
+    onReportAboutInvalidMessage(msg, oss.str().c_str());
+    delete msg;
     return;
   }
 
   if (readOnly) {
     if (activeExecutions_ > 0) {
       if (deferredRORequests_.size() < maxQueueSize_) {
-        deferredRORequests_.push_back(
-            m);  // We should handle span and deleting the message when we handle the deferred message
+        // We should handle span and deleting the message when we handle the deferred message
+        deferredRORequests_.push_back(msg);
         deferredRORequestsMetric_++;
       } else {
-        delete m;
+        delete msg;
       }
     } else {
-      executeReadOnlyRequest(span, m);
-      delete m;
+      executeReadOnlyRequest(span, msg);
+      delete msg;
     }
     return;
   }
@@ -477,12 +466,12 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
     LOG_INFO(CNSUS,
              "Ignoring ClientRequest because system is stopped at checkpoint pending control state operation (upgrade, "
              "etc...)");
-    delete m;
+    delete msg;
     return;
   }
 
   if (!currentViewIsActive()) {
-    delete m;
+    delete msg;
     return;
   }
 
@@ -494,15 +483,15 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
         LOG_WARN(CNSUS,
                  "ClientRequestMsg dropped. Primary request queue is full. "
                      << KVLOG(clientId, reqSeqNum, requestsQueueOfPrimary.size()));
-        delete m;
+        delete msg;
         return;
       }
       if (clientsManager->canBecomePending(clientId, reqSeqNum)) {
         LOG_DEBUG(CNSUS, "Pushing to primary queue, request " << KVLOG(reqSeqNum, clientId, senderId));
         if (time_to_collect_batch_ == MinTime) time_to_collect_batch_ = getMonotonicTime();
-        metric_primary_batching_duration_.addStartTimeStamp(m->getCid());
-        requestsQueueOfPrimary.push(m);
-        primaryCombinedReqSize += m->size();
+        metric_primary_batching_duration_.addStartTimeStamp(cid);
+        requestsQueueOfPrimary.push(msg);
+        primaryCombinedReqSize += msg->size();
         primary_queue_size_.Get().Set(requestsQueueOfPrimary.size());
         tryToSendPrePrepareMsg(true);
         return;
@@ -513,23 +502,23 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
       }
     } else {  // not the current primary
       if (clientsManager->canBecomePending(clientId, reqSeqNum)) {
-        clientsManager->addPendingRequest(clientId, reqSeqNum, m->getCid());
+        clientsManager->addPendingRequest(clientId, reqSeqNum, cid);
 
         // Adding the message to a queue for future retransmission.
         if (requestsOfNonPrimary.size() < NonPrimaryCombinedReqSize) {
-          if (requestsOfNonPrimary.count(m->requestSeqNum())) {
-            delete std::get<1>(requestsOfNonPrimary.at(m->requestSeqNum()));
+          if (requestsOfNonPrimary.count(msg->requestSeqNum())) {
+            delete std::get<1>(requestsOfNonPrimary.at(msg->requestSeqNum()));
           }
-          requestsOfNonPrimary[m->requestSeqNum()] = std::make_pair(getMonotonicTime(), m);
+          requestsOfNonPrimary[msg->requestSeqNum()] = std::make_pair(getMonotonicTime(), msg);
         }
-        send(m, currentPrimary());
+        send(msg, currentPrimary());
         LOG_INFO(CNSUS,
                  "Forwarding ClientRequestMsg to the current primary." << KVLOG(reqSeqNum, clientId, currentPrimary()));
         return;
       }
       if (clientsManager->isPending(clientId, reqSeqNum)) {
         // As long as this request is not committed, we want to continue and alert the primary about it
-        send(m, currentPrimary());
+        send(msg, currentPrimary());
       } else {
         LOG_INFO(CNSUS,
                  "ClientRequestMsg is ignored because: request is old, or primary is currently working on it"
@@ -545,34 +534,37 @@ void ReplicaImp::onMessage<ClientRequestMsg>(ClientRequestMsg *m) {
       send(repMsg.get(), clientId);
     }
   }
-  delete m;
+  delete msg;
 }  // namespace bftEngine::impl
 
 template <>
-void ReplicaImp::onMessage<preprocessor::PreProcessResultMsg>(preprocessor::PreProcessResultMsg *m) {
+void ReplicaImp::onMessage<preprocessor::PreProcessResultMsg>(std::unique_ptr<preprocessor::PreProcessResultMsg> msg) {
   LOG_DEBUG(GL,
             "Handling PreProcessResultMsg via ClientRequestMsg handler "
-                << KVLOG(m->clientProxyId(), m->getCid(), m->requestSeqNum()));
-  return onMessage<ClientRequestMsg>(m);
+                << KVLOG(msg->clientProxyId(), msg->getCid(), msg->requestSeqNum()));
+  return onMessage<ClientRequestMsg>(std::make_unique<ClientRequestMsg>(msg.release()));
 }
 
 template <>
-void ReplicaImp::onMessage<ReplicaAsksToLeaveViewMsg>(ReplicaAsksToLeaveViewMsg *m) {
+void ReplicaImp::onMessage<ReplicaAsksToLeaveViewMsg>(std::unique_ptr<ReplicaAsksToLeaveViewMsg> message) {
+  auto *msg = message.release();
   if (activeExecutions_ > 0) {
-    pushDeferredMessage(m);
+    pushDeferredMessage(msg);
     return;
   }
   MDC_PUT(MDC_SEQ_NUM_KEY, std::to_string(getCurrentView()));
-  if (m->viewNumber() == getCurrentView()) {
+  if (msg->viewNumber() == getCurrentView()) {
     LOG_INFO(VC_LOG,
-             "Received ReplicaAsksToLeaveViewMsg " << KVLOG(m->viewNumber(), m->senderId(), m->idOfGeneratedReplica()));
-    viewsManager->storeComplaint(std::unique_ptr<ReplicaAsksToLeaveViewMsg>(m));
+             "Received ReplicaAsksToLeaveViewMsg "
+                 << KVLOG(msg->viewNumber(), msg->senderId(), msg->idOfGeneratedReplica()));
+    viewsManager->storeComplaint(std::unique_ptr<ReplicaAsksToLeaveViewMsg>(msg));
     tryToGoToNextView();
   } else {
-    LOG_WARN(VC_LOG,
-             "Ignoring ReplicaAsksToLeaveViewMsg " << KVLOG(
-                 getCurrentView(), currentViewIsActive(), m->viewNumber(), m->senderId(), m->idOfGeneratedReplica()));
-    delete m;
+    LOG_WARN(
+        VC_LOG,
+        "Ignoring ReplicaAsksToLeaveViewMsg " << KVLOG(
+            getCurrentView(), currentViewIsActive(), msg->viewNumber(), msg->senderId(), msg->idOfGeneratedReplica()));
+    delete msg;
   }
 }
 
@@ -1063,7 +1055,8 @@ bool ReplicaImp::validatePreProcessedResults(const PrePrepareMsg *msg, const Vie
 }
 
 template <>
-void ReplicaImp::onMessage<PrePrepareMsg>(PrePrepareMsg *msg) {
+void ReplicaImp::onMessage<PrePrepareMsg>(std::unique_ptr<PrePrepareMsg> message) {
+  auto *msg = message.release();
   if (isSeqNumToStopAt(msg->seqNumber())) {
     LOG_INFO(GL,
              "Ignoring PrePrepareMsg because system is stopped at checkpoint pending control state operation (upgrade, "
@@ -1300,8 +1293,9 @@ void ReplicaImp::tryToAskForMissingInfo() {
 }
 
 template <>
-void ReplicaImp::onMessage<StartSlowCommitMsg>(StartSlowCommitMsg *msg) {
+void ReplicaImp::onMessage<StartSlowCommitMsg>(std::unique_ptr<StartSlowCommitMsg> message) {
   metric_received_start_slow_commits_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
   LOG_INFO(CNSUS, "Received StartSlowCommitMsg " << KVLOG(msgSeqNum, msg->senderId()));
@@ -1451,8 +1445,9 @@ void ReplicaImp::sendCommitPartial(const SeqNum s) {
 }
 
 template <>
-void ReplicaImp::onMessage<PartialCommitProofMsg>(PartialCommitProofMsg *msg) {
+void ReplicaImp::onMessage<PartialCommitProofMsg>(std::unique_ptr<PartialCommitProofMsg> message) {
   metric_received_partial_commit_proofs_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   const SeqNum msgView = msg->viewNumber();
   const NodeIdType msgSender = msg->senderId();
@@ -1484,7 +1479,8 @@ void ReplicaImp::onMessage<PartialCommitProofMsg>(PartialCommitProofMsg *msg) {
 }
 
 template <>
-void ReplicaImp::onMessage<FullCommitProofMsg>(FullCommitProofMsg *msg) {
+void ReplicaImp::onMessage<FullCommitProofMsg>(std::unique_ptr<FullCommitProofMsg> message) {
+  auto *msg = message.release();
   pm_->Delay<concord::performance::SlowdownPhase::ConsensusFullCommitMsgProcess>(
       reinterpret_cast<char *>(msg),
       msg->sizeNeededForObjAndMsgInLocalBuffer(),
@@ -1579,7 +1575,7 @@ void ReplicaImp::onInternalMsg(InternalMessage &&msg) {
       ppcim->ppm_ = nullptr;
       return;
     } else {
-      return onMessage(ppcim->ppm_);
+      return onMessage(std::make_unique<PrePrepareMsg>(ppcim->ppm_));
     }
   }
 
@@ -1742,8 +1738,9 @@ void ReplicaImp::onInternalMsg(GetStatus &status) const {
 }
 
 template <>
-void ReplicaImp::onMessage<PreparePartialMsg>(PreparePartialMsg *msg) {
+void ReplicaImp::onMessage<PreparePartialMsg>(std::unique_ptr<PreparePartialMsg> message) {
   metric_received_prepare_partials_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -1794,8 +1791,9 @@ void ReplicaImp::onMessage<PreparePartialMsg>(PreparePartialMsg *msg) {
 }
 
 template <>
-void ReplicaImp::onMessage<CommitPartialMsg>(CommitPartialMsg *msg) {
+void ReplicaImp::onMessage<CommitPartialMsg>(std::unique_ptr<CommitPartialMsg> message) {
   metric_received_commit_partials_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
 
@@ -1837,8 +1835,9 @@ void ReplicaImp::onMessage<CommitPartialMsg>(CommitPartialMsg *msg) {
 }
 
 template <>
-void ReplicaImp::onMessage<PrepareFullMsg>(PrepareFullMsg *msg) {
+void ReplicaImp::onMessage<PrepareFullMsg>(std::unique_ptr<PrepareFullMsg> message) {
   metric_received_prepare_fulls_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
@@ -1879,8 +1878,9 @@ void ReplicaImp::onMessage<PrepareFullMsg>(PrepareFullMsg *msg) {
   }
 }
 template <>
-void ReplicaImp::onMessage<CommitFullMsg>(CommitFullMsg *msg) {
+void ReplicaImp::onMessage<CommitFullMsg>(std::unique_ptr<CommitFullMsg> message) {
   metric_received_commit_fulls_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
   SCOPED_MDC_PRIMARY(std::to_string(currentPrimary()));
@@ -2300,7 +2300,8 @@ void ReplicaImp::onFastPathCommitVerifyCombinedSigResult(SeqNum seqNumber,
 }
 
 template <>
-void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
+void ReplicaImp::onMessage<CheckpointMsg>(std::unique_ptr<CheckpointMsg> message) {
+  auto *msg = message.release();
   if (activeExecutions_ > 0) {
     pushDeferredMessage(msg);
     return;
@@ -2457,24 +2458,19 @@ void ReplicaImp::onMessage<CheckpointMsg>(CheckpointMsg *msg) {
  * Is sent from a read-only replica
  */
 template <>
-void ReplicaImp::onMessage<AskForCheckpointMsg>(AskForCheckpointMsg *msg) {
+void ReplicaImp::onMessage<AskForCheckpointMsg>(std::unique_ptr<AskForCheckpointMsg> msg) {
   // metric_received_checkpoints_++; // TODO [TK]
-
-  // DD: handlers are supposed to either save or delete messages
-  std::unique_ptr<AskForCheckpointMsg> m{msg};
-  LOG_INFO(GL, "Received AskForCheckpoint message: " << KVLOG(m->senderId(), lastStableSeqNum));
-
+  LOG_INFO(GL, "Received AskForCheckpoint message:" << KVLOG(msg->senderId(), lastStableSeqNum));
   const auto &checkpointInfo = checkpointsLog->get(lastStableSeqNum);
   CheckpointMsg *checkpointMsg = checkpointInfo.selfCheckpointMsg();
 
   if (checkpointMsg == nullptr) {
-    LOG_INFO(GL, "This replica does not have the current checkpoint. " << KVLOG(m->senderId(), lastStableSeqNum));
+    LOG_INFO(GL, "This replica does not have the current checkpoint." << KVLOG(msg->senderId(), lastStableSeqNum));
   } else {
     // TODO [TK] check if already sent within a configurable time period
-    auto destination = m->senderId();
-    LOG_INFO(GL, "Sending CheckpointMsg: " << KVLOG(destination));
-
-    send(checkpointMsg, m->senderId());
+    auto destination = msg->senderId();
+    LOG_INFO(GL, "Sending CheckpointMsg:" << KVLOG(destination));
+    send(checkpointMsg, msg->senderId());
   }
 }
 
@@ -2661,12 +2657,13 @@ void ReplicaImp::onRetransmissionsProcessingResults(SeqNum relatedLastStableSeqN
 }
 
 template <>
-void ReplicaImp::onMessage<ReplicaStatusMsg>(ReplicaStatusMsg *msg) {
+void ReplicaImp::onMessage<ReplicaStatusMsg>(std::unique_ptr<ReplicaStatusMsg> message) {
   metric_received_replica_statuses_++;
   // TODO(GG): we need filter for msgs (to avoid denial of service attack) + avoid sending messages at a high rate.
   // TODO(GG): for some communication modules/protocols, we can also utilize information about
   // connection/disconnection.
 
+  auto *msg = message.release();
   auto span = concordUtils::startChildSpanFromContext(msg->spanContext<std::remove_pointer<decltype(msg)>::type>(),
                                                       "bft_handling_status_report");
   (void)span;
@@ -2917,8 +2914,9 @@ void ReplicaImp::tryToSendStatusReport(bool onTimer) {
 }
 
 template <>
-void ReplicaImp::onMessage<ViewChangeMsg>(ViewChangeMsg *msg) {
+void ReplicaImp::onMessage<ViewChangeMsg>(std::unique_ptr<ViewChangeMsg> message) {
   SCOPED_MDC_SEQ_NUM(std::to_string(getCurrentView()));
+  auto *msg = message.release();
   if (!viewChangeProtocolEnabled) {
     delete msg;
     return;
@@ -2995,8 +2993,9 @@ void ReplicaImp::onMessage<ViewChangeMsg>(ViewChangeMsg *msg) {
 }
 
 template <>
-void ReplicaImp::onMessage<NewViewMsg>(NewViewMsg *msg) {
+void ReplicaImp::onMessage<NewViewMsg>(std::unique_ptr<NewViewMsg> message) {
   SCOPED_MDC_SEQ_NUM(std::to_string(getCurrentView()));
+  auto *msg = message.release();
   if (!viewChangeProtocolEnabled) {
     delete msg;
     return;
@@ -3705,8 +3704,9 @@ void ReplicaImp::tryToSendReqMissingDataMsg(SeqNum seqNumber, bool slowPathOnly,
 }
 
 template <>
-void ReplicaImp::onMessage<ReqMissingDataMsg>(ReqMissingDataMsg *msg) {
+void ReplicaImp::onMessage<ReqMissingDataMsg>(std::unique_ptr<ReqMissingDataMsg> message) {
   metric_received_req_missing_datas_++;
+  auto *msg = message.release();
   const SeqNum msgSeqNum = msg->seqNumber();
   const ReplicaId msgSender = msg->senderId();
   SCOPED_MDC_SEQ_NUM(std::to_string(msgSeqNum));
@@ -3953,8 +3953,9 @@ void ReplicaImp::onInfoRequestTimer(Timers::Handle timer) {
 }
 
 template <>
-void ReplicaImp::onMessage<SimpleAckMsg>(SimpleAckMsg *msg) {
+void ReplicaImp::onMessage<SimpleAckMsg>(std::unique_ptr<SimpleAckMsg> message) {
   metric_received_simple_acks_++;
+  auto *msg = message.release();
   SCOPED_MDC_SEQ_NUM(std::to_string(msg->seqNumber()));
   uint16_t relatedMsgType = (uint16_t)msg->ackData();  // TODO(GG): does this make sense ?
   if (retransmissionsLogicEnabled) {
@@ -3968,7 +3969,8 @@ void ReplicaImp::onMessage<SimpleAckMsg>(SimpleAckMsg *msg) {
 }
 
 template <>
-void ReplicaImp::onMessage<ReplicaRestartReadyMsg>(ReplicaRestartReadyMsg *msg) {
+void ReplicaImp::onMessage<ReplicaRestartReadyMsg>(std::unique_ptr<ReplicaRestartReadyMsg> message) {
+  auto *msg = message.release();
   auto &restart_msgs = restart_ready_msgs_[static_cast<uint8_t>(msg->getReason())];
   if (restart_msgs.find(msg->idOfGeneratedReplica()) == restart_msgs.end()) {
     restart_msgs[msg->idOfGeneratedReplica()] = std::make_unique<ReplicaRestartReadyMsg>(msg);
@@ -3996,7 +3998,8 @@ void ReplicaImp::onMessage<ReplicaRestartReadyMsg>(ReplicaRestartReadyMsg *msg) 
 }
 
 template <>
-void ReplicaImp::onMessage<ReplicasRestartReadyProofMsg>(ReplicasRestartReadyProofMsg *msg) {
+void ReplicaImp::onMessage<ReplicasRestartReadyProofMsg>(std::unique_ptr<ReplicasRestartReadyProofMsg> message) {
+  auto *msg = message.release();
   LOG_INFO(GL,
            "Received  ReplicasRestartReadyProofMsg from sender_id "
                << std::to_string(msg->idOfGeneratedReplica()) << " with seq_num" << std::to_string(msg->seqNum()));
@@ -5346,24 +5349,24 @@ void ReplicaImp::handleDeferredRequests() {
       shouldTryToGoToNextView_ = false;
     }
     while (!deferredMessages_.empty()) {
-      auto msg = deferredMessages_.front();
+      auto *msg = deferredMessages_.front();
       deferredMessages_.pop_front();
       deferredMessagesMetric_--;
       auto msgHandlerCallback = msgHandlers_->getCallback(msg->type());
       if (msgHandlerCallback) {
-        msgHandlerCallback(msg);
+        msgHandlerCallback(std::make_unique<MessageBase>(*msg));
       } else {
         delete msg;
       }
     }
     // Currently we are avoiding duplicates on deferred RO requests queue
     while (!deferredRORequests_.empty()) {
-      auto msg = deferredRORequests_.front();
+      auto *msg = deferredRORequests_.front();
       deferredRORequests_.pop_front();
       deferredRORequestsMetric_--;
       auto msgHandlerCallback = msgHandlers_->getCallback(msg->type());
       if (msgHandlerCallback) {
-        msgHandlerCallback(msg);
+        msgHandlerCallback(std::make_unique<MessageBase>(*msg));
       } else {
         delete msg;
       }
@@ -5400,7 +5403,7 @@ void ReplicaImp::onExecutionFinish() {
                                     60000,
                                     "wedge-noop-command-" + std::to_string(lastExecutedSeqNum + 1));
     // Now, try to send a new PrePrepare message immediately, without waiting to a new batch
-    onMessage(crm);
+    onMessage(std::make_unique<ClientRequestMsg>(crm));
     tryToSendPrePrepareMsg(false);
   }
 
@@ -5875,7 +5878,7 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
                                       60000,
                                       "wedge-noop-command-" + std::to_string(lastExecutedSeqNum + 1));
       // Now, try to send a new PrePrepare message immediately, without waiting to a new batch
-      onMessage(crm);
+      onMessage(std::make_unique<ClientRequestMsg>(crm));
       tryToSendPrePrepareMsg(false);
     }
   }
@@ -5906,7 +5909,7 @@ void ReplicaImp::executeNextCommittedRequests(concordUtils::SpanWrapper &parent_
                                     60000,
                                     "wedge-noop-command-" + std::to_string(lastExecutedSeqNum));
     // Now, try to send a new PrePrepare message immediately, without waiting to a new batch
-    onMessage(crm);
+    onMessage(std::make_unique<ClientRequestMsg>(crm));
     tryToSendPrePrepareMsg(false);
   }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -447,7 +447,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void registerMsgHandlers();
 
   template <typename T>
-  void messageHandler(MessageBase* msg);
+  void messageHandler(std::unique_ptr<MessageBase> msg);
 
   template <typename T>
   void validatedMessageHandler(CarrierMesssage* msg);
@@ -472,7 +472,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   std::string getReplicaState() const;
   std::string getReplicaLastStableSeqNum() const;
   template <typename T>
-  void onMessage(T* msg);
+  void onMessage(std::unique_ptr<T> msg);
 
   void onInternalMsg(InternalMessage&& msg);
   void onInternalMsg(GetStatus& msg) const;
@@ -508,10 +508,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   std::pair<PrePrepareMsg*, bool> buildPrePrepareMessageByBatchSize(uint32_t requiredBatchSizeInBytes);
 
-  void validatePrePrepareMsg(PrePrepareMsg*& ppm);
+  void validatePrePrepareMsg(std::unique_ptr<PrePrepareMsg> ppm);
 
   template <typename MSG>
-  void asyncValidateMessage(MSG* msg);
+  void asyncValidateMessage(std::unique_ptr<MSG>);
 
   void removeDuplicatedRequestsFromRequestsQueue();
 

--- a/bftengine/src/bftengine/ViewsManager.cpp
+++ b/bftengine/src/bftengine/ViewsManager.cpp
@@ -995,7 +995,6 @@ bool ViewsManager::addPotentiallyMissingPP(PrePrepareMsg* p, SeqNum currentLastS
   ConcordAssert(!p->isNull());
 
   const SeqNum s = p->seqNumber();
-
   bool hasRelevantRestriction =
       (minRestrictionOfPendingView != 0) && (s >= minRestrictionOfPendingView) && (s <= maxRestrictionOfPendingView);
 
@@ -1004,17 +1003,12 @@ bool ViewsManager::addPotentiallyMissingPP(PrePrepareMsg* p, SeqNum currentLastS
     ConcordAssert(idx < kWorkWindowSize);
 
     ViewChangeSafetyLogic::Restriction& r = restrictionsOfPendingView[idx];
-
     // if we need this message
     if (prePrepareMsgsOfRestrictions[idx] == nullptr && !r.isNull && r.digest == p->digestOfRequests()) {
       prePrepareMsgsOfRestrictions[idx] = p;
-
       return true;
     }
   }
-
-  delete p;  // p is not needed
-
   return false;
 }
 

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -287,7 +287,7 @@ void RequestsBatch::sendCancelBatchedPreProcessingMsgToNonPrimaries(const Client
                                           0,
                                           0,
                                           preProcessor_.myReplica_.getCurrentView(),
-                                          clientMsg->spanContext<ClientPreProcessReqMsgUniquePtr::element_type>());
+                                          clientMsg->spanContext<ClientPreProcessReqMsgSharedPtr::element_type>());
     reqsBatch.push_back(preProcessReqMsg);
     overallPreProcessReqMsgsSize += preProcessReqMsg->size();
   }
@@ -453,6 +453,7 @@ PreProcessor::~PreProcessor() {
       delete[] result->buffer;
     }
   }
+  while (msgs_.read_available()) delete msgs_.front();
   LOG_TRACE(logger(), "~PreProcessor done");
 }
 
@@ -640,20 +641,19 @@ void PreProcessor::sendRejectPreProcessReplyMsg(NodeIdType clientId,
 }
 
 template <>
-void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessRequestMsg *msg) {
+void PreProcessor::onMessage<ClientPreProcessRequestMsg>(ClientPreProcessReqMsgUniquePtr msg) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onClientPreProcessRequestMsg);
   preProcessorMetrics_.preProcReqReceived++;
-  ClientPreProcessReqMsgUniquePtr clientMsg(msg);
-  const string &reqCid = clientMsg->getCid();
-  const NodeIdType &senderId = clientMsg->senderId();
-  const NodeIdType &clientId = clientMsg->clientProxyId();
-  const ReqId &reqSeqNum = clientMsg->requestSeqNum();
-  const auto &reqTimeoutMilli = clientMsg->requestTimeoutMilli();
+  const string &reqCid = msg->getCid();
+  const NodeIdType &senderId = msg->senderId();
+  const NodeIdType &clientId = msg->clientProxyId();
+  const ReqId &reqSeqNum = msg->requestSeqNum();
+  const auto &reqTimeoutMilli = msg->requestTimeoutMilli();
   LOG_DEBUG(logger(),
             "Received ClientPreProcessRequestMsg" << KVLOG(reqSeqNum, reqCid, clientId, senderId, reqTimeoutMilli));
-  if (!checkClientMsgCorrectness(reqSeqNum, reqCid, clientMsg->isReadOnly(), clientId, senderId, "")) return;
+  if (!checkClientMsgCorrectness(reqSeqNum, reqCid, msg->isReadOnly(), clientId, senderId, "")) return;
   PreProcessRequestMsgSharedPtr preProcessRequestMsg;
-  handleSingleClientRequestMessage(std::move(clientMsg), senderId, false, 0, preProcessRequestMsg, "", 1);
+  handleSingleClientRequestMessage(std::move(msg), senderId, false, 0, preProcessRequestMsg, "", 1);
 }
 
 // Should be called under reqEntry->mutex lock
@@ -782,21 +782,20 @@ void PreProcessor::sendPreProcessBatchReqToAllReplicas(ClientBatchRequestMsgUniq
 }
 
 template <>
-void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) {
+void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsgUniquePtr msg) {
   preProcessorMetrics_.preProcBatchReqReceived++;
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onClientBatchPreProcessRequestMsg);
-  ClientBatchRequestMsgUniquePtr clientBatchMsg(msg);
-  const auto clientId = clientBatchMsg->clientId();
+  const auto clientId = msg->clientId();
   // senderId should be taken from ClientBatchRequestMsg as it does not get re-set in batched client messages
-  const auto senderId = clientBatchMsg->senderId();
-  const auto &batchCid = clientBatchMsg->getCid();
-  const auto batchSize = clientBatchMsg->numOfMessagesInBatch();
+  const auto senderId = msg->senderId();
+  const auto &batchCid = msg->getCid();
+  const auto batchSize = msg->numOfMessagesInBatch();
   LOG_DEBUG(logger(), "Received ClientBatchRequestMsg" << KVLOG(batchCid, senderId, clientId, batchSize));
-  if (!checkClientBatchMsgCorrectness(clientBatchMsg)) {
+  if (!checkClientBatchMsgCorrectness(msg)) {
     preProcessorMetrics_.preProcReqIgnored++;
     return;
   }
-  ClientMsgsList &clientMsgs = clientBatchMsg->getClientPreProcessRequestMsgs();
+  ClientMsgsList &clientMsgs = msg->getClientPreProcessRequestMsgs();
   const auto &batchEntry = ongoingReqBatches_[clientId];
   string ongoingBatchCid;
   if (batchEntry->isBatchRegistered(ongoingBatchCid)) {
@@ -846,11 +845,10 @@ void PreProcessor::onMessage<ClientBatchRequestMsg>(ClientBatchRequestMsg *msg) 
     if (!preProcessReqMsgList.empty())
       // For the non-batched inter-replicas communication PreProcessReq messages get sent to all non-primary replicas
       // in handleClientPreProcessRequestByPrimary function one-by-one
-      sendPreProcessBatchReqToAllReplicas(
-          std::move(clientBatchMsg), preProcessReqMsgList, overallPreProcessReqMsgsSize);
+      sendPreProcessBatchReqToAllReplicas(std::move(msg), preProcessReqMsgList, overallPreProcessReqMsgsSize);
   } else {
     LOG_DEBUG(logger(), "Pass ClientBatchRequestMsg to the current primary" << KVLOG(senderId, clientId, batchCid));
-    sendMsg(clientBatchMsg->body(), myReplica_.currentPrimary(), clientBatchMsg->type(), clientBatchMsg->size());
+    sendMsg(msg->body(), myReplica_.currentPrimary(), msg->type(), msg->size());
   }
 }  // namespace preprocessor
 
@@ -886,7 +884,7 @@ bool PreProcessor::checkPreProcessReqPrerequisites(SeqNum reqSeqNum,
   return true;
 }
 
-bool PreProcessor::checkPreProcessBatchReqMsgCorrectness(const PreProcessBatchReqMsgSharedPtr &batchReq) {
+bool PreProcessor::checkPreProcessBatchReqMsgCorrectness(const PreProcessBatchReqMsgUniquePtr &batchReq) {
   const auto &preProcessRequestMsgs = batchReq->getPreProcessRequestMsgs();
   bool valid = true;
 
@@ -916,23 +914,22 @@ bool PreProcessor::checkPreProcessBatchReqMsgCorrectness(const PreProcessBatchRe
 
 // Non-primary replica request handling
 template <>
-void PreProcessor::onMessage<PreProcessBatchRequestMsg>(PreProcessBatchRequestMsg *msg) {
+void PreProcessor::onMessage<PreProcessBatchRequestMsg>(PreProcessBatchReqMsgUniquePtr msg) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onPreProcessBatchRequestMsg);
-  PreProcessBatchReqMsgSharedPtr batchMsg(msg);
   const auto &batchCid = msg->getCid();
-  const NodeIdType &senderId = batchMsg->senderId();
-  const NodeIdType &clientId = batchMsg->clientId();
-  const string reqType = batchMsg->reqType() == REQ_TYPE_PRE_PROCESS ? "REQ_TYPE_PRE_PROCESS" : "REQ_TYPE_CANCEL";
+  const NodeIdType &senderId = msg->senderId();
+  const NodeIdType &clientId = msg->clientId();
+  const string reqType = msg->reqType() == REQ_TYPE_PRE_PROCESS ? "REQ_TYPE_PRE_PROCESS" : "REQ_TYPE_CANCEL";
   LOG_DEBUG(logger(),
             "Received PreProcessBatchRequestMsg"
-                << KVLOG(reqType, senderId, clientId, batchCid, batchMsg->numOfMessagesInBatch()));
-  if (!checkPreProcessBatchReqMsgCorrectness(batchMsg)) return;
+                << KVLOG(reqType, senderId, clientId, batchCid, msg->numOfMessagesInBatch()));
+  if (!checkPreProcessBatchReqMsgCorrectness(msg)) return;
 
-  PreProcessReqMsgsList &preProcessReqMsgs = batchMsg->getPreProcessRequestMsgs();
+  PreProcessReqMsgsList &preProcessReqMsgs = msg->getPreProcessRequestMsgs();
   const auto batchSize = preProcessReqMsgs.size();
 
   const auto &batchEntry = ongoingReqBatches_[clientId];
-  if (batchMsg->reqType() == REQ_TYPE_CANCEL && !batchEntry->isBatchInProcess()) {
+  if (msg->reqType() == REQ_TYPE_CANCEL && !batchEntry->isBatchInProcess()) {
     // Don't cancel the batch if it has received PreProcessBatchRequestMsg before
     batchEntry->cancelBatchAndReleaseRequests(batchCid, CANCELLED_BY_PRIMARY);
     return;
@@ -1039,14 +1036,14 @@ bool PreProcessor::checkPreProcessRequestMsgCorrectness(const PreProcessRequestM
 
 // Non-primary replica request handling
 template <>
-void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsg *message) {
-  auto msg = PreProcessRequestMsgSharedPtr(message);
+void PreProcessor::onMessage<PreProcessRequestMsg>(PreProcessRequestMsgUniquePtr msg) {
   const string reqType = msg->reqType() == REQ_TYPE_PRE_PROCESS ? "REQ_TYPE_PRE_PROCESS" : "REQ_TYPE_CANCEL";
   LOG_DEBUG(logger(),
             "Received PreProcessRequestMsg" << KVLOG(
                 reqType, msg->reqSeqNum(), msg->getCid(), msg->senderId(), msg->clientId(), msg->reqOffsetInBatch()));
-  if (checkPreProcessRequestMsgCorrectness(msg)) {
-    handleSinglePreProcessRequestMsg(msg, "", 1);
+  PreProcessRequestMsgSharedPtr message = move(msg);
+  if (checkPreProcessRequestMsgCorrectness(message)) {
+    handleSinglePreProcessRequestMsg(message, "", 1);
   }
 }
 
@@ -1106,16 +1103,16 @@ bool PreProcessor::checkPreProcessReplyMsgCorrectness(const PreProcessReplyMsgSh
 
 // Primary replica handling
 template <>
-void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsg *message) {
-  auto msg = PreProcessReplyMsgSharedPtr(message);
+void PreProcessor::onMessage<PreProcessReplyMsg>(PreProcessReplyMsgUniquePtr msg) {
   string replyStatus = "STATUS_GOOD";
   if (msg->status() == STATUS_REJECT) replyStatus = "STATUS_REJECT";
   LOG_DEBUG(
       logger(),
       "Received PreProcessReplyMsg" << KVLOG(
           msg->reqSeqNum(), msg->getCid(), msg->senderId(), msg->clientId(), msg->reqOffsetInBatch(), replyStatus));
-  if (checkPreProcessReplyMsgCorrectness(msg)) {
-    handleSinglePreProcessReplyMsg(msg, "");
+  PreProcessReplyMsgSharedPtr message = move(msg);
+  if (checkPreProcessReplyMsgCorrectness(message)) {
+    handleSinglePreProcessReplyMsg(message, "");
   }
 }
 
@@ -1147,7 +1144,7 @@ bool PreProcessor::checkPreProcessReplyPrerequisites(
   return true;
 }
 
-bool PreProcessor::checkPreProcessBatchReplyMsgCorrectness(const PreProcessBatchReplyMsgSharedPtr &batchReply) {
+bool PreProcessor::checkPreProcessBatchReplyMsgCorrectness(const PreProcessBatchReplyMsgUniquePtr &batchReply) {
   const auto &preProcessReplyMsgs = batchReply->getPreProcessReplyMsgs();
   NodeIdType senderId = batchReply->senderId();
   const string batchCid = batchReply->getCid();
@@ -1173,13 +1170,12 @@ bool PreProcessor::checkPreProcessBatchReplyMsgCorrectness(const PreProcessBatch
 
 // Primary replica handling
 template <>
-void PreProcessor::onMessage<PreProcessBatchReplyMsg>(PreProcessBatchReplyMsg *msg) {
+void PreProcessor::onMessage<PreProcessBatchReplyMsg>(PreProcessBatchReplyMsgUniquePtr msg) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.onPreProcessBatchReplyMsg);
-  PreProcessBatchReplyMsgSharedPtr batchMsg(msg);
   const auto &batchCid = msg->getCid();
-  const NodeIdType &senderId = batchMsg->senderId();
-  const NodeIdType &clientId = batchMsg->clientId();
-  PreProcessReplyMsgsList &preProcessReplyMsgs = batchMsg->getPreProcessReplyMsgs();
+  const NodeIdType &senderId = msg->senderId();
+  const NodeIdType &clientId = msg->clientId();
+  PreProcessReplyMsgsList &preProcessReplyMsgs = msg->getPreProcessReplyMsgs();
   const auto batchSize = preProcessReplyMsgs.size();
   LOG_DEBUG(logger(), "Received PreProcessBatchReplyMsg" << KVLOG(batchCid, senderId, clientId, batchSize));
   const auto &batchEntry = ongoingReqBatches_[clientId];
@@ -1192,7 +1188,7 @@ void PreProcessor::onMessage<PreProcessBatchReplyMsg>(PreProcessBatchReplyMsg *m
     return;
   }
 
-  if (!checkPreProcessBatchReplyMsgCorrectness(batchMsg)) return;
+  if (!checkPreProcessBatchReplyMsgCorrectness(msg)) return;
 
   for (auto &singleReplyMsg : preProcessReplyMsgs) {
     const auto &reqSeqNum = singleReplyMsg->reqSeqNum();
@@ -1205,15 +1201,13 @@ void PreProcessor::onMessage<PreProcessBatchReplyMsg>(PreProcessBatchReplyMsg *m
 }
 
 template <typename T>
-void PreProcessor::messageHandler(MessageBase *msg) {
+void PreProcessor::messageHandler(unique_ptr<MessageBase> msg) {
   if (!msgs_.write_available()) {
     LOG_WARN(logger(), "PreProcessor queue is full, returning message");
-    incomingMsgsStorage_->pushExternalMsg(std::unique_ptr<MessageBase>(msg));
+    incomingMsgsStorage_->pushExternalMsg(std::move(msg));
     return;
   }
-  T *trueTypeObj = new T(msg);
-  delete msg;
-  msgs_.push(trueTypeObj);
+  msgs_.push(msg.release());
   msgLoopSignal_.notify_one();
 }
 
@@ -1225,9 +1219,8 @@ void PreProcessor::msgProcessingLoop() {
         msgLoopSignal_.wait_until(l, chrono::steady_clock::now() + std::chrono::milliseconds(WAIT_TIMEOUT_MILLI));
       }
     }
-
     while (!msgLoopDone_ && msgs_.read_available()) {
-      auto msg = msgs_.front();
+      MessageBase *msg = msgs_.front();
       msgs_.pop();
       if (bftEngine::ControlStateManager::instance().isWedged()) {
         LOG_INFO(logger(), "The replica is wedged, the request is ignored");
@@ -1237,35 +1230,35 @@ void PreProcessor::msgProcessingLoop() {
       if (validateMessage(msg)) {
         switch (msg->type()) {
           case (MsgCode::ClientBatchRequest): {
-            onMessage<ClientBatchRequestMsg>(static_cast<ClientBatchRequestMsg *>(msg));
+            onMessage<ClientBatchRequestMsg>(make_unique<ClientBatchRequestMsg>(msg));
             break;
           }
           case (MsgCode::ClientPreProcessRequest): {
-            onMessage<ClientPreProcessRequestMsg>(static_cast<ClientPreProcessRequestMsg *>(msg));
+            onMessage<ClientPreProcessRequestMsg>(make_unique<ClientPreProcessRequestMsg>(msg));
             break;
           }
           case (MsgCode::PreProcessRequest): {
-            onMessage<PreProcessRequestMsg>(static_cast<PreProcessRequestMsg *>(msg));
+            onMessage<PreProcessRequestMsg>(make_unique<PreProcessRequestMsg>(msg));
             break;
           }
           case (MsgCode::PreProcessBatchRequest): {
-            onMessage<PreProcessBatchRequestMsg>(static_cast<PreProcessBatchRequestMsg *>(msg));
+            onMessage<PreProcessBatchRequestMsg>(make_unique<PreProcessBatchRequestMsg>(msg));
             break;
           }
           case (MsgCode::PreProcessReply): {
-            onMessage<PreProcessReplyMsg>(static_cast<PreProcessReplyMsg *>(msg));
+            onMessage<PreProcessReplyMsg>(make_unique<PreProcessReplyMsg>(msg));
             break;
           }
           case (MsgCode::PreProcessBatchReply): {
-            onMessage<PreProcessBatchReplyMsg>(static_cast<PreProcessBatchReplyMsg *>(msg));
+            onMessage<PreProcessBatchReplyMsg>(make_unique<PreProcessBatchReplyMsg>(msg));
             break;
           }
           default:
             LOG_ERROR(logger(), "Unknown message" << KVLOG(msg->type()));
+            delete msg;
         }
       } else {
         preProcessorMetrics_.preProcReqInvalid++;
-        delete msg;
       }
     }
   }

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -152,8 +152,8 @@ class PreProcessor {
  protected:
   bool checkPreProcessRequestMsgCorrectness(const PreProcessRequestMsgSharedPtr &requestMsg);
   bool checkPreProcessReplyMsgCorrectness(const PreProcessReplyMsgSharedPtr &replyMsg);
-  bool checkPreProcessBatchReqMsgCorrectness(const PreProcessBatchReqMsgSharedPtr &batchReq);
-  bool checkPreProcessBatchReplyMsgCorrectness(const PreProcessBatchReplyMsgSharedPtr &batchReply);
+  bool checkPreProcessBatchReqMsgCorrectness(const PreProcessBatchReqMsgUniquePtr &batchReq);
+  bool checkPreProcessBatchReplyMsgCorrectness(const PreProcessBatchReplyMsgUniquePtr &batchReply);
 
  private:
   friend class AsyncPreProcessJob;
@@ -162,10 +162,10 @@ class PreProcessor {
   uint16_t numOfRequiredReplies();
 
   template <typename T>
-  void messageHandler(MessageBase *msg);
+  void messageHandler(std::unique_ptr<MessageBase> msg);
 
   template <typename T>
-  void onMessage(T *msg);
+  void onMessage(std::unique_ptr<T> msg);
 
   bool registerRequestOnPrimaryReplica(const std::string &batchCid,
                                        uint32_t batchSize,

--- a/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientBatchRequestMsg.hpp
@@ -61,6 +61,6 @@ inline size_t sizeOfHeader<ClientBatchRequestMsgHeader>() {
   return sizeof(ClientBatchRequestMsgHeader);
 }
 
-typedef std::unique_ptr<ClientBatchRequestMsg> ClientBatchRequestMsgUniquePtr;
+using ClientBatchRequestMsgUniquePtr = std::unique_ptr<ClientBatchRequestMsg>;
 
 }  // namespace bftEngine::impl

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -37,6 +37,7 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
 };
 
 typedef std::unique_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgUniquePtr;
+typedef std::shared_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgSharedPtr;
 
 }  // namespace preprocessor
 

--- a/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/ClientPreProcessRequestMsg.hpp
@@ -36,8 +36,8 @@ class ClientPreProcessRequestMsg : public ClientRequestMsg {
   std::unique_ptr<MessageBase> convertToClientRequestMsg(bool emptyReq = false);
 };
 
-typedef std::unique_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgUniquePtr;
-typedef std::shared_ptr<ClientPreProcessRequestMsg> ClientPreProcessReqMsgSharedPtr;
+using ClientPreProcessReqMsgUniquePtr = std::unique_ptr<ClientPreProcessRequestMsg>;
+using ClientPreProcessReqMsgSharedPtr = std::shared_ptr<ClientPreProcessRequestMsg>;
 
 }  // namespace preprocessor
 

--- a/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.hpp
@@ -67,6 +67,7 @@ class PreProcessBatchReplyMsg : public MessageBase {
   PreProcessReplyMsgsList preProcessReplyMsgsList_;
 };
 
+using PreProcessBatchReplyMsgUniquePtr = std::unique_ptr<PreProcessBatchReplyMsg>;
 using PreProcessBatchReplyMsgSharedPtr = std::shared_ptr<PreProcessBatchReplyMsg>;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchRequestMsg.hpp
@@ -74,6 +74,7 @@ class PreProcessBatchRequestMsg : public MessageBase {
   PreProcessReqMsgsList preProcessReqMsgsList_;
 };
 
+using PreProcessBatchReqMsgUniquePtr = std::unique_ptr<PreProcessBatchRequestMsg>;
 using PreProcessBatchReqMsgSharedPtr = std::shared_ptr<PreProcessBatchRequestMsg>;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -112,7 +112,7 @@ class PreProcessReplyMsg : public MessageBase {
   inline static preprocessor::PreProcessorRecorder* preProcessorHistograms_ = nullptr;
 };
 
-typedef std::unique_ptr<PreProcessReplyMsg> PreProcessReplyMsgUniquePtr;
-typedef std::shared_ptr<PreProcessReplyMsg> PreProcessReplyMsgSharedPtr;
+using PreProcessReplyMsgUniquePtr = std::unique_ptr<PreProcessReplyMsg>;
+using PreProcessReplyMsgSharedPtr = std::shared_ptr<PreProcessReplyMsg>;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessReplyMsg.hpp
@@ -112,6 +112,7 @@ class PreProcessReplyMsg : public MessageBase {
   inline static preprocessor::PreProcessorRecorder* preProcessorHistograms_ = nullptr;
 };
 
+typedef std::unique_ptr<PreProcessReplyMsg> PreProcessReplyMsgUniquePtr;
 typedef std::shared_ptr<PreProcessReplyMsg> PreProcessReplyMsgSharedPtr;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -105,6 +105,7 @@ class PreProcessRequestMsg : public MessageBase {
   Header* msgBody() const { return ((Header*)msgBody_); }
 };
 
+typedef std::unique_ptr<PreProcessRequestMsg> PreProcessRequestMsgUniquePtr;
 typedef std::shared_ptr<PreProcessRequestMsg> PreProcessRequestMsgSharedPtr;
 
 }  // namespace preprocessor

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.hpp
@@ -105,7 +105,7 @@ class PreProcessRequestMsg : public MessageBase {
   Header* msgBody() const { return ((Header*)msgBody_); }
 };
 
-typedef std::unique_ptr<PreProcessRequestMsg> PreProcessRequestMsgUniquePtr;
-typedef std::shared_ptr<PreProcessRequestMsg> PreProcessRequestMsgSharedPtr;
+using PreProcessRequestMsgUniquePtr = std::unique_ptr<PreProcessRequestMsg>;
+using PreProcessRequestMsgSharedPtr = std::shared_ptr<PreProcessRequestMsg>;
 
 }  // namespace preprocessor

--- a/bftengine/tests/incomingMsgsStorage/incomingMsgsStorage_test.cpp
+++ b/bftengine/tests/incomingMsgsStorage/incomingMsgsStorage_test.cpp
@@ -31,7 +31,7 @@ using namespace std::chrono_literals;
 
 class incoming_msgs_storage_test : public ::testing::Test {
   void SetUp() override {
-    reg_->registerMsgHandler(msg_id_, [this](MessageBase* msg) { consumer_(msg); });
+    reg_->registerMsgHandler(msg_id_, [this](std::unique_ptr<MessageBase> msg) { consumer_(move(msg)); });
     storage_.emplace(reg_, msg_wait_timeout_, replica_id_);
     storage_->start();
   }
@@ -41,7 +41,6 @@ class incoming_msgs_storage_test : public ::testing::Test {
  protected:
   auto newMsg() const { return std::make_unique<MessageBase>(sender_, msg_id_, msg_size_); }
   auto newMsg(std::uint16_t msg_id) const { return std::make_unique<MessageBase>(sender_, msg_id, msg_size_); }
-  static std::unique_ptr<MessageBase> own(MessageBase* msg) { return std::unique_ptr<MessageBase>{msg}; }
   auto waitTillMsgConsumed() { return consumer_.get_future().get(); }
   std::string buffer() const { return std::string(maxMessageSize<MessageBase>(), '\0'); }
 
@@ -51,7 +50,8 @@ class incoming_msgs_storage_test : public ::testing::Test {
   const NodeIdType sender_{0};
   const std::chrono::milliseconds msg_wait_timeout_{100ms};
   const MsgSize msg_size_{sizeof(MessageBase::Header)};
-  std::packaged_task<std::unique_ptr<MessageBase>(MessageBase*)> consumer_{[](MessageBase* msg) { return own(msg); }};
+  std::packaged_task<std::unique_ptr<MessageBase>(std::unique_ptr<MessageBase>)> consumer_{
+      [](std::unique_ptr<MessageBase> msg) { return msg; }};
   const std::shared_ptr<MsgHandlersRegistrator> reg_ = std::make_shared<MsgHandlersRegistrator>();
   std::optional<IncomingMsgsStorageImp> storage_;
 };
@@ -93,14 +93,15 @@ TEST_F(incoming_msgs_storage_test, push_external_from_consumer_thread) {
   auto popped = std::atomic_bool{false};
   auto reg = std::make_shared<MsgHandlersRegistrator>();
   auto storage = std::unique_ptr<IncomingMsgsStorageImp>{};
-  auto consumer1 = std::packaged_task<std::unique_ptr<MessageBase>(MessageBase*)>{[&](MessageBase* msg) {
-    storage->pushExternalMsg(newMsg(msg_id_ + 1), [&popped]() { popped = true; });
-    return own(msg);
-  }};
-  auto consumer2 =
-      std::packaged_task<std::unique_ptr<MessageBase>(MessageBase*)>{[&](MessageBase* msg) { return own(msg); }};
-  reg->registerMsgHandler(msg_id_, [&](MessageBase* msg) { consumer1(msg); });
-  reg->registerMsgHandler(msg_id_ + 1, [&](MessageBase* msg) { consumer2(msg); });
+  auto consumer1 = std::packaged_task<std::unique_ptr<MessageBase>(std::unique_ptr<MessageBase> msg)>{
+      [&](std::unique_ptr<MessageBase> msg) {
+        storage->pushExternalMsg(newMsg(msg_id_ + 1), [&popped]() { popped = true; });
+        return msg;
+      }};
+  auto consumer2 = std::packaged_task<std::unique_ptr<MessageBase>(std::unique_ptr<MessageBase>)>{
+      [&](std::unique_ptr<MessageBase> msg) { return msg; }};
+  reg->registerMsgHandler(msg_id_, [&](std::unique_ptr<MessageBase> msg) { consumer1(move(msg)); });
+  reg->registerMsgHandler(msg_id_ + 1, [&](std::unique_ptr<MessageBase> msg) { consumer2(move(msg)); });
   storage = std::make_unique<IncomingMsgsStorageImp>(reg, msg_wait_timeout_, replica_id_);
   storage->start();
   storage->pushExternalMsg(newMsg(msg_id_));

--- a/utt-replica/signature-processor/src/sigProcessor.cpp
+++ b/utt-replica/signature-processor/src/sigProcessor.cpp
@@ -86,11 +86,11 @@ SigProcessor::SigProcessor(uint16_t repId,
       n_{n},
       threshold_{threshold},
       timer_handler_timeout_{timer_handler_timeout} {
-  msg_handlers->registerMsgHandler(bftEngine::impl::MsgCode::Reserved, [&](bftEngine::impl::MessageBase* message) {
-    messages::PartialSigMsg* msg = (messages::PartialSigMsg*)message;
-    onReceivingNewPartialSig(msg->getsig_id(), msg->idOfGeneratedReplica(), msg->getPartialSig());
-    delete msg;
-  });
+  msg_handlers->registerMsgHandler(
+      bftEngine::impl::MsgCode::Reserved, [&](std::unique_ptr<bftEngine::impl::MessageBase> message) {
+        auto msg = std::make_unique<messages::PartialSigMsg>(message.release());
+        onReceivingNewPartialSig(msg->getsig_id(), msg->idOfGeneratedReplica(), msg->getPartialSig());
+      });
   timeout_handler_ = timers_.add(std::chrono::milliseconds(timer_handler_timeout_),
                                  concordUtil::Timers::Timer::RECURRING,
                                  [&](concordUtil::Timers::Handle h) {

--- a/utt-replica/signature-processor/tests/sigProcessorTests.cpp
+++ b/utt-replica/signature-processor/tests/sigProcessorTests.cpp
@@ -294,8 +294,8 @@ class test_utt_instance : public ::testing::Test {
       sig_processors[i] = std::make_shared<utt::SigProcessor>(
           i, n, t, 1000, msc, msr, ((IncomingMsgsStorageImp*)(ims.get()))->timers());
       auto sp = sig_processors[i];
-      msr->registerMsgHandler(MsgCode::ClientRequest, [&, sp](bftEngine::impl::MessageBase* message) {
-        ClientRequestMsg* msg = (ClientRequestMsg*)message;
+      msr->registerMsgHandler(MsgCode::ClientRequest, [&, sp](std::unique_ptr<bftEngine::impl::MessageBase> message) {
+        auto msg = std::make_unique<ClientRequestMsg>(message.release());
         uint64_t job_id{0};
 
         std::vector<uint8_t> cs_buffer(msg->requestLength() - sizeof(uint64_t));
@@ -316,7 +316,6 @@ class test_utt_instance : public ::testing::Test {
         }
         sp->onReceivingNewValidFullSig(job_id);
         cv.notify_all();
-        delete msg;
       });
       msc->startCommunication(i);
       msc->startMsgsProcessing(i);


### PR DESCRIPTION
- Problem Overview
BFT messages are used as raw pointers in the concord-bft code, as a result, we have memory leaks. This code has to be improved by starting to use managed pointers instead. This PR changes the onMessage API to pass messages as smart pointers and have initial support for them in the PreProcessor module.

- Testing Done
Runs on a reserved system with interruptions + Maestro high-end run.
