### PR TITLE
Fix memory leaks caused by a duplicated message creation

### DIFF
--- a/bftengine/src/bftengine/ReadOnlyReplica.hpp
+++ b/bftengine/src/bftengine/ReadOnlyReplica.hpp
@@ -43,7 +43,8 @@ class ReadOnlyReplica : public ReplicaForStateTransfer {
 
   template <typename T>
   void messageHandler(std::unique_ptr<MessageBase> msg) {
-    auto trueTypeObj = std::make_unique<T>(msg.release());
+    auto trueTypeObj = std::make_unique<T>(msg.get());
+    msg.reset();
     if (validateMessage(trueTypeObj.get())) {
       onMessage<T>(std::move(trueTypeObj));
     }

--- a/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.hpp
@@ -58,7 +58,8 @@ class ReplicaForStateTransfer : public IReplicaForStateTransfer, public ReplicaB
 
   template <typename T>
   void messageHandler(std::unique_ptr<MessageBase> msg) {
-    auto trueTypeObj = std::make_unique<T>(msg.release());
+    auto trueTypeObj = std::make_unique<T>(msg.get());
+    msg.reset();
     if (validateMessage(trueTypeObj.get())) {
       onMessage<T>(std::move(trueTypeObj));
     }

--- a/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
+++ b/bftengine/src/bftengine/messages/AskForCheckpointMsg.hpp
@@ -28,8 +28,6 @@ class AskForCheckpointMsg : public MessageBase {
 
   BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(AskForCheckpointMsg)
 
-  AskForCheckpointMsg* clone() { return new AskForCheckpointMsg(*this); }
-
   void validate(const ReplicasInfo& repInfo) const override {
     ConcordAssert(type() == MsgCode::AskForCheckpoint);
     ConcordAssert(senderId() != repInfo.myId());
@@ -52,4 +50,5 @@ class AskForCheckpointMsg : public MessageBase {
 
   Header* b() const { return (Header*)msgBody_; }
 };
+
 }  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/messages/MessageBase.cpp
+++ b/bftengine/src/bftengine/messages/MessageBase.cpp
@@ -82,18 +82,6 @@ bool MessageBase::reallocSize(uint32_t size) {
   }
 }
 
-MessageBase::MessageBase(NodeIdType sender) {
-  storageSize_ = 0;
-  msgBody_ = nullptr;
-  msgSize_ = 0;
-  owner_ = false;
-  sender_ = sender;
-
-#ifdef DEBUG_MEMORY_MSG
-  liveMessagesDebug.insert(this);
-#endif
-}
-
 MessageBase::MessageBase(NodeIdType sender, MsgType type, MsgSize size) : MessageBase(sender, type, 0u, size) {}
 
 MessageBase::MessageBase(NodeIdType sender, MsgType type, SpanContextSize spanContextSize, MsgSize size) {

--- a/bftengine/src/bftengine/messages/MessageBase.hpp
+++ b/bftengine/src/bftengine/messages/MessageBase.hpp
@@ -35,14 +35,10 @@ class MessageBase {
 
   static_assert(sizeof(Header) == 6, "MessageBase::Header is 6B");
 
-  explicit MessageBase(NodeIdType sender);
-
   MessageBase(NodeIdType sender, MsgType type, MsgSize size);
   MessageBase(NodeIdType sender, MsgType type, SpanContextSize spanContextSize, MsgSize size);
 
   MessageBase(NodeIdType sender, Header *body, MsgSize size, bool ownerOfStorage);
-
-  void acquireOwnership() { owner_ = true; }
 
   void releaseOwnership() { owner_ = false; }
 
@@ -126,7 +122,7 @@ class MessageBase {
 };
 
 // Every subclass of MessageBase has to use this macro to generate a constructor for creation from MessageBase.
-// During deserialization we first place the raw char array that we receive with the actual message into the msgBody_
+// During de-serialization we first place the raw char array that we receive with the actual message into the msgBody_
 // of a MessageBase object to be able to get the msgType. Later during dispatch we need to create an object of the
 // actual message type from the MessageBase object holding the msgBody_ of the actual message.
 #define BFTENGINE_GEN_CONSTRUCT_FROM_BASE_MESSAGE(TrueTypeName)                                                     \

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.cpp
@@ -131,7 +131,7 @@ PrePrepareMsg::PrePrepareMsg(ReplicaId sender, ViewNum v, SeqNum s, CommitPath f
 // Sequence number provided in the PPM at the time of constructor call might change later
 // This will result into allotment of next available sequence number. As the sequence number
 // is a monotonically increasing series, the next available sequence number will be greater
-// then the sequence number allocated and with a probability of 1/(10^digits(seqNum)), the
+// than the sequence number allocated and with a probability of 1/(10^digits(seqNum)), the
 // next available seq number is having one more digit. As this probability is decreasing
 // exponentially for higher digits, the case of seq number with next digit is only taken care,
 // and a 0 is prefixed.
@@ -280,18 +280,6 @@ bool PrePrepareMsg::checkRequests() const {
 
   ConcordAssert(false);
   return false;
-}
-const std::string PrePrepareMsg::getClientCorrelationIdForMsg(int index) const {
-  auto it = RequestsIterator(this);
-  int req_num = 0;
-  while (!it.end() && req_num < index) {
-    it.gotoNext();
-    req_num++;
-  }
-  if (it.end()) return std::string();
-  char* requestBody = nullptr;
-  it.getCurrent(requestBody);
-  return ClientRequestMsg((ClientRequestMsgHeader*)requestBody).getCid();
 }
 
 const std::string PrePrepareMsg::getBatchCorrelationIdAsString() const {

--- a/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
+++ b/bftengine/src/bftengine/messages/PrePrepareMsg.hpp
@@ -116,7 +116,6 @@ class PrePrepareMsg : public MessageBase {
   // update view and first path
 
   void updateView(ViewNum v, CommitPath firstPath = CommitPath::SLOW);
-  const std::string getClientCorrelationIdForMsg(int index) const;
   const std::string getBatchCorrelationIdAsString() const;
 
  protected:

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1227,38 +1227,64 @@ void PreProcessor::msgProcessingLoop() {
         delete msg;
         continue;
       }
-      if (validateMessage(msg)) {
-        switch (msg->type()) {
-          case (MsgCode::ClientBatchRequest): {
-            onMessage<ClientBatchRequestMsg>(make_unique<ClientBatchRequestMsg>(msg));
-            break;
+      switch (msg->type()) {
+        case (MsgCode::ClientBatchRequest): {
+          auto msgPtr = make_unique<ClientBatchRequestMsg>(msg);
+          if (validateMessage(msgPtr.get())) {
+            onMessage<ClientBatchRequestMsg>(std::move(msgPtr));
+          } else {
+            preProcessorMetrics_.preProcReqInvalid++;
           }
-          case (MsgCode::ClientPreProcessRequest): {
-            onMessage<ClientPreProcessRequestMsg>(make_unique<ClientPreProcessRequestMsg>(msg));
-            break;
-          }
-          case (MsgCode::PreProcessRequest): {
-            onMessage<PreProcessRequestMsg>(make_unique<PreProcessRequestMsg>(msg));
-            break;
-          }
-          case (MsgCode::PreProcessBatchRequest): {
-            onMessage<PreProcessBatchRequestMsg>(make_unique<PreProcessBatchRequestMsg>(msg));
-            break;
-          }
-          case (MsgCode::PreProcessReply): {
-            onMessage<PreProcessReplyMsg>(make_unique<PreProcessReplyMsg>(msg));
-            break;
-          }
-          case (MsgCode::PreProcessBatchReply): {
-            onMessage<PreProcessBatchReplyMsg>(make_unique<PreProcessBatchReplyMsg>(msg));
-            break;
-          }
-          default:
-            LOG_ERROR(logger(), "Unknown message" << KVLOG(msg->type()));
-            delete msg;
+          break;
         }
-      } else {
-        preProcessorMetrics_.preProcReqInvalid++;
+        case (MsgCode::ClientPreProcessRequest): {
+          auto msgPtr = make_unique<ClientPreProcessRequestMsg>(msg);
+          if (validateMessage(msgPtr.get())) {
+            onMessage<ClientPreProcessRequestMsg>(std::move(msgPtr));
+          } else {
+            preProcessorMetrics_.preProcReqInvalid++;
+          }
+          break;
+        }
+        case (MsgCode::PreProcessRequest): {
+          auto msgPtr = make_unique<PreProcessRequestMsg>(msg);
+          if (validateMessage(msgPtr.get())) {
+            onMessage<PreProcessRequestMsg>(std::move(msgPtr));
+          } else {
+            preProcessorMetrics_.preProcReqInvalid++;
+          }
+          break;
+        }
+        case (MsgCode::PreProcessBatchRequest): {
+          auto msgPtr = make_unique<PreProcessBatchRequestMsg>(msg);
+          if (validateMessage(msgPtr.get())) {
+            onMessage<PreProcessBatchRequestMsg>(std::move(msgPtr));
+          } else {
+            preProcessorMetrics_.preProcReqInvalid++;
+          }
+          break;
+        }
+        case (MsgCode::PreProcessReply): {
+          auto msgPtr = make_unique<PreProcessReplyMsg>(msg);
+          if (validateMessage(msgPtr.get())) {
+            onMessage<PreProcessReplyMsg>(std::move(msgPtr));
+          } else {
+            preProcessorMetrics_.preProcReqInvalid++;
+          }
+          break;
+        }
+        case (MsgCode::PreProcessBatchReply): {
+          auto msgPtr = make_unique<PreProcessBatchReplyMsg>(msg);
+          if (validateMessage(msgPtr.get())) {
+            onMessage<PreProcessBatchReplyMsg>(std::move(msgPtr));
+          } else {
+            preProcessorMetrics_.preProcReqInvalid++;
+          }
+          break;
+        }
+        default:
+          LOG_ERROR(logger(), "Unknown message" << KVLOG(msg->type()));
+          delete msg;
       }
     }
   }

--- a/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.hpp
+++ b/bftengine/src/preprocessor/messages/PreProcessBatchReplyMsg.hpp
@@ -32,7 +32,6 @@ class PreProcessBatchReplyMsg : public MessageBase {
 
   std::string getCid() const;
   uint16_t clientId() const { return msgBody()->clientId; }
-  uint32_t numOfMessagesInBatch() const { return msgBody()->numOfMessagesInBatch; }
   ViewNum viewNum() const { return msgBody()->viewNum; }
   PreProcessReplyMsgsList& getPreProcessReplyMsgs();
   void validate(const ReplicasInfo&) const override;

--- a/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
+++ b/bftengine/src/preprocessor/messages/PreProcessRequestMsg.cpp
@@ -94,7 +94,7 @@ void PreProcessRequestMsg::validate(const ReplicasInfo& repInfo) const {
   }
 
   if (senderId() == repInfo.myId()) {
-    LOG_WARN(logger(), "Message sender is ivalid" << KVLOG(senderId(), repInfo.myId()));
+    LOG_WARN(logger(), "Message sender is invalid" << KVLOG(senderId(), repInfo.myId()));
     throw std::runtime_error(__PRETTY_FUNCTION__);
   }
 

--- a/utt-replica/signature-processor/src/sigProcessor.cpp
+++ b/utt-replica/signature-processor/src/sigProcessor.cpp
@@ -88,7 +88,7 @@ SigProcessor::SigProcessor(uint16_t repId,
       timer_handler_timeout_{timer_handler_timeout} {
   msg_handlers->registerMsgHandler(
       bftEngine::impl::MsgCode::Reserved, [&](std::unique_ptr<bftEngine::impl::MessageBase> message) {
-        auto msg = std::make_unique<messages::PartialSigMsg>(message.release());
+        std::unique_ptr<messages::PartialSigMsg> msg(reinterpret_cast<messages::PartialSigMsg*>(message.release()));
         onReceivingNewPartialSig(msg->getsig_id(), msg->idOfGeneratedReplica(), msg->getPartialSig());
       });
   timeout_handler_ = timers_.add(std::chrono::milliseconds(timer_handler_timeout_),

--- a/utt-replica/signature-processor/tests/sigProcessorTests.cpp
+++ b/utt-replica/signature-processor/tests/sigProcessorTests.cpp
@@ -294,7 +294,7 @@ class test_utt_instance : public ::testing::Test {
       sig_processors[i] = std::make_shared<utt::SigProcessor>(
           i, n, t, 1000, msc, msr, ((IncomingMsgsStorageImp*)(ims.get()))->timers());
       msr->registerMsgHandler(MsgCode::ClientRequest, [&, i](std::unique_ptr<bftEngine::impl::MessageBase> message) {
-        ClientRequestMsg* msg = (ClientRequestMsg*)(message.get());
+        std::unique_ptr<ClientRequestMsg> msg(reinterpret_cast<ClientRequestMsg*>(message.release()));
         uint64_t job_id{0};
 
         std::vector<uint8_t> cs_buffer(msg->requestLength() - sizeof(uint64_t));


### PR DESCRIPTION
* **Problem Overview**  
- After introducing the unique pointers in the messageHandler and onMessage APIs new memory leaks appeared. The problem was caused by a missing delete of an original message pointer.
- In addition, some unused functions have been removed.
- An initial call to the validate functions in the PreProcessor code has been fixed to call the correct virtual ones.
* **Testing Done**  
Apollo tests with asan (skvbc_basic_tests_v4, test_skvbc_reconfiguration, test_skvbc_state_transfer, skvbc_preexecution_tests), long-run Maestro tests with interruptions.
