### PR TITLE
DbCheckpointManager:fix forced kill of concord (sleeping monitor thread)

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -119,6 +119,7 @@ class DbCheckpointManager {
   }
   ~DbCheckpointManager() {
     stopped_ = true;
+    shutdownCond_.notify_all();  // to wake up monitor thread so it can be destructed
     if (monitorThread_.joinable()) monitorThread_.join();
   }
   void sendInternalCreateDbCheckpointMsg(const SeqNum& seqNum, bool noop);
@@ -196,6 +197,8 @@ class DbCheckpointManager {
   mutable std::mutex lock_;
   mutable std::mutex lockDbCheckPtFuture_;
   std::mutex lockLastDbCheckpointDesc_;
+  std::condition_variable shutdownCond_;  // used to wake up monitor thread periodically or when destructing an obj
+  std::mutex shutdownLock_;          // used for the above cond var. doesn't really coordinate anything between threads.
   uint32_t maxNumOfCheckpoints_{0};  // 0-disabled
   SeqNum lastCheckpointSeqNum_{0};
   std::optional<DbCheckpointMetadata::DbCheckPointDescriptor> lastCreatedCheckpointMetadata_{std::nullopt};


### PR DESCRIPTION
DB checkpoint manager monitor thread was sleeping for 60 secs (default) intervals, preventing concord from shutting down gracefully on a relevant signal (such as SIGTERM). It is now using a cond var and the monitor thread is woken up upon destruction of DbCheckpointManager obj

