### PR TITLE
Stability fix for test test_view_change_with_non_primary_replica_in_s…

### DIFF
--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -583,7 +583,7 @@ class SkvbcRestartRecoveryTest(ApolloTest):
             # Advance the system 5 Checkpoints.
             skvbc = kvbc.SimpleKVBCProtocol(bft_network, tracker)
             await skvbc.fill_and_wait_for_checkpoint(
-                initial_nodes=bft_network.all_replicas(without={replica_to_restart}),
+                initial_nodes=[next_primary],
                 num_of_checkpoints_to_add=5,
                 verify_checkpoint_persistency=False,
                 assert_state_transfer_not_started=False


### PR DESCRIPTION
…tate_transfer.

While we are advancing the system we need to narrow down the selection of replicas to ones we are sure have the latest state. We therefore chose the expected next primary.

* **Problem Overview**  
 Test instability was observed during nightly runs.
* **Testing Done**  
  Tested locally with multiple runs to verify stability.
