### PR TITLE
Emit lastexecutedSeqNum as well in get status for replica

### DIFF
--- a/bftengine/src/bftengine/ReadOnlyReplica.cpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.cpp
@@ -278,7 +278,7 @@ void ReadOnlyReplica::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_s
 
 void ReadOnlyReplica::registerStatusHandlers() {
   auto h = concord::diagnostics::StatusHandler(
-      "replica", "Last executed sequence number of the read-only replica", [this]() {
+      "replica-sequence-numbers", "Last executed sequence number of the read-only replica", [this]() {
         concordUtils::BuildJson bj;
 
         bj.startJson();

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -1663,6 +1663,13 @@ std::string ReplicaImp::getReplicaLastStableSeqNum() const {
   return j.dump();
 }
 
+std::string ReplicaImp::getReplicaSequenceNumbers() const {
+  nlohmann::json j;
+  j["sequenceNumbers"]["lastStableSeqNum"] = std::to_string(lastStableSeqNum);
+  j["sequenceNumbers"]["lastExecutedSeqNum"] = std::to_string(getLastExecutedSeqNum());
+  return j.dump();
+}
+
 std::string ReplicaImp::getReplicaState() const {
   auto primary = getReplicasInfo().primaryOfView(getCurrentView());
   concordUtils::BuildJson bj;
@@ -1717,8 +1724,8 @@ std::string ReplicaImp::getReplicaState() const {
 }
 
 void ReplicaImp::onInternalMsg(GetStatus &status) const {
-  if (status.key == "replica") {  // TODO: change this key name (coordinate with deployment)
-    return status.output.set_value(getReplicaLastStableSeqNum());
+  if (status.key == "replica-sequence-numbers") {  // TODO: change this key name (coordinate with deployment)
+    return status.output.set_value(getReplicaSequenceNumbers());
   }
 
   if (status.key == "replica-state") {

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -471,6 +471,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // Generate diagnostics status replies
   std::string getReplicaState() const;
   std::string getReplicaLastStableSeqNum() const;
+  std::string getReplicaSequenceNumbers() const;
   template <typename T>
   void onMessage(T* msg);
 

--- a/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
+++ b/bftengine/src/bftengine/ReplicaStatusHandlers.cpp
@@ -39,7 +39,8 @@ void ReplicaStatusHandlers::registerStatusHandlers() const {
   };
 
   // TODO: handler name left for backward compatibility with callers, change the name 'replica'.
-  auto replica_handler = make_handler_callback("replica", "Last stable sequence number of the concord-bft replica");
+  auto replica_handler = make_handler_callback(
+      "replica-sequence-numbers", "Last stable and Last executed sequence number of the concord-bft replica");
   auto state_transfer_handler = make_handler_callback("state-transfer", "Status of blockchain state transfer");
   auto key_exchange_handler = make_handler_callback("key-exchange", "Status of key-exchange");
   auto preexecution_handler = make_handler_callback("pre-execution", "Status of pre-execution");


### PR DESCRIPTION
* **Problem Overview**  

Replica currently emits out lastStableSeqNum on using "status get replica" command with concord-ctl diagnostic tool and 
RO Replica currently emits out lastExecutedSeqNum on using "status get replica" command with concord-ctl diagnostic tool.

Agent code for concord.health earlier used to check for lastStableSeqNum to validate health status on replica but this check always failed for RO-Replica as they emit lastExecutedSeqNum.

We want to have consistency between health check of both Replica and RO-Replica.
Agent code for concord.health now checks for lastExecutedSeqNum for both Replica and RO-Replica and hence, this change makes sure Replicas emit lastExecutedSeqNum as well on using "status get replica" command

Used to_string function to make seqNum values a string because RO-Replica also emits seqNum values as string. (See - ReadOnlyReplica::registerStatusHandlers()). This is to maintain consistency in parsing both inputs (from Replica and RO-Replica) in agent health check code.

* **Testing Done**  

Tested on castor deployment and validated agent logs for the same.

Logs : 

```
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord# ./concord-ctl status get replica
*--STATUS_NOT_FOUND--*

root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord# ./concord-ctl status get replica-sequence-numbers
{"sequenceNumbers":{"lastExecutedSeqNum":"33","lastStableSeqNum":"0"}}

root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord# ./concord-ctl status get replica-sequence-numbers | cut -d":" -f4 | cut -d"}" -f1
"0"

root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
root@e613b65592a8:/concord#
```

```
2022-11-25 13:42:51.119  INFO 1 --- [taskScheduler-1] .b.a.s.n.h.c.ConcordHealthServiceInvoker : Creating client socket. host: 172.18.0.8, port: 6888
2022-11-25 13:42:51.120  INFO 1 --- [taskScheduler-1] .b.a.s.n.h.c.ConcordHealthServiceInvoker : Sending request to concord socket server:
status get replica-sequence-numbers

2022-11-25 13:42:51.121  INFO 1 --- [taskScheduler-1] .b.a.s.n.h.c.ConcordHealthServiceInvoker : Message received from concord:
{"sequenceNumbers":{"lastExecutedSeqNum":"33","lastStableSeqNum":"0"}}
2022-11-25 13:42:51.121  INFO 1 --- [taskScheduler-1] .b.a.s.n.h.c.ConcordHealthServiceInvoker : lastExecutedSeqNum: 33
2022-11-25 13:42:51.121  INFO 1 --- [taskScheduler-1] .b.a.s.n.h.c.ConcordHealthServiceInvoker : Metric agent.health.concord is updated with value 0
2022-11-25 13:42:51.121  INFO 1 --- [taskScheduler-1] c.v.b.a.s.n.health.HealthCheckScheduler  : Calling daml health check in background..
2022-11-25 13:42:51.121  INFO 1 --- [taskScheduler-1] c.v.b.a.s.n.h.NodeComponentHealthFactory : Invoking com.vmware.blockchain.agent.services.node.health.daml.DamlHealth
2022-11-25 13:42:51.122  INFO 1 --- [taskScheduler-1] c.v.b.a.s.node.health.daml.DamlHealth    : Invoking daml health query..
2022-11-25 13:42:51.122  INFO 1 --- [taskScheduler-1] c.v.b.a.s.n.h.d.DamlHealthServiceInvoker : received health check request for daml components.
2022-11-25 13:42:51.134  INFO 1 --- [onPool-worker-3] c.v.b.a.s.n.h.d.DamlHealthServiceInvoker : Request - service: "validator"
; Response - status: SERVING
```