### PR TITLE
Small fix in verify_matching_replica_client_communication()

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -29,7 +29,7 @@ import inspect
 import time
 from pathlib import Path
 from typing import Coroutine, Sequence, Callable
-
+import re
 import trio
 
 from util.test_base import repeat_test
@@ -872,10 +872,11 @@ class BftTestNetwork:
             'PlainUdp': bft_client.UdpClient
         }
 
+        communication_phrase = communication_str + ".*,"
         log_data = ""
         with open(replica_test_log_path, 'r') as replica_log:
             time_elapsed = 0
-            while communication_str not in log_data and \
+            while re.search(communication_phrase, log_data) is None and \
                     time_elapsed < timeout_seconds and \
                     len(log_data) < max_read_bytes:
                 log_data += replica_log.read(chunk_bytes)


### PR DESCRIPTION
Keep reading log file until the comma that comes after communication key ('Replica communication protocol=') to ensure we have the whole string of communication type ('TlsTcp' or 'PlainUdp').

* **Problem Overview**  
  We read from replica nodes the communication protocol (tcp/udp). That was done by reading till 'Replica communication protocol=' was read. Should make sure to read till the end of the value that comes after the =  
* **Testing Done**  
  Apollo tests
