### PR TITLE
Fix for halting CRE activity after ST.

### DIFF
--- a/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
+++ b/bftengine/src/bftengine/ReplicaForStateTransfer.cpp
@@ -94,12 +94,12 @@ void ReplicaForStateTransfer::start() {
                 succ = false;
                 break;
               }  // else if (!isGettingBlocks)
-              LOG_INFO(GL, "halting cre");
-              // 2. Now we can safely halt cre. We know for sure that there are no update in the state transffered
-              // blocks that haven't been handled yet
-              cre_->halt();
             }
           }  // while (!succ) {
+          LOG_INFO(GL, "halting cre");
+          // 2. Now we can safely halt cre. We know for sure that there are no update in the state transffered
+          // blocks that haven't been handled yet
+          cre_->halt();
         }
       },
       IStateTransfer::StateTransferCallBacksPriorities::HIGH);


### PR DESCRIPTION
We need to halt the CRE activity independently of the presence of reconfiguration events once State Transfer completes. Otherwise the polling loop never terminates and leads to unnecessary read load on the system.

* **Problem Overview**  
  CRE events are polled even though ST completes, leading to unnecessary read load in the system. 
* **Testing Done**  
  LRT test with multiple interruptions of replicas in a way that triggers State Transfer was performed and showed correct behavior after the fix.
