### PR TITLE
Fix the memory leaks in sigProcessorTests

### DIFF
--- a/utt-replica/signature-processor/tests/sigProcessorTests.cpp
+++ b/utt-replica/signature-processor/tests/sigProcessorTests.cpp
@@ -293,8 +293,8 @@ class test_utt_instance : public ::testing::Test {
       message_comms[i] = msc;
       sig_processors[i] = std::make_shared<utt::SigProcessor>(
           i, n, t, 1000, msc, msr, ((IncomingMsgsStorageImp*)(ims.get()))->timers());
-      msr->registerMsgHandler(MsgCode::ClientRequest, [&, i](bftEngine::impl::MessageBase* message) {
-        ClientRequestMsg* msg = (ClientRequestMsg*)message;
+      msr->registerMsgHandler(MsgCode::ClientRequest, [&, i](std::unique_ptr<bftEngine::impl::MessageBase> message) {
+        ClientRequestMsg* msg = (ClientRequestMsg*)(message.get());
         uint64_t job_id{0};
 
         std::vector<uint8_t> cs_buffer(msg->requestLength() - sizeof(uint64_t));

--- a/utt-replica/signature-processor/tests/sigProcessorTests.cpp
+++ b/utt-replica/signature-processor/tests/sigProcessorTests.cpp
@@ -293,8 +293,7 @@ class test_utt_instance : public ::testing::Test {
       message_comms[i] = msc;
       sig_processors[i] = std::make_shared<utt::SigProcessor>(
           i, n, t, 1000, msc, msr, ((IncomingMsgsStorageImp*)(ims.get()))->timers());
-      auto sp = sig_processors[i];
-      msr->registerMsgHandler(MsgCode::ClientRequest, [&, sp](bftEngine::impl::MessageBase* message) {
+      msr->registerMsgHandler(MsgCode::ClientRequest, [&, i](bftEngine::impl::MessageBase* message) {
         ClientRequestMsg* msg = (ClientRequestMsg*)message;
         uint64_t job_id{0};
 
@@ -314,7 +313,7 @@ class test_utt_instance : public ::testing::Test {
             }
           }
         }
-        sp->onReceivingNewValidFullSig(job_id);
+        sig_processors[i]->onReceivingNewValidFullSig(job_id);
         cv.notify_all();
         delete msg;
       });
@@ -328,6 +327,8 @@ class test_utt_instance : public ::testing::Test {
       message_comms[i]->stopMsgsProcessing();
       message_comms[i]->stopCommunication();
     }
+    sig_processors.clear();
+    message_comms.clear();
   }
   bool wait_cond(uint64_t sigId, uint16_t source) {
     if (full_signatures.find(source) == full_signatures.end()) return false;


### PR DESCRIPTION
* **Problem Overview**  
  ASAN reported leaks in sigProcessorTests. 
  After digging into it, it appears that due to some circular ownership of smart pointers, the constructors have not been called. 
This PR is top fix the memory leaks reported by ASAN
To clarify, the leaks were related to the test only and were reported at its end as the smart pointers were not released. No leaks in the actual SigProcessor component.
* **Testing Done**  
  Running SigProcessorTests under ASAN
