### PR TITLE
Small fix in verify_matching_replica_client_communication()

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -882,6 +882,10 @@ class BftTestNetwork:
                 time.sleep(sleep_seconds)
                 time_elapsed += sleep_seconds
 
+            # make sure we have read the whole communication phrase
+            if "," not in log_data[log_data.find(communication_str) + len(communication_str):]:
+                log_data += replica_log.read(chunk_bytes)
+
         assert communication_str in log_data, \
             f"Communication str not in {max_read_bytes + chunk_bytes} first bytes of the log, " \
             f"time elapsed: {time_elapsed}, read bytes: {len(log_data)}"


### PR DESCRIPTION
Keep reading log file until the comma that comes after communication key ('Replica communication protocol=') to ensure we have the whole string of communication type ('TlsTcp' or 'PlainUdp').

* **Problem Overview**  
  We read from replica nodes the communication protocol (tcp/udp). That was done by reading till 'Replica communication protocol=' was read. Should make sure to read till the end of the value that comes after the =
* **Testing Done**  
  Apollo
