### PR TITLE
State transfer remove a wrong assertion on reserved pages only cycle

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -375,7 +375,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
     LOG_TRACE(GL, "Thread ID: " << std::this_thread::get_id());
     return stateTransfer->isCollectingState();
   }
-  void startCollectingState(std::string&& reason = "");
+  void startCollectingState(std::string_view reason = "");
   bool isValidClient(NodeIdType clientId) const override { return clientsManager->isValidClient(clientId); }
   bool isIdOfReplica(NodeIdType id) const override { return repsInfo->isIdOfReplica(id); }
   const std::set<ReplicaId>& getIdsOfPeerReplicas() const override { return repsInfo->idsOfPeerReplicas(); }


### PR DESCRIPTION
* **Problem Overview**  
Remove a wrong assertion on ST cycle which requires fetching only reserved pages.
In some rare cases replica might need to collect reserved pages which
it already has (this is done that way for simplification) This is not
an error, but should by highlighted with warning

* **Testing Done**  
Added a new unittest dstEmptyCycleWithReservdPagesOnly to check this rare case
