### PR TITLE
Remove the cyclic deps between reconfiguration and bftengine

### DIFF
--- a/bftengine/CMakeLists.txt
+++ b/bftengine/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Boost ${MIN_BOOST_VERSION})
 add_subdirectory("cmf")
 
 set(corebft_source_files
+    src/bftengine/Reconfiguration.cpp
     src/bftengine/PrimitiveTypes.cpp
     src/bftengine/DebugStatistics.cpp
     src/bftengine/SeqNumInfo.cpp

--- a/bftengine/src/bftengine/Reconfiguration.hpp
+++ b/bftengine/src/bftengine/Reconfiguration.hpp
@@ -1,35 +1,25 @@
 // Concord
 //
-// Copyright (c) 2018-2021 VMware, Inc. All Rights Reserved.
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
 //
-// This product is licensed to you under the Apache 2.0 license (the "License").
-// You may not use this product except in compliance with the Apache 2.0 License.
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
 //
-// This product may include a number of subcomponents with separate copyright
-// notices and license terms. Your use of these subcomponents is subject to the
-// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// This product may include a number of subcomponents with separate copyright notices and license terms. Your use of
+// these subcomponents is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
 // file.
 
 #pragma once
 
-#include "Logger.hpp"
-#include "Replica.hpp"
-#include "concord.cmf.hpp"
-#include "ireconfiguration.hpp"
-#include "OpenTracing.hpp"
-#include "SigManager.hpp"
+#include "reconfiguration/reconfiguration.hpp"
+#include "ReplicasInfo.hpp"
 
-namespace concord::reconfiguration {
-class BftReconfigurationHandler : public IReconfigurationHandler {
- public:
-  BftReconfigurationHandler();
-  bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override;
+namespace bftEngine::impl {
 
-  std::unique_ptr<concord::crypto::IVerifier> verifier_;
-};
-class ReconfigurationHandler : public BftReconfigurationHandler {
+class ReconfigurationHandler : public concord::reconfiguration::OperatorCommandsReconfigurationHandler {
  public:
-  ReconfigurationHandler() {}
+  ReconfigurationHandler(const std::string &operator_pub_key_path, concord::crypto::SignatureAlgorithm type)
+      : OperatorCommandsReconfigurationHandler{operator_pub_key_path, type} {}
   bool handle(const concord::messages::WedgeCommand &,
               uint64_t,
               uint32_t,
@@ -98,16 +88,16 @@ class ReconfigurationHandler : public BftReconfigurationHandler {
 
 class ClientReconfigurationHandler : public concord::reconfiguration::IReconfigurationHandler {
  public:
+  ClientReconfigurationHandler(const ReplicasInfo &reps_info) : reps_info_{reps_info} {}
   bool handle(const concord::messages::ClientExchangePublicKey &,
               uint64_t,
               uint32_t,
               const std::optional<bftEngine::Timestamp> &,
               concord::messages::ReconfigurationResponse &) override;
 
-  bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override {
-    if (!bftEngine::impl::SigManager::instance()->hasVerifier(sender_id)) return false;
-    return bftEngine::impl::SigManager::instance()->verifySig(sender_id, data, signature);
-  }
-};
+  bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override;
 
-}  // namespace concord::reconfiguration
+ protected:
+  ReplicasInfo reps_info_;
+};
+}  // namespace bftEngine::impl

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -20,6 +20,7 @@
 #include "SimpleClient.hpp"
 #include "SharedTypes.hpp"
 #include "ControlStateManager.hpp"
+#include "Replica.hpp"
 #include <optional>
 #include <sstream>
 

--- a/bftengine/src/bftengine/RequestHandler.h
+++ b/bftengine/src/bftengine/RequestHandler.h
@@ -12,11 +12,12 @@
 
 #pragma once
 
-#include "reconfiguration/reconfiguration_handler.hpp"
 #include "reconfiguration/dispatcher.hpp"
 #include "IRequestHandler.hpp"
 #include "Metrics.hpp"
-
+#include "ReplicasInfo.hpp"
+#include "Reconfiguration.hpp"
+#include "ReplicaConfig.hpp"
 #include <ccron/cron_table_registry.hpp>
 #include <optional>
 
@@ -26,12 +27,14 @@ class RequestHandler : public IRequestsHandler {
  public:
   RequestHandler(
       std::shared_ptr<concordMetrics::Aggregator> aggregator_ = std::make_shared<concordMetrics::Aggregator>()) {
-    using namespace concord::reconfiguration;
-    reconfig_handler_.push_back(std::make_shared<ReconfigurationHandler>());
+    bftEngine::impl::ReplicasInfo reps_info(ReplicaConfig::instance(), false, false);
+    reconfig_handler_.push_back(
+        std::make_shared<ReconfigurationHandler>(bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                                                 bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo));
     for (const auto &rh : reconfig_handler_) {
       reconfig_dispatcher_.addReconfigurationHandler(rh);
     }
-    reconfig_dispatcher_.addReconfigurationHandler(std::make_shared<ClientReconfigurationHandler>());
+    reconfig_dispatcher_.addReconfigurationHandler(std::make_shared<ClientReconfigurationHandler>(reps_info));
     reconfig_dispatcher_.setAggregator(aggregator_);
   }
 

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -13,19 +13,21 @@
 #pragma once
 
 #include "ReplicaConfig.hpp"
-#include "reconfiguration/ireconfiguration.hpp"
 #include "db_interfaces.h"
 #include "blockchain_misc.hpp"
 #include "hex_tools.h"
 #include "block_metadata.hpp"
 #include "kvbc_key_types.hpp"
 #include "SigManager.hpp"
-#include "reconfiguration/reconfiguration_handler.hpp"
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
 #include "AdaptivePruningManager.hpp"
 #include "IntervalMappingResourceManager.hpp"
 #include "newest_public_event_group_record_time.h"
 #include "bftengine/PersistentStorageImp.hpp"
+#include "Reconfiguration.hpp"
+#include "reconfiguration/reconfiguration.hpp"
+#include "Replica.hpp"
+#include "ControlStateManager.hpp"
 #include <functional>
 #include <string>
 #include <utility>
@@ -55,13 +57,18 @@ class ReconfigurationBlockTools {
 class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
                                             public concord::reconfiguration::IReconfigurationHandler {
  public:
-  StateSnapshotReconfigurationHandler(kvbc::IBlockAdder& block_adder,
+  StateSnapshotReconfigurationHandler(const std::string& path_to_operator_pub_key,
+                                      concord::crypto::SignatureAlgorithm sig_type,
+                                      const bftEngine::impl::ReplicasInfo& reps_info,
+                                      kvbc::IBlockAdder& block_adder,
                                       kvbc::IReader& ro_storage,
                                       const Converter& state_value_converter,
                                       const kvbc::LastApplicationTransactionTimeCallback& last_app_txn_time_cb_)
       : ReconfigurationBlockTools{block_adder, ro_storage},
         state_value_converter_{state_value_converter},
-        last_app_txn_time_cb_{last_app_txn_time_cb_} {}
+        last_app_txn_time_cb_{last_app_txn_time_cb_},
+        op_reconf_handler_{path_to_operator_pub_key, sig_type},
+        client_reconf_handler_{reps_info} {}
 
   bool handle(const concord::messages::StateSnapshotRequest&,
               uint64_t,
@@ -83,12 +90,12 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
 
   // Allow snapshot requests from the Operator and from Clients.
   bool verifySignature(uint32_t sender_id, const std::string& data, const std::string& signature) const override {
-    // Try the BFT reconfiguration handler first. If not verified by the reconfiguration handler, try the
+    // Try the operator reconfiguration handler first. If not verified by the reconfiguration handler, try the
     // ClientReconfigurationHandler, if transaction signing is enabled, else donot check the signature.
     // For StateSnapshotRequest, SignedPublicStateHashRequest and StateSnapshotReadAsOfRequest, we will
     // allow the reconfiguration request without verification.
     if (bftEngine::ReplicaConfig::instance().clientTransactionSigningEnabled) {
-      return (bft_reconf_handler_.verifySignature(sender_id, data, signature) ||
+      return (op_reconf_handler_.verifySignature(sender_id, data, signature) ||
               client_reconf_handler_.verifySignature(sender_id, data, signature));
     } else {
       return true;
@@ -104,18 +111,20 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
   // The result must be a string that can be parsed via google::protobuf::util::TimeUtil::FromString().
   kvbc::LastApplicationTransactionTimeCallback last_app_txn_time_cb_{kvbc::newestPublicEventGroupRecordTime};
 
-  const concord::reconfiguration::BftReconfigurationHandler bft_reconf_handler_;
-  const concord::reconfiguration::ClientReconfigurationHandler client_reconf_handler_;
+  const concord::reconfiguration::OperatorCommandsReconfigurationHandler op_reconf_handler_;
+  const bftEngine::impl::ClientReconfigurationHandler client_reconf_handler_;
 };
 
 /*
  * This component is responsible for logging a reconfiguration requests (issued by a specific bft CRE) to the blockchain
  */
-class KvbcClientReconfigurationHandler : public concord::reconfiguration::ClientReconfigurationHandler,
+class KvbcClientReconfigurationHandler : public bftEngine::impl::ClientReconfigurationHandler,
                                          public ReconfigurationBlockTools {
  public:
-  KvbcClientReconfigurationHandler(kvbc::IBlockAdder& block_adder, kvbc::IReader& ro_storage)
-      : ReconfigurationBlockTools{block_adder, ro_storage} {}
+  KvbcClientReconfigurationHandler(const bftEngine::impl::ReplicasInfo& reps_info,
+                                   kvbc::IBlockAdder& block_adder,
+                                   kvbc::IReader& ro_storage)
+      : bftEngine::impl::ClientReconfigurationHandler{reps_info}, ReconfigurationBlockTools{block_adder, ro_storage} {}
   bool handle(const concord::messages::ClientExchangePublicKey&,
               uint64_t,
               uint32_t,
@@ -146,14 +155,19 @@ class KvbcClientReconfigurationHandler : public concord::reconfiguration::Client
  * This component is responsible for logging reconfiguration request (issued by an authorized operator) in the
  * blockchian.
  */
-class ReconfigurationHandler : public concord::reconfiguration::BftReconfigurationHandler,
+class ReconfigurationHandler : public concord::reconfiguration::OperatorCommandsReconfigurationHandler,
                                public ReconfigurationBlockTools {
  public:
-  ReconfigurationHandler(kvbc::IBlockAdder& block_adder,
+  ReconfigurationHandler(const std::string& path_to_operator_pub_key,
+                         concord::crypto::SignatureAlgorithm sig_type,
+                         kvbc::IBlockAdder& block_adder,
                          kvbc::IReader& ro_storage,
                          concord::performance::AdaptivePruningManager& apm,
                          concord::performance::ISystemResourceEntity& replicaResources)
-      : ReconfigurationBlockTools{block_adder, ro_storage}, apm_(apm), replicaResources_(replicaResources) {
+      : concord::reconfiguration::OperatorCommandsReconfigurationHandler{path_to_operator_pub_key, sig_type},
+        ReconfigurationBlockTools{block_adder, ro_storage},
+        apm_(apm),
+        replicaResources_(replicaResources) {
     const auto& command = apm_.getLatestConfiguration();
     if (command.sender_id != 0) {
       if (command.mode == concord::performance::PruningMode::LEGACY) {

--- a/kvbc/include/st_reconfiguraion_sm.hpp
+++ b/kvbc/include/st_reconfiguraion_sm.hpp
@@ -22,6 +22,8 @@
 #include "secrets/secrets_manager_plain.h"
 #include "AdaptivePruningManager.hpp"
 #include "IntervalMappingResourceManager.hpp"
+#include "Replica.hpp"
+#include "ControlStateManager.hpp"
 
 namespace concord::kvbc {
 /*

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -63,7 +63,10 @@ Status Replica::initInternals() {
     LOG_INFO(logger,
              "ReadOnly Replica Status:" << KVLOG(getLastBlockNum(), getLastBlockId(), getLastReachableBlockNum()));
     auto requestHandler = bftEngine::IRequestsHandler::createRequestsHandler(m_cmdHandler, cronTableRegistry_);
-    requestHandler->setReconfigurationHandler(std::make_shared<pruning::ReadOnlyReplicaPruningHandler>(*this));
+    requestHandler->setReconfigurationHandler(std::make_shared<pruning::ReadOnlyReplicaPruningHandler>(
+        bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+        bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+        *this));
     m_replicaPtr = bftEngine::IReplica::createNewRoReplica(
         replicaConfig_, requestHandler, m_stateTransfer, m_ptrComm.get(), m_metadataStorage);
     m_stateTransfer->addOnTransferringCompleteCallback([this](std::uint64_t) {
@@ -164,24 +167,41 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
   adapter::ReplicaBlockchain &blockchain_;
 };
 void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler) {
+  bftEngine::impl::ReplicasInfo reps_info(bftEngine::ReplicaConfig::instance(), false, false);
   requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(
-                                                *this, *this, this->AdaptivePruningManager_, this->replicaResources_),
+                                                bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                                                bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                                                *this,
+                                                *this,
+                                                this->AdaptivePruningManager_,
+                                                this->replicaResources_),
                                             concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::StateSnapshotReconfigurationHandler>(
-          *this, *this, m_stateSnapshotValueConverter, m_lastAppTxnCallback),
+          bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+          bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+          reps_info,
+          *this,
+          *this,
+          m_stateSnapshotValueConverter,
+          m_lastAppTxnCallback),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::InternalKvReconfigurationHandler>(
                                                 *this, *this, this->AdaptivePruningManager_),
                                             concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
-      std::make_shared<kvbc::reconfiguration::KvbcClientReconfigurationHandler>(*this, *this),
+      std::make_shared<kvbc::reconfiguration::KvbcClientReconfigurationHandler>(reps_info, *this, *this),
       concord::reconfiguration::ReconfigurationHandlerType::PRE);
   requestHandler->setReconfigurationHandler(
       std::make_shared<kvbc::reconfiguration::InternalPostKvReconfigurationHandler>(*this, *this),
       concord::reconfiguration::ReconfigurationHandlerType::POST);
   auto pruning_handler = std::shared_ptr<kvbc::pruning::PruningHandler>(
-      new concord::kvbc::pruning::PruningHandler(*this, *this, *this, true));
+      new concord::kvbc::pruning::PruningHandler(bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                                                 bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                                                 *this,
+                                                 *this,
+                                                 *this,
+                                                 true));
   requestHandler->setReconfigurationHandler(pruning_handler);
   for (const auto &rh : m_cmdHandler->getReconfigurationHandler()) {
     stReconfigurationSM_->registerHandler(rh);

--- a/kvbc/src/pruning_handler.cpp
+++ b/kvbc/src/pruning_handler.cpp
@@ -114,11 +114,14 @@ const PruningVerifier::Replica& PruningVerifier::getReplica(ReplicaVector::size_
   return replicas_[idx];
 }
 
-PruningHandler::PruningHandler(kvbc::IReader& ro_storage,
+PruningHandler::PruningHandler(const std::string& operator_pkey_path,
+                               concord::crypto::SignatureAlgorithm type,
+                               kvbc::IReader& ro_storage,
                                kvbc::IBlockAdder& blocks_adder,
                                kvbc::IBlocksDeleter& blocks_deleter,
                                bool run_async)
-    : logger_{logging::getLogger("concord.pruning")},
+    : concord::reconfiguration::OperatorCommandsReconfigurationHandler{operator_pkey_path, type},
+      logger_{logging::getLogger("concord.pruning")},
       signer_{bftEngine::ReplicaConfig::instance().replicaPrivateKey},
       verifier_{bftEngine::ReplicaConfig::instance().publicKeysOfReplicas},
       ro_storage_{ro_storage},

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -431,7 +431,12 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_correct_num_bocks_to_keep) {
 
   // Construct the pruning state machine with a nullptr TimeContract to verify
   // it works in case the time service is disabled.
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
@@ -452,7 +457,12 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_big_num_blocks_to_keep) {
   auto &blocks_deleter = storage;
   const auto verifier = PruningVerifier{replicaConfig.publicKeysOfReplicas};
 
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   concord::messages::LatestPrunableBlock resp;
   concord::messages::LatestPrunableBlockRequest req;
@@ -479,7 +489,12 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_no_pruning_conf) {
 
   InitBlockchainStorage(replica_count, storage);
 
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
@@ -506,7 +521,12 @@ TEST_F(test_rocksdb, sm_latest_prunable_request_pruning_disabled) {
 
   InitBlockchainStorage(replica_count, storage);
 
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   concord::messages::LatestPrunableBlockRequest req;
   concord::messages::LatestPrunableBlock resp;
@@ -527,7 +547,12 @@ TEST_F(test_rocksdb, sm_handle_prune_request_on_pruning_disabled) {
 
   TestStorage storage(db);
   auto &blocks_deleter = storage;
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas);
   concord::messages::ReconfigurationResponse rres;
@@ -547,7 +572,12 @@ TEST_F(test_rocksdb, sm_handle_correct_prune_request) {
   TestStorage storage(db);
   auto &blocks_deleter = storage;
   InitBlockchainStorage(replica_count, storage);
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   const auto latest_prunable_block_id = storage.getLastBlockId() - num_blocks_to_keep;
   const auto req = ConstructPruneRequest(client_idx, private_keys_of_replicas, latest_prunable_block_id);
@@ -571,7 +601,12 @@ TEST_F(test_rocksdb, sm_handle_incorrect_prune_request) {
   auto &blocks_deleter = storage;
   InitBlockchainStorage(replica_count, storage);
 
-  auto sm = PruningHandler{storage, storage, blocks_deleter, false};
+  auto sm = PruningHandler{bftEngine::ReplicaConfig::instance().pathToOperatorPublicKey_,
+                           bftEngine::ReplicaConfig::instance().operatorMsgSigningAlgo,
+                           storage,
+                           storage,
+                           blocks_deleter,
+                           false};
 
   // Add a valid N + 1 latest prunable block.
   {

--- a/reconfiguration/CMakeLists.txt
+++ b/reconfiguration/CMakeLists.txt
@@ -2,14 +2,13 @@ find_package(CMFC REQUIRED)
 add_subdirectory(cmf)
 
 add_library(concordbft_reconfiguration
-        src/reconfiguration_handler.cpp
-        src/dispatcher.cpp)
+        src/dispatcher.cpp
+        src/reconfiguration.cpp)
         
 target_include_directories(concordbft_reconfiguration PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(concordbft_reconfiguration PUBLIC
- bftcommunication
  cmf_messages
- corebft
  util
+ logging
 )
 

--- a/reconfiguration/include/reconfiguration/dispatcher.hpp
+++ b/reconfiguration/include/reconfiguration/dispatcher.hpp
@@ -14,7 +14,6 @@
 
 #include "ireconfiguration.hpp"
 #include "concord.cmf.hpp"
-#include "OpenTracing.hpp"
 #include "Logger.hpp"
 #include "Metrics.hpp"
 

--- a/reconfiguration/include/reconfiguration/ireconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/ireconfiguration.hpp
@@ -13,12 +13,14 @@
 #pragma once
 
 #include "concord.cmf.hpp"
-#include "OpenTracing.hpp"
-#include "kv_types.hpp"
-#include "Replica.hpp"
-#include "bftengine/TimeService.hpp"
-#include "bftengine/PersistentStorageImp.hpp"
-
+#include <memory>
+#include "Logger.hpp"
+namespace bftEngine {
+struct Timestamp;
+namespace impl {
+class PersistentStorage;
+}
+}  // namespace bftEngine
 namespace concord::reconfiguration {
 enum ReconfigurationHandlerType : unsigned int { PRE, REGULAR, POST };
 const static std::string configurationsFileName{"configurations"};
@@ -332,7 +334,7 @@ class IReconfigurationHandler {
 
  protected:
   logging::Logger getLogger() const {
-    static logging::Logger logger_(logging::getLogger("concord.bft.reconfiguration"));
+    static logging::Logger logger_(logging::getLogger("concord.reconfiguration"));
     return logger_;
   }
 };

--- a/reconfiguration/include/reconfiguration/reconfiguration.hpp
+++ b/reconfiguration/include/reconfiguration/reconfiguration.hpp
@@ -1,0 +1,27 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include "ireconfiguration.hpp"
+#include "crypto/verifier.hpp"
+#include "crypto/crypto.hpp"
+namespace concord::reconfiguration {
+class OperatorCommandsReconfigurationHandler : public IReconfigurationHandler {
+ public:
+  OperatorCommandsReconfigurationHandler(const std::string &path_to_operator_pub_key,
+                                         concord::crypto::SignatureAlgorithm sig_type);
+  bool verifySignature(uint32_t sender_id, const std::string &data, const std::string &signature) const override;
+
+ protected:
+  std::unique_ptr<concord::crypto::IVerifier> verifier_;
+};
+}  // namespace concord::reconfiguration

--- a/reconfiguration/src/dispatcher.cpp
+++ b/reconfiguration/src/dispatcher.cpp
@@ -11,6 +11,7 @@
 // file.
 
 #include "reconfiguration/dispatcher.hpp"
+#include "kvstream.h"
 
 using namespace concord::messages;
 

--- a/reconfiguration/src/reconfiguration.cpp
+++ b/reconfiguration/src/reconfiguration.cpp
@@ -1,0 +1,46 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "reconfiguration/reconfiguration.hpp"
+#include "crypto/factory.hpp"
+#include <fstream>
+#include <string>
+namespace concord::reconfiguration {
+OperatorCommandsReconfigurationHandler::OperatorCommandsReconfigurationHandler(
+    const std::string& path_to_operator_pub_key, concord::crypto::SignatureAlgorithm sig_type) {
+  if (path_to_operator_pub_key.empty()) {
+    LOG_WARN(getLogger(),
+             "The operator public key is missing, the reconfiguration handler won't be able to execute the requests");
+    return;
+  }
+  std::ifstream key_content;
+  key_content.open(path_to_operator_pub_key);
+  if (!key_content) {
+    LOG_WARN(getLogger(), "unable to read the operator public key file");
+    return;
+  }
+  auto key_str = std::string{};
+  auto buf = std::string(4096, '\0');
+  while (key_content.read(&buf[0], 4096)) {
+    key_str.append(buf, 0, key_content.gcount());
+  }
+  key_str.append(buf, 0, key_content.gcount());
+  verifier_ = crypto::Factory::getVerifier(key_str, sig_type, crypto::KeyFormat::PemFormat);
+}
+
+bool OperatorCommandsReconfigurationHandler::verifySignature(uint32_t sender_id,
+                                                             const std::string& data,
+                                                             const std::string& signature) const {
+  if (verifier_ == nullptr) return false;
+  return verifier_->verify(data, signature);
+}
+}  // namespace concord::reconfiguration


### PR DESCRIPTION
* **Problem Overview**  
  Currently, there is a cyclic dependency between the reconfiguration library and core-bft.  This PR is to remove this dependency.
It is done by moving all the bft-related logic into the core-bft library and leaving the reconfiguration library clean from any core-bft functionality 
* **Testing Done**  
  CI
