### PR TITLE
Memory management dev1 pr3

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -119,6 +119,7 @@ class DbCheckpointManager {
   }
   ~DbCheckpointManager() {
     stopped_ = true;
+    shutdownCond_.notify_all();  // to wake up monitor thread so it can be destructed
     if (monitorThread_.joinable()) monitorThread_.join();
   }
   void sendInternalCreateDbCheckpointMsg(const SeqNum& seqNum, bool noop);
@@ -196,6 +197,8 @@ class DbCheckpointManager {
   mutable std::mutex lock_;
   mutable std::mutex lockDbCheckPtFuture_;
   std::mutex lockLastDbCheckpointDesc_;
+  std::condition_variable shutdownCond_;  // used to wake up monitor thread periodically or when destructing an obj
+  std::mutex shutdownLock_;          // used for the above cond var. doesn't really coordinate anything between threads.
   uint32_t maxNumOfCheckpoints_{0};  // 0-disabled
   SeqNum lastCheckpointSeqNum_{0};
   std::optional<DbCheckpointMetadata::DbCheckPointDescriptor> lastCreatedCheckpointMetadata_{std::nullopt};

--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -1136,11 +1136,19 @@ void BCStateTran::setEraseMetadataFlagImpl() { psd_->setEraseDataStoreFlag(); }
 
 void BCStateTran::setReconfigurationEngineImpl(std::shared_ptr<ClientReconfigurationEngine> cre) { cre_ = cre; }
 
+template <typename MSG>
+void BCStateTran::freeStateTransferMsg(const MSG *m) {
+  const char *p_to_delete = (reinterpret_cast<const char *>(m) - sizeof(MessageBase::Header));
+  std::free(const_cast<char *>(p_to_delete));
+}
+
 // this function can be executed in context of another thread.
 void BCStateTran::handleStateTransferMessageImpl(char *msg,
                                                  uint32_t msgLen,
                                                  uint16_t senderId,
                                                  LocalTimePoint incomingEventsQPushTime) {
+  // msgHeader is now the owner of msg. after getting true type of msg, the ownership will be of onMessage functions.
+  auto msgHeader = STMessageUptr<BCStateTranBaseMsg>(reinterpret_cast<BCStateTranBaseMsg *>(msg));
   if (!running_) {
     return;
   }
@@ -1154,63 +1162,61 @@ void BCStateTran::handleStateTransferMessageImpl(char *msg,
   if (msgSizeTooSmall || sentFromSelf || invalidSender) {
     metrics_.received_illegal_msg_++;
     LOG_WARN(logger_, "Illegal message: " << KVLOG(msgLen, senderId, msgSizeTooSmall, sentFromSelf, invalidSender));
-    replicaForStateTransfer_->freeStateTransferMsg(msg);
     time_in_incoming_events_queue_rec_.start();
     return;
   }
 
-  BCStateTranBaseMsg *msgHeader = reinterpret_cast<BCStateTranBaseMsg *>(msg);
   LOG_DEBUG(logger_, "new message with type=" << msgHeader->type);
 
   FetchingState fs = getFetchingState();
-  bool freeMessage{true};
   switch (msgHeader->type) {
-    case MsgType::AskForCheckpointSummaries:
+    case MsgType::AskForCheckpointSummaries: {
       if (fs == FetchingState::NotFetching) {
 #ifdef ENABLE_ALL_METRICS
         metrics_.handle_AskForCheckpointSummaries_msg_++;
 #endif
-        freeMessage = onMessage(reinterpret_cast<AskForCheckpointSummariesMsg *>(msg), msgLen, senderId);
+        onMessage(convertBaseStMsgToRealStMsgType<AskForCheckpointSummariesMsg>(msgHeader.release()), msgLen, senderId);
       }
-      break;
-    case MsgType::CheckpointsSummary:
+    } break;
+    case MsgType::CheckpointsSummary: {
       if (fs == FetchingState::GettingCheckpointSummaries) {
 #ifdef ENABLE_ALL_METRICS
         metrics_.handle_CheckpointsSummary_msg_++;
 #endif
-        freeMessage = onMessage(reinterpret_cast<CheckpointSummaryMsg *>(msg), msgLen, senderId);
+        onMessage(convertBaseStMsgToRealStMsgType<CheckpointSummaryMsg>(msgHeader.release()), msgLen, senderId);
       }
-      break;
+    } break;
     case MsgType::FetchBlocks: {
       TimeRecorder scoped_timer(*histograms_.src_handle_FetchBlocks_msg_duration);
       metrics_.handle_FetchBlocks_msg_++;
-      freeMessage = onMessage(reinterpret_cast<FetchBlocksMsg *>(msg), msgLen, senderId);
+      onMessage(convertBaseStMsgToRealStMsgType<FetchBlocksMsg>(msgHeader.release()), msgLen, senderId);
     } break;
     case MsgType::FetchResPages: {
       TimeRecorder scoped_timer(*histograms_.src_handle_FetchResPages_msg_duration);
       metrics_.handle_FetchResPages_msg_++;
-      freeMessage = onMessage(reinterpret_cast<FetchResPagesMsg *>(msg), msgLen, senderId);
+      onMessage(convertBaseStMsgToRealStMsgType<FetchResPagesMsg>(msgHeader.release()), msgLen, senderId);
     } break;
-    case MsgType::RejectFetching:
+    case MsgType::RejectFetching: {
       if (fs == FetchingState::GettingMissingBlocks || fs == FetchingState::GettingMissingResPages) {
         metrics_.handle_RejectFetching_msg_++;
-        freeMessage = onMessage(reinterpret_cast<RejectFetchingMsg *>(msg), msgLen, senderId);
+        onMessage(convertBaseStMsgToRealStMsgType<RejectFetchingMsg>(msgHeader.release()), msgLen, senderId);
       }
-      break;
-    case MsgType::ItemData:
+    } break;
+    case MsgType::ItemData: {
       if (fs == FetchingState::GettingMissingBlocks || fs == FetchingState::GettingMissingResPages) {
         TimeRecorder scoped_timer(*histograms_.dst_handle_ItemData_msg);
         metrics_.handle_ItemData_msg_++;
-        freeMessage = onMessage(reinterpret_cast<ItemDataMsg *>(msg), msgLen, senderId, incomingEventsQPushTime);
+        onMessage(convertBaseStMsgToRealStMsgType<ItemDataMsg>(msgHeader.release()),
+                  msgLen,
+                  senderId,
+                  incomingEventsQPushTime);
       }
-      break;
+    } break;
     default:
+      LOG_WARN(GL, "Unknown type of state transfer msg" << KVLOG(msgHeader->type));
       break;
   }
 
-  if (freeMessage) {
-    replicaForStateTransfer_->freeStateTransferMsg(msg);
-  }
   time_in_incoming_events_queue_rec_.start();
 }
 
@@ -1646,7 +1652,7 @@ void BCStateTran::sendFetchResPagesMsg(int16_t lastKnownChunkInLastRequiredBlock
 // Message handlers
 //////////////////////////////////////////////////////////////////////////////
 
-bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<AskForCheckpointSummariesMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(replicaId, m->msgSeqNum));
   LOG_INFO(logger_, KVLOG(replicaId, m->msgSeqNum));
 
@@ -1658,7 +1664,7 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
 #ifdef ENABLE_ALL_METRICS
     metrics_.invalid_ask_for_checkpoint_summaries_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -1672,7 +1678,7 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_ask_for_checkpoint_summaries_msg_++;
 #endif
-    return true;
+    return;
   }
 
   uint64_t toCheckpoint = lastStoredCheckpoint;
@@ -1706,8 +1712,7 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
                                                        msg->requestMsgSeqNum,
                                                        msg->sizeofRvbData()));
 
-    replicaForStateTransfer_->sendStateTransferMessage(reinterpret_cast<char *>(msg), msg->size(), toReplicaId);
-    CheckpointSummaryMsg::free(msg);
+    replicaForStateTransfer_->sendStateTransferMessage(msg.getSerializedMsg(), msg->size(), toReplicaId);
     metrics_.sent_checkpoint_summary_msg_++;
     sent = true;
   }
@@ -1715,10 +1720,10 @@ bool BCStateTran::onMessage(const AskForCheckpointSummariesMsg *m, uint32_t msgL
   if (!sent) {
     LOG_INFO(logger_, "Failed to send relevant CheckpointSummaryMsg: " << KVLOG(toReplicaId));
   }
-  return true;
+  return;
 }
 
-bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<CheckpointSummaryMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(config_.myReplicaId, uniqueMsgSeqNum()));
   LOG_INFO(logger_, KVLOG(replicaId, m->checkpointNum, m->maxBlockId, m->requestMsgSeqNum, m->sizeofRvbData()));
 
@@ -1730,7 +1735,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_checkpoint_summary_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is invalid
@@ -1740,7 +1745,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
              "Msg is invalid: " << KVLOG(
                  replicaId, msgLen, m->checkpointNum, m->digestOfResPagesDescriptor.isZero(), m->requestMsgSeqNum));
     metrics_.invalid_checkpoint_summary_msg_++;
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -1751,7 +1756,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_checkpoint_summary_msg_++;
 #endif
-    return true;
+    return;
   }
 
   uint16_t numOfMsgsFromSender =
@@ -1760,31 +1765,31 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   // if we have too many messages from the same replica
   if (numOfMsgsFromSender >= (psd_->getMaxNumOfStoredCheckpoints() + 1)) {
     LOG_WARN(logger_, "Too many messages from replica: " << KVLOG(replicaId, numOfMsgsFromSender));
-    return true;
+    return;
   }
 
-  auto p = summariesCerts.find(m->checkpointNum);
-  CheckpointSummaryMsgCert *cert = nullptr;
-
-  if (p == summariesCerts.end()) {
-    cert = new CheckpointSummaryMsgCert(
-        replicaForStateTransfer_, replicas_.size(), config_.fVal, config_.fVal + 1, config_.myReplicaId);
-    summariesCerts[m->checkpointNum] = cert;
-  } else {
-    cert = p->second;
+  if (summariesCerts.find(m->checkpointNum) == summariesCerts.end()) {
+    summariesCerts.emplace(
+        m->checkpointNum,
+        new CheckpointSummaryMsgCert(
+            replicaForStateTransfer_, replicas_.size(), config_.fVal, config_.fVal + 1, config_.myReplicaId));
   }
+  auto pos = summariesCerts.find(m->checkpointNum);
+  ConcordAssertNE(pos, summariesCerts.end());
+  auto &cert = *pos->second;
 
-  bool used = cert->addMsg(const_cast<CheckpointSummaryMsg *>(m), replicaId);
+  // TODO: Should adjust MsgsCertificate to allow smart pointers. Meanwhile, pass here a raw pointer
+  bool used = cert.addMsg(const_cast<CheckpointSummaryMsg *>(m.release()), replicaId);
 
   if (used) numOfSummariesFromOtherReplicas[replicaId] = numOfMsgsFromSender + 1;
 
-  if (!cert->isComplete()) {
+  if (!cert.isComplete()) {
     LOG_INFO(logger_, "Does not have enough CheckpointSummaryMsg messages");
-    return false;
+    return;
   }
 
   LOG_INFO(logger_, "Has enough CheckpointSummaryMsg messages");
-  CheckpointSummaryMsg *cpSummaryMsg = cert->bestCorrectMsg();
+  CheckpointSummaryMsg *cpSummaryMsg = cert.bestCorrectMsg();
 
   ConcordAssertNE(cpSummaryMsg, nullptr);
   ConcordAssert(sourceSelector_.isReset());
@@ -1805,14 +1810,14 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
     LOG_ERROR(logger_, "Failed to set new RVT data! restart cycle...");
     // enter new cycle
     startCollectingStateInternal();
-    return false;
+    return;
   }
   metrics_.current_rvb_data_state_.Get().Set(rvbm_->getStateOfRvbData());
 
   // set the preferred replicas
   for (uint16_t r : replicas_) {  // TODO(GG): can be improved
-    CheckpointSummaryMsg *t = cert->getMsgFromReplica(r);
-    if (t != nullptr && CheckpointSummaryMsg::equivalent(t, cpSummaryMsg)) {
+    CheckpointSummaryMsg *otherRepCpSummaryMsg = cert.getMsgFromReplica(r);
+    if (otherRepCpSummaryMsg != nullptr && CheckpointSummaryMsg::equivalent(otherRepCpSummaryMsg, cpSummaryMsg)) {
       sourceSelector_.addPreferredReplica(r);
       ConcordAssertLT(r, config_.numReplicas);
     }
@@ -1886,7 +1891,7 @@ bool BCStateTran::onMessage(const CheckpointSummaryMsg *m, uint32_t msgLen, uint
   metrics_.last_block_.Get().Set(newCheckpoint.maxBlockId);
 
   processData();
-  return false;
+  return;
 }
 
 uint16_t BCStateTran::getBlocksConcurrentAsync(uint64_t maxBlockId, uint64_t minBlockId, uint16_t numBlocks) {
@@ -1997,7 +2002,7 @@ void BCStateTran::sourcePrepareBatch(uint64_t numBlocksRequested) {
   }
 }
 
-bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<FetchBlocksMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(replicaId, m->msgSeqNum));
   LOG_INFO(logger_,
            KVLOG(replicaId,
@@ -2023,7 +2028,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 #ifdef ENABLE_ALL_METRICS
     metrics_.invalid_fetch_blocks_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -2032,13 +2037,13 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_fetch_blocks_msg_++;
 #endif
-    return true;
+    return;
   }
 
   uint64_t numBlocksRequested = static_cast<uint64_t>(m->maxBlockId - m->minBlockId + 1);
   if (numBlocksRequested > config_.maxNumberOfChunksInBatch) {
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::INVALID_NUMBER_OF_BLOCKS_REQUESTED, m->msgSeqNum, replicaId);
-    return true;
+    return;
   }
 
   FetchingState fetchingState = getFetchingState();
@@ -2047,14 +2052,14 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
   // Reject if I'm already in ST (source or destination)
   if (isActiveDestination(fetchingState)) {
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::IN_STATE_TRANSFER, m->msgSeqNum, replicaId);
-    return true;
+    return;
   }
   if (m->maxBlockId > lastReachableBlockNum) {
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::BLOCK_RANGE_NOT_FOUND,
                           m->msgSeqNum,
                           replicaId,
                           KVLOG(m->maxBlockId, lastReachableBlockNum));
-    return true;
+    return;
   }
   auto [sessionOpened, otherReplicaSessionClosed] = sourceSession_.tryOpen(replicaId);
   (void)otherReplicaSessionClosed;
@@ -2062,7 +2067,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
     auto additionalInfo =
         "Active session with ownerDestReplicaId=" + std::to_string(sourceSession_.ownerDestReplicaId());
     sendRejectFetchingMsg(RejectFetchingMsg::Reason::IN_ACTIVE_SESSION, m->msgSeqNum, replicaId, additionalInfo);
-    return true;
+    return;
   }
   // comment: otherReplicaSessionClosed is supposed to mark the need to clear io contexts.
   // To save time, do it later and not here.
@@ -2074,7 +2079,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
     sendRejectFetchingMsg(
         RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, replicaId, additionalInfo);
     sourceSession_.close();
-    return true;
+    return;
   }
 
   // start recording time to send a whole batch, and its size
@@ -2089,7 +2094,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
                     (m->lastKnownChunkInLastRequiredBlock == 0),
                     config_,
                     rvbGroupDigestsExpectedSize,
-                    m,
+                    m.get(),
                     replicaId);
   ConcordAssertEQ(sourceBatch_.destReplicaId, sourceSession_.ownerDestReplicaId());
 
@@ -2103,7 +2108,7 @@ bool BCStateTran::onMessage(const FetchBlocksMsg *m, uint32_t msgLen, uint16_t r
                                                                      m->lastKnownChunkInLastRequiredBlock,
                                                                      m->rvbGroupId));
   continueSendBatch();
-  return true;
+  return;
 }
 
 void BCStateTran::continueSendBatch() {
@@ -2181,13 +2186,12 @@ void BCStateTran::continueSendBatch() {
     ConcordAssertGT(chunkSize, 0);
 
     char *pRawChunk = buffer + (sb.nextChunk - 1) * config_.maxChunkSize;
-    ItemDataMsg *outMsg = ItemDataMsg::alloc(chunkSize + sb.rvbGroupDigestsExpectedSize);  // TODO(GG): improve
+    auto outMsg = ItemDataMsg::alloc(chunkSize + sb.rvbGroupDigestsExpectedSize);
 
     outMsg->requestMsgSeqNum = m->msgSeqNum;
     outMsg->blockNumber = sb.nextBlockId;
     outMsg->totalNumberOfChunksInBlock = numOfChunksInNextBlock;
     outMsg->chunkNumber = sb.nextChunk;
-    outMsg->dataSize = chunkSize + sb.rvbGroupDigestsExpectedSize;
 
     outMsg->lastInBatch =
         ((sb.numSentChunks + 1) >= config_.maxNumberOfChunksInBatch) || ((sb.nextBlockId - 1) < m->minBlockId);
@@ -2203,7 +2207,6 @@ void BCStateTran::continueSendBatch() {
       if ((rvbGroupDigestsActualSize == 0) || (sb.rvbGroupDigestsExpectedSize != rvbGroupDigestsActualSize)) {
         auto additionalInfo = "Rejecting message - not holding all requested digests (or some other error)" +
                               KVLOG(sb.rvbGroupDigestsExpectedSize, rvbGroupDigestsActualSize);
-        ItemDataMsg::free(outMsg);
         sendRejectFetchingMsg(
             RejectFetchingMsg::Reason::DIGESTS_FOR_RVBGROUP_NOT_FOUND, m->msgSeqNum, sb.destReplicaId, additionalInfo);
         sourceSession_.close();
@@ -2228,16 +2231,14 @@ void BCStateTran::continueSendBatch() {
                                                outMsg->blockNumber,
                                                outMsg->totalNumberOfChunksInBlock,
                                                outMsg->chunkNumber,
-                                               outMsg->dataSize,
+                                               outMsg->getDataSize(),
                                                outMsg->rvbDigestsSize,
                                                (bool)outMsg->lastInBatch));
 
     metrics_.sent_item_data_msg_++;
-    replicaForStateTransfer_->sendStateTransferMessage(
-        reinterpret_cast<char *>(outMsg), outMsg->size(), sb.destReplicaId);
+    replicaForStateTransfer_->sendStateTransferMessage(outMsg.getSerializedMsg(), outMsg->size(), sb.destReplicaId);
     ++sb.numSentChunks;
     sb.numSentBytes += (chunkSize + sb.rvbGroupDigestsExpectedSize);
-    ItemDataMsg::free(outMsg);
 
     auto finalizeContext = [&]() {
       ioPool_.free(ctx);
@@ -2306,7 +2307,7 @@ void BCStateTran::continueSendBatch() {
   return;
 }
 
-bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<FetchResPagesMsg> m, uint32_t msgLen, uint16_t replicaId) {
   SCOPED_MDC_SEQ_NUM(getScopedMdcStr(replicaId, m->msgSeqNum));
   LOG_INFO(
       logger_,
@@ -2319,7 +2320,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
 #ifdef ENABLE_ALL_METRICS
     metrics_.invalid_fetch_res_pages_msg_++;
 #endif
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -2328,7 +2329,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_fetch_res_pages_msg_++;
 #endif
-    return true;
+    return;
   }
 
   FetchingState fetchingState = getFetchingState();
@@ -2348,7 +2349,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
     metrics_.sent_reject_fetch_msg_++;
     replicaForStateTransfer_->sendStateTransferMessage(
         reinterpret_cast<char *>(&outMsg), sizeof(RejectFetchingMsg), replicaId);
-    return true;
+    return;
   }
 
   // find virtual block
@@ -2392,7 +2393,7 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
   // if msg is invalid (because lastKnownChunk+1 does not exist)
   if (nextChunk > numOfChunksInVBlock) {
     LOG_WARN(logger_, "Msg is invalid: illegal chunk number: " << KVLOG(replicaId, nextChunk, numOfChunksInVBlock));
-    return true;
+    return;
   }
 
   // send chunks
@@ -2403,13 +2404,12 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
     ConcordAssertGT(chunkSize, 0);
 
     char *pRawChunk = vblock + (nextChunk - 1) * config_.maxChunkSize;
-    ItemDataMsg *outMsg = ItemDataMsg::alloc(chunkSize);
+    auto outMsg = ItemDataMsg::alloc(chunkSize);
 
     outMsg->requestMsgSeqNum = m->msgSeqNum;
     outMsg->blockNumber = ID_OF_VBLOCK_RES_PAGES;
     outMsg->totalNumberOfChunksInBlock = numOfChunksInVBlock;
     outMsg->chunkNumber = nextChunk;
-    outMsg->dataSize = chunkSize;
     outMsg->lastInBatch =
         ((numOfSentChunks + 1) >= config_.maxNumberOfChunksInBatch || (nextChunk == numOfChunksInVBlock));
     memcpy(outMsg->data, pRawChunk, chunkSize);
@@ -2421,13 +2421,13 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
                                                outMsg->blockNumber,
                                                outMsg->totalNumberOfChunksInBlock,
                                                outMsg->chunkNumber,
-                                               outMsg->dataSize,
+                                               outMsg->getDataSize(),
+                                               outMsg->rvbDigestsSize,
                                                (bool)outMsg->lastInBatch));
     metrics_.sent_item_data_msg_++;
 
-    replicaForStateTransfer_->sendStateTransferMessage(reinterpret_cast<char *>(outMsg), outMsg->size(), replicaId);
+    replicaForStateTransfer_->sendStateTransferMessage(outMsg.getSerializedMsg(), outMsg->size(), replicaId);
 
-    ItemDataMsg::free(outMsg);
     numOfSentChunks++;
 
     // if we've already sent enough chunks
@@ -2443,10 +2443,10 @@ bool BCStateTran::onMessage(const FetchResPagesMsg *m, uint32_t msgLen, uint16_t
       break;
     }
   }
-  return true;
+  return;
 }
 
-bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_t replicaId) {
+void BCStateTran::onMessage(STMessageUptr<RejectFetchingMsg> m, uint32_t msgLen, uint16_t replicaId) {
   LOG_DEBUG(logger_, KVLOG(replicaId, m->requestMsgSeqNum));
   metrics_.received_reject_fetching_msg_++;
 
@@ -2454,21 +2454,21 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
   if (fs != FetchingState::GettingMissingBlocks && fs != FetchingState::GettingMissingResPages) {
     LOG_ERROR(logger_,
               "Expected Fetching State GettingMissingBlocks or GettingMissingResPages. Got: " << stateName(fs));
-    return true;
+    return;
   }
 
   // if msg is invalid
   if (msgLen < sizeof(RejectFetchingMsg)) {
     LOG_WARN(logger_, "Msg is invalid: " << KVLOG(replicaId, msgLen));
     metrics_.invalid_reject_fetching_msg_++;
-    return true;
+    return;
   }
 
   auto itr = m->reasonMessages.find(m->rejectionCode);
   if (itr == m->reasonMessages.end()) {
     LOG_WARN(logger_, "Msg is invalid: " << KVLOG(replicaId, m->rejectionCode));
     metrics_.invalid_reject_fetching_msg_++;
-    return true;
+    return;
   }
 
   // if msg is not relevant
@@ -2487,7 +2487,7 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
 #ifdef ENABLE_ALL_METRICS
     metrics_.irrelevant_reject_fetching_msg_++;
 #endif
-    return true;
+    return;
   }
 
   LOG_INFO(
@@ -2508,11 +2508,11 @@ bool BCStateTran::onMessage(const RejectFetchingMsg *m, uint32_t msgLen, uint16_
     clearAllPendingItemsData();
     processData();
   }
-  return true;
+  return;
 }
 
 // Retrieve either a chunk of a block or a reserved page when fetching
-bool BCStateTran::onMessage(const ItemDataMsg *m,
+void BCStateTran::onMessage(STMessageUptr<ItemDataMsg> m,
                             uint32_t msgLen,
                             uint16_t replicaId,
                             LocalTimePoint incomingEventsQPushTime) {
@@ -2523,44 +2523,50 @@ bool BCStateTran::onMessage(const ItemDataMsg *m,
   if ((fs != FetchingState::GettingMissingBlocks) && (fs != FetchingState::GettingMissingResPages)) {
     LOG_ERROR(logger_,
               "Expected Fetching State GettingMissingBlocks or GettingMissingResPages. Got: " << stateName(fs));
-    return true;
+    return;
   }
 
   if (!sourceSelector_.isValidSourceId(replicaId)) {
     LOG_ERROR(logger_, "Msg received from invalid source " << replicaId);
-    return true;
+    return;
   }
 
   const auto MaxNumOfChunksInBlock =
       (fs == FetchingState::GettingMissingBlocks) ? maxNumOfChunksInAppBlock_ : maxNumOfChunksInVBlock_;
 
+  // The following fields of m are used after m is moved. copy them here to allow using them later.
+  auto msgRequestSeqNum = m->requestMsgSeqNum;
+  auto msgRvbDigestsSize = m->rvbDigestsSize;
+  auto msgDataSize = m->getDataSize();
+  auto msgLastInBatch = m->lastInBatch;
+
   LOG_DEBUG(logger_,
             std::boolalpha << KVLOG(replicaId,
-                                    m->requestMsgSeqNum,
+                                    msgRequestSeqNum,
                                     m->blockNumber,
                                     m->totalNumberOfChunksInBlock,
                                     m->chunkNumber,
-                                    m->dataSize,
-                                    (bool)m->lastInBatch,
-                                    m->rvbDigestsSize));
+                                    msgDataSize,
+                                    (bool)msgLastInBatch,
+                                    msgRvbDigestsSize));
 
   // if msg is invalid
-  if ((msgLen != m->size()) || (m->requestMsgSeqNum == 0) || (m->blockNumber == 0) ||
+  if ((msgLen != m->size()) || (msgRequestSeqNum == 0) || (m->blockNumber == 0) ||
       (m->totalNumberOfChunksInBlock == 0) || (m->totalNumberOfChunksInBlock > MaxNumOfChunksInBlock) ||
-      (m->chunkNumber == 0) || (m->dataSize == 0) || (m->rvbDigestsSize >= m->dataSize)) {
+      (m->chunkNumber == 0) || (msgDataSize == 0) || (msgRvbDigestsSize >= msgDataSize)) {
     LOG_WARN(logger_,
              "Msg is invalid: " << KVLOG(replicaId,
                                          msgLen,
                                          m->size(),
-                                         m->requestMsgSeqNum,
+                                         msgRequestSeqNum,
                                          m->blockNumber,
                                          m->totalNumberOfChunksInBlock,
                                          MaxNumOfChunksInBlock,
                                          m->chunkNumber,
-                                         m->rvbDigestsSize,
-                                         m->dataSize));
+                                         msgRvbDigestsSize,
+                                         msgDataSize));
     metrics_.invalid_item_data_msg_++;
-    return true;
+    return;
   }
 
   auto fetchingState = fs;
@@ -2573,49 +2579,49 @@ bool BCStateTran::onMessage(const ItemDataMsg *m,
     // delayed due to retransmissions, but it should still be valid block with an expected ID. No reason to drop.
     if ((sourceSelector_.currentReplica() != replicaId) || (fetchState_.minBlockId > m->blockNumber) ||
         (fetchState_.nextBlockId < m->blockNumber) ||
-        (m->dataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica)) {
+        (msgDataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica)) {
       LOG_WARN(logger_,
                "Msg is irrelevant: " << KVLOG(replicaId,
                                               fetchingState,
                                               sourceSelector_.currentReplica(),
-                                              m->requestMsgSeqNum,
+                                              msgRequestSeqNum,
                                               lastMsgSeqNum_,
                                               m->blockNumber,
                                               fetchState_,
                                               config_.maxNumberOfChunksInBatch,
-                                              m->rvbDigestsSize,
-                                              m->dataSize,
+                                              msgRvbDigestsSize,
+                                              msgDataSize,
                                               totalSizeOfPendingItemDataMsgs,
                                               config_.maxPendingDataFromSourceReplica));
       metrics_.irrelevant_item_data_msg_++;
-      return true;
+      return;
     }
   } else {
     ConcordAssertEQ(psd_->getFirstRequiredBlock(), 0);
     ConcordAssertEQ(psd_->getLastRequiredBlock(), 0);
 
-    if ((sourceSelector_.currentReplica() != replicaId) || (m->requestMsgSeqNum != lastMsgSeqNum_) ||
+    if ((sourceSelector_.currentReplica() != replicaId) || (msgRequestSeqNum != lastMsgSeqNum_) ||
         (m->blockNumber != ID_OF_VBLOCK_RES_PAGES) ||
-        (m->dataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica) ||
-        (m->rvbDigestsSize > 0)) {
+        (msgDataSize + totalSizeOfPendingItemDataMsgs > config_.maxPendingDataFromSourceReplica) ||
+        (msgRvbDigestsSize > 0)) {
       LOG_WARN(logger_,
                "Msg is irrelevant: " << KVLOG(replicaId,
                                               fetchingState,
                                               sourceSelector_.currentReplica(),
-                                              m->requestMsgSeqNum,
+                                              msgRequestSeqNum,
                                               lastMsgSeqNum_,
                                               (m->blockNumber == ID_OF_VBLOCK_RES_PAGES),
-                                              m->rvbDigestsSize,
-                                              m->dataSize,
+                                              msgRvbDigestsSize,
+                                              msgDataSize,
                                               totalSizeOfPendingItemDataMsgs,
                                               config_.maxPendingDataFromSourceReplica));
       metrics_.irrelevant_item_data_msg_++;
-      return true;
+      return;
     }
   }
 
   bool added = false;
-  tie(std::ignore, added) = pendingItemDataMsgs.insert(const_cast<ItemDataMsg *>(m));
+  tie(std::ignore, added) = pendingItemDataMsgs.emplace(std::move(m));
 
   // Log time spent in handoff queue
   auto fetchingTimeStamp = getMonotonicTimeMilli();
@@ -2632,19 +2638,18 @@ bool BCStateTran::onMessage(const ItemDataMsg *m,
 
   if (added) {
     LOG_DEBUG(logger_,
-              "ItemDataMsg was added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, m->requestMsgSeqNum));
+              "ItemDataMsg was added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, msgRequestSeqNum));
 #ifdef ENABLE_ALL_METRICS
     metrics_.num_pending_item_data_msgs_.Get().Set(pendingItemDataMsgs.size());
 #endif
-    totalSizeOfPendingItemDataMsgs += m->dataSize;
+    totalSizeOfPendingItemDataMsgs += msgDataSize;
     metrics_.total_size_of_pending_item_data_msgs_.Get().Set(totalSizeOfPendingItemDataMsgs);
-    processData(m->lastInBatch, m->rvbDigestsSize);
-    return false;
+    processData(msgLastInBatch, msgRvbDigestsSize);
+    return;
   } else {
-    LOG_INFO(
-        logger_,
-        "ItemDataMsg was NOT added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, m->requestMsgSeqNum));
-    return true;
+    LOG_INFO(logger_,
+             "ItemDataMsg was NOT added to pendingItemDataMsgs: " << KVLOG(replicaId, fetchingState, msgRequestSeqNum));
+    return;
   }
 }
 
@@ -2757,12 +2762,6 @@ char *BCStateTran::createVBlock(const DescOfVBlockForResPages &desc) {
 void BCStateTran::clearInfoAboutGettingCheckpointSummary() {
   lastTimeSentAskForCheckpointSummariesMsg = 0;
   retransmissionNumberOfAskForCheckpointSummariesMsg = 0;
-
-  for (auto i : summariesCerts) {
-    i.second->resetAndFree();
-    delete i.second;
-  }
-
   summariesCerts.clear();
   numOfSummariesFromOtherReplicas.clear();
 }
@@ -2781,10 +2780,6 @@ void BCStateTran::verifyEmptyInfoAboutGettingCheckpointSummary() {
 void BCStateTran::clearAllPendingItemsData() {
   LOG_DEBUG(logger_, "");
 
-  for (auto i : pendingItemDataMsgs) {
-    replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(i));
-  }
-
   pendingItemDataMsgs.clear();
   totalSizeOfPendingItemDataMsgs = 0;
 #ifdef ENABLE_ALL_METRICS
@@ -2800,11 +2795,10 @@ void BCStateTran::clearPendingItemsData(uint64_t fromBlock, uint64_t untilBlock)
 
   auto it = pendingItemDataMsgs.begin();
   while (it != pendingItemDataMsgs.end()) {
-    ConcordAssertGE(totalSizeOfPendingItemDataMsgs, (*it)->dataSize);
+    ConcordAssertGE(totalSizeOfPendingItemDataMsgs, (*it)->getDataSize());
 
     if (((*it)->blockNumber >= fromBlock) && ((*it)->blockNumber <= untilBlock)) {
-      totalSizeOfPendingItemDataMsgs -= (*it)->dataSize;
-      replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(*it));
+      totalSizeOfPendingItemDataMsgs -= (*it)->getDataSize();
       it = pendingItemDataMsgs.erase(it);
     }
     ++it;
@@ -2834,15 +2828,15 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
   uint16_t maxAvailableChunk = 0;
   uint32_t blockSize = 0;
 
-  auto it = pendingItemDataMsgs.begin();
-  while ((it != pendingItemDataMsgs.end()) && ((*it)->blockNumber == requiredBlock)) {
-    ItemDataMsg *msg = *it;
-
+  for (const auto &msg : pendingItemDataMsgs) {
+    if (msg->blockNumber != requiredBlock) {
+      break;
+    }
     // the conditions of these asserts are checked when receiving the message
     ConcordAssertGT(msg->totalNumberOfChunksInBlock, 0);
     ConcordAssertGE(msg->chunkNumber, 1);
     if (totalNumberOfChunks == 0) totalNumberOfChunks = msg->totalNumberOfChunksInBlock;
-    blockSize += (msg->dataSize - msg->rvbDigestsSize);
+    blockSize += (msg->getDataSize() - msg->rvbDigestsSize);
     if (totalNumberOfChunks != msg->totalNumberOfChunksInBlock || msg->chunkNumber > totalNumberOfChunks ||
         blockSize > maxSize) {
       badData = true;
@@ -2859,8 +2853,7 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
       fullBlock = true;
       break;
     }
-    ++it;
-  }  // while
+  }
 
   if (badData) {
     ConcordAssert(!fullBlock);
@@ -2878,23 +2871,21 @@ bool BCStateTran::getNextFullBlock(uint64_t requiredBlock,
   uint16_t currentChunk = 0;
   uint32_t currentPos = 0;
 
-  it = pendingItemDataMsgs.begin();
+  auto it = pendingItemDataMsgs.begin();
   while (true) {
     ConcordAssertNE(it, pendingItemDataMsgs.end());
-    ConcordAssertEQ((*it)->blockNumber, requiredBlock);
+    auto &msg = *it;
 
-    ItemDataMsg *msg = *it;
-
+    ConcordAssertEQ(msg->blockNumber, requiredBlock);
     ConcordAssertGE(msg->chunkNumber, 1);
     ConcordAssertEQ(msg->totalNumberOfChunksInBlock, totalNumberOfChunks);
     ConcordAssertEQ(currentChunk + 1, msg->chunkNumber);
-    ConcordAssertLE(currentPos + msg->dataSize - msg->rvbDigestsSize, maxSize);
+    ConcordAssertLE(currentPos + msg->getDataSize() - msg->rvbDigestsSize, maxSize);
 
-    memcpy(outBlock + currentPos, msg->data, msg->dataSize);
+    memcpy(outBlock + currentPos, msg->data, msg->getDataSize());
     currentChunk = msg->chunkNumber;
-    currentPos += msg->dataSize;
-    totalSizeOfPendingItemDataMsgs -= (*it)->dataSize;
-    replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(*it));
+    currentPos += msg->getDataSize();
+    totalSizeOfPendingItemDataMsgs -= msg->getDataSize();
     it = pendingItemDataMsgs.erase(it);
 #ifdef ENABLE_ALL_METRICS
     metrics_.num_pending_item_data_msgs_.Get().Set(pendingItemDataMsgs.size());
@@ -3321,9 +3312,6 @@ void BCStateTran::stReset(DataStoreTransaction *txn, bool resetRvbm, bool resetS
   cacheOfVirtualBlockForResPages.clear();
   lastTimeSentAskForCheckpointSummariesMsg = 0;
   retransmissionNumberOfAskForCheckpointSummariesMsg = 0;
-  for (auto i : summariesCerts) {
-    replicaForStateTransfer_->freeStateTransferMsg(reinterpret_cast<char *>(i.second));
-  }
   summariesCerts.clear();
   numOfSummariesFromOtherReplicas.clear();
   clearIoContexts();
@@ -3638,13 +3626,13 @@ void BCStateTran::processData(bool lastInBatch, uint32_t rvbDigestsSize) {
         // Report Completion to 3rd parties. At this point ST moves to the next and final state, while asynchronously
         // for all callbacks to finish in a worker thead context.
         on_transferring_complete_ongoing_ = true;
-        auto fs = getFetchingState();
+        auto currentFs = getFetchingState();
         LOG_INFO(
             logger_,
             "Invoking onTransferringComplete callbacks (asynchronously):"
                 << std::boolalpha
                 << KVLOG(on_transferring_complete_ongoing_, targetCheckpointDesc_.checkpointNum, getFetchingState()));
-        ConcordAssertEQ(fs, FetchingState::FinalizingCycle);
+        ConcordAssertEQ(currentFs, FetchingState::FinalizingCycle);
         ConcordAssert(psd_->getIsFetchingState());
         on_transferring_complete_future_ = std::async(std::launch::async, [this]() {
           auto size = on_transferring_complete_cb_registry_.size();

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -42,6 +42,7 @@
 #include "TimeUtils.hpp"
 #include "SimpleMemoryPool.hpp"
 #include "messages/MessageBase.hpp"
+#include "memory.hpp"
 
 using std::set;
 using std::map;
@@ -349,13 +350,27 @@ class BCStateTran : public IStateTransfer {
   // Message handlers
   ///////////////////////////////////////////////////////////////////////////
 
+  template <typename MSG>
+  static void freeStateTransferMsg(const MSG* m);
+
+  template <typename T>
+  using STMessageUptr = custom_deleter_unique_ptr<const T, freeStateTransferMsg<T>>;
+
+  template <typename T>
+  STMessageUptr<T> convertBaseStMsgToRealStMsgType(const BCStateTranBaseMsg* msgHeader) {
+    return STMessageUptr<T>(reinterpret_cast<const T*>(msgHeader));
+  }
+
   inline std::string getScopedMdcStr(uint16_t replicaId, uint64_t seqNum, uint16_t = 0, uint64_t = 0);
-  bool onMessage(const AskForCheckpointSummariesMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const CheckpointSummaryMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const FetchBlocksMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const FetchResPagesMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const RejectFetchingMsg* m, uint32_t msgLen, uint16_t replicaId);
-  bool onMessage(const ItemDataMsg* m, uint32_t msgLen, uint16_t replicaId, LocalTimePoint incomingEventsQPushTime);
+  void onMessage(STMessageUptr<AskForCheckpointSummariesMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<CheckpointSummaryMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<FetchBlocksMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<FetchResPagesMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<RejectFetchingMsg> m, uint32_t msgLen, uint16_t replicaId);
+  void onMessage(STMessageUptr<ItemDataMsg> m,
+                 uint32_t msgLen,
+                 uint16_t replicaId,
+                 LocalTimePoint incomingEventsQPushTime);
 
   ///////////////////////////////////////////////////////////////////////////
   // cache that holds virtual blocks
@@ -391,8 +406,13 @@ class BCStateTran : public IStateTransfer {
 
   typedef MsgsCertificate<CheckpointSummaryMsg, false, false, true, CheckpointSummaryMsg> CheckpointSummaryMsgCert;
 
+  static void freeCheckpointSummariesCert(CheckpointSummaryMsgCert* c) {
+    c->resetAndFree();
+    delete c;
+  }
+  using CheckpointSummaryMsgCertUptr = custom_deleter_unique_ptr<CheckpointSummaryMsgCert, freeCheckpointSummariesCert>;
   // map from checkpointNum to CheckpointSummaryMsgCert
-  map<uint64_t, CheckpointSummaryMsgCert*> summariesCerts;
+  map<uint64_t, CheckpointSummaryMsgCertUptr> summariesCerts;
 
   // map from replica Id to number of accepted CheckpointSummaryMsg messages
   map<uint16_t, uint16_t> numOfSummariesFromOtherReplicas;
@@ -445,7 +465,7 @@ class BCStateTran : public IStateTransfer {
   inline uint64_t nextRvbBlockId(uint64_t block_id) const;
 
   struct compareItemDataMsg {
-    bool operator()(const ItemDataMsg* l, const ItemDataMsg* r) const {
+    bool operator()(STMessageUptr<ItemDataMsg> const& l, STMessageUptr<ItemDataMsg> const& r) const {
       if (l->blockNumber != r->blockNumber)
         return (l->blockNumber > r->blockNumber);
       else
@@ -453,7 +473,7 @@ class BCStateTran : public IStateTransfer {
     }
   };
 
-  set<ItemDataMsg*, compareItemDataMsg> pendingItemDataMsgs;
+  set<STMessageUptr<ItemDataMsg>, compareItemDataMsg> pendingItemDataMsgs;
   uint32_t totalSizeOfPendingItemDataMsgs = 0;
 
   void stReset(DataStoreTransaction* txn,

--- a/bftengine/src/bcstatetransfer/Messages.hpp
+++ b/bftengine/src/bcstatetransfer/Messages.hpp
@@ -40,14 +40,32 @@ class MsgType {
 };
 
 struct BCStateTranBaseMsg {
+  BCStateTranBaseMsg(uint16_t type) : type(type) {}
   uint16_t type;
+  // This struct and its derived structs are used to de/serialize message buffers sent over communication channels.
+  // Since virtual methods modify the memory layout of a struct, there cannot be any for both this base struct and its
+  // inheritors.
+};
+
+// VariableSizeMsg is useful for structs with a flexible array member
+template <typename T>
+class VariableSizeMsg {
+ public:
+  VariableSizeMsg(size_t dataSize) : buffer_(new concord::Byte[calcMsgSize(dataSize)]()) {}
+
+  T* operator->() const { return reinterpret_cast<T*>(buffer_.get()); }
+
+  char* getSerializedMsg() const { return reinterpret_cast<char*>(buffer_.get()); }
+
+  static size_t calcMsgSize(size_t dataSize) { return sizeof(T) - 1 + dataSize; }
+
+ private:
+  std::unique_ptr<concord::Byte[]> buffer_;
 };
 
 struct AskForCheckpointSummariesMsg : public BCStateTranBaseMsg {
-  AskForCheckpointSummariesMsg() {
-    memset(this, 0, sizeof(AskForCheckpointSummariesMsg));
-    type = MsgType::AskForCheckpointSummaries;
-  }
+  AskForCheckpointSummariesMsg()
+      : BCStateTranBaseMsg{MsgType::AskForCheckpointSummaries}, msgSeqNum{}, minRelevantCheckpointNum{} {}
 
   uint64_t msgSeqNum;
   uint64_t minRelevantCheckpointNum;
@@ -56,31 +74,11 @@ struct AskForCheckpointSummariesMsg : public BCStateTranBaseMsg {
 struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
   CheckpointSummaryMsg() = delete;
 
-  static CheckpointSummaryMsg* alloc(size_t rvbDataSize) {
-    size_t totalByteSize = sizeof(CheckpointSummaryMsg) + rvbDataSize - 1;
-    CheckpointSummaryMsg* msg{static_cast<CheckpointSummaryMsg*>(std::malloc(totalByteSize))};
-    if (!msg) {
-      throw std::bad_alloc();
-    }
-    memset(msg, 0, totalByteSize);
+  static VariableSizeMsg<CheckpointSummaryMsg> alloc(size_t rvbDataSize) {
+    VariableSizeMsg<CheckpointSummaryMsg> msg{rvbDataSize};
     msg->type = MsgType::CheckpointsSummary;
     msg->rvbDataSize = rvbDataSize;
     return msg;
-  }
-
-  static CheckpointSummaryMsg* alloc(const CheckpointSummaryMsg* rMsg) {
-    auto msg = alloc(rMsg->rvbDataSize);
-    msg->checkpointNum = rMsg->checkpointNum;
-    msg->maxBlockId = rMsg->maxBlockId;
-    msg->digestOfMaxBlockId = rMsg->digestOfMaxBlockId;
-    msg->digestOfResPagesDescriptor = rMsg->digestOfResPagesDescriptor;
-    msg->requestMsgSeqNum = rMsg->requestMsgSeqNum;
-    memcpy(msg->data, rMsg->data, rMsg->rvbDataSize);
-    return msg;
-  }
-
-  static void free(const CheckpointSummaryMsg* msg) {
-    std::free(const_cast<char*>(reinterpret_cast<const char*>(msg)));
   }
 
   static void free(void* context, const CheckpointSummaryMsg* msg) {
@@ -88,7 +86,7 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
     rep->freeStateTransferMsg(const_cast<char*>(reinterpret_cast<const char*>(msg)));
   }
 
-  size_t size() const { return sizeof(CheckpointSummaryMsg) + rvbDataSize - 1; }
+  size_t size() const { return VariableSizeMsg<CheckpointSummaryMsg>::calcMsgSize(rvbDataSize); }
   size_t sizeofRvbData() const { return rvbDataSize; }
 
   uint64_t checkpointNum;
@@ -168,10 +166,14 @@ struct CheckpointSummaryMsg : public BCStateTranBaseMsg {
 };
 
 struct FetchBlocksMsg : public BCStateTranBaseMsg {
-  FetchBlocksMsg() {
-    memset(this, 0, sizeof(FetchBlocksMsg));
-    type = MsgType::FetchBlocks;
-  }
+  FetchBlocksMsg()
+      : BCStateTranBaseMsg{MsgType::FetchBlocks},
+        msgSeqNum{},
+        minBlockId{},
+        maxBlockId{},
+        maxBlockIdInCycle{},
+        rvbGroupId{},
+        lastKnownChunkInLastRequiredBlock{} {}
 
   uint64_t msgSeqNum;
   uint64_t minBlockId;
@@ -182,10 +184,12 @@ struct FetchBlocksMsg : public BCStateTranBaseMsg {
 };
 
 struct FetchResPagesMsg : public BCStateTranBaseMsg {
-  FetchResPagesMsg() {
-    memset(this, 0, sizeof(FetchResPagesMsg));
-    type = MsgType::FetchResPages;
-  }
+  FetchResPagesMsg()
+      : BCStateTranBaseMsg{MsgType::FetchResPages},
+        msgSeqNum{},
+        lastCheckpointKnownToRequester{},
+        requiredCheckpointNum{},
+        lastKnownChunk{} {}
 
   uint64_t msgSeqNum;
   uint64_t lastCheckpointKnownToRequester;
@@ -211,12 +215,8 @@ struct RejectFetchingMsg : public BCStateTranBaseMsg {
     };
   };
   RejectFetchingMsg() = delete;
-  RejectFetchingMsg(uint16_t rejCode, uint64_t reqMsgSeqNum) {
-    memset(this, 0, sizeof(RejectFetchingMsg));
-    type = MsgType::RejectFetching;
-    rejectionCode = rejCode;
-    requestMsgSeqNum = reqMsgSeqNum;
-  }
+  RejectFetchingMsg(uint16_t rejCode, uint64_t reqMsgSeqNum)
+      : BCStateTranBaseMsg{MsgType::RejectFetching}, requestMsgSeqNum{reqMsgSeqNum}, rejectionCode{rejCode} {}
 
   uint64_t requestMsgSeqNum;
   uint16_t rejectionCode;
@@ -232,31 +232,30 @@ struct RejectFetchingMsg : public BCStateTranBaseMsg {
 };
 
 struct ItemDataMsg : public BCStateTranBaseMsg {
-  static ItemDataMsg* alloc(uint32_t dataSize) {
-    size_t msgSize = sizeof(ItemDataMsg) - 1 + dataSize;
-    ItemDataMsg* msg = static_cast<ItemDataMsg*>(std::malloc(msgSize));
-    if (!msg) {
-      throw std::bad_alloc();
-    }
-    memset(msg, 0, msgSize);
+  ItemDataMsg() = delete;
+
+  static VariableSizeMsg<ItemDataMsg> alloc(size_t dataSize) {
+    VariableSizeMsg<ItemDataMsg> msg{dataSize};
     msg->type = MsgType::ItemData;
     msg->dataSize = dataSize;
     return msg;
   }
 
-  static void free(ItemDataMsg* msg) { std::free(msg); }
-
   uint64_t requestMsgSeqNum;
   uint64_t blockNumber;
   uint16_t totalNumberOfChunksInBlock;
   uint16_t chunkNumber;
-  uint32_t dataSize;
   uint8_t lastInBatch;
   uint32_t rvbDigestsSize;  // if non-zero, size in bytes  which is dedicated to RVB
                             // digests from the total of dataSize (rvbDigestsSize < dataSize)
-  char data[1];             // MSB[raw block of size dataSize-rvbDigestsSize|RVB DIGESTS of size rvbDigestsSize]LSB
+ private:
+  uint32_t dataSize;
 
-  uint32_t size() const { return sizeof(ItemDataMsg) - 1 + dataSize; }
+ public:
+  char data[1];  // MSB[raw block of size dataSize-rvbDigestsSize|RVB DIGESTS of size rvbDigestsSize]LSB
+
+  uint32_t size() const { return VariableSizeMsg<ItemDataMsg>::calcMsgSize(dataSize); }
+  uint32_t getDataSize() const { return dataSize; }
 };
 
 #pragma pack(pop)

--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -46,6 +46,9 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual SeqNum getLastExecutedSeqNum() const = 0;
   virtual std::pair<PrePrepareMsg*, bool> buildPrePrepareMessage() { return std::make_pair(nullptr, false); }
   virtual bool tryToSendPrePrepareMsg(bool batchingLogic) { return false; }
+  // register a components' stop function to be run at the beginning of ReplicaImp's stop function.
+  // all components dependent on ReplicaImp running (and only those components) must register a stop func
+  virtual void registerStopCallback(std::function<void(void)> stopCallback) = 0;
   virtual std::pair<PrePrepareMsg*, bool> buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
     return std::make_pair(nullptr, false);
   }

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -44,6 +44,7 @@
 #include "EpochManager.hpp"
 #include "PerfMetrics.hpp"
 #include "ControlStateManager.hpp"
+#include "callback_registry.hpp"
 
 namespace preprocessor {
 class PreProcessResultMsg;
@@ -354,6 +355,11 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   virtual ~ReplicaImp();
 
   void start() override;
+
+  // register a component's stop function to be run at the beginning of ReplicaImp's stop function.
+  // all components dependent of ReplicaImp running (and only those components) must register a stop func
+  void registerStopCallback(std::function<void(void)> stopCallback) override { stopCallbacks_.add(stopCallback); }
+
   void stop() override;
 
   std::shared_ptr<IInternalBFTClient> internalClient() const { return internalBFTClient_; }
@@ -619,6 +625,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void onCarrierMessage(CarrierMesssage* msg);
 
  private:
+  // CallbackRegistry holding "stop" functions of components dependent on replicaImp that need to stop before the
+  // replica is stopped
+  concord::util::CallbackRegistry<> stopCallbacks_;
+
   void addTimers();
   void startConsensusProcess(PrePrepareMsg* pp, bool isCreatedEarlier);
   void startConsensusProcess(PrePrepareMsg* pp);

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -348,11 +348,26 @@ bool PreProcessor::validateMessage(MessageBase *msg) const {
   }
 }
 
+void PreProcessor::stop() {
+  if (!msgLoopDone_) {
+    msgLoopDone_ = true;
+    msgLoopSignal_.notify_all();
+    cancelTimers();
+  }
+
+  if (!threadPool_.isStopped()) {
+    threadPool_.stop();
+    if (msgLoopThread_.joinable()) {
+      msgLoopThread_.join();
+    }
+  }
+}
+
 PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                            shared_ptr<IncomingMsgsStorage> &incomingMsgsStorage,
                            shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
                            IRequestsHandler &requestsHandler,
-                           const InternalReplicaApi &myReplica,
+                           InternalReplicaApi &myReplica,
                            concordUtil::Timers &timers,
                            shared_ptr<concord::performance::PerformanceManager> &pm)
     : msgsCommunicator_(msgsCommunicator),
@@ -392,6 +407,9 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       launchAsyncPreProcessJobRecorder_{histograms_.launchAsyncPreProcessJob},
       pm_{pm},
       memoryPoolEnabled_(myReplica_.getReplicaConfig().enablePreProcessorMemoryPool) {
+  // register a stop call back for the new preprocessor in order to stop it before replica is destroyed
+  myReplica_.registerStopCallback([this]() { this->stop(); });
+
   clientMaxBatchSize_ = clientBatchingEnabled_ ? myReplica.getReplicaConfig().clientBatchingMaxMsgsNbr : 1,
   registerMsgHandlers();
   metricsComponent_.Register();
@@ -441,13 +459,9 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
 
 PreProcessor::~PreProcessor() {
   LOG_TRACE(logger(), "~PreProcessor start");
-  msgLoopDone_ = true;
-  msgLoopSignal_.notify_all();
-  cancelTimers();
-  threadPool_.stop();
-  if (msgLoopThread_.joinable()) {
-    msgLoopThread_.join();
-  }
+
+  stop();
+
   if (!memoryPoolEnabled_) {
     for (const auto &result : preProcessResultBuffers_) {
       delete[] result->buffer;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -129,11 +129,12 @@ class PreProcessor {
                std::shared_ptr<IncomingMsgsStorage> &incomingMsgsStorage,
                std::shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
                bftEngine::IRequestsHandler &requestsHandler,
-               const InternalReplicaApi &replica,
+               InternalReplicaApi &replica,
                concordUtil::Timers &timers,
                std::shared_ptr<concord::performance::PerformanceManager> &sdm);
 
   ~PreProcessor();
+  void stop();
 
   static void addNewPreProcessor(std::shared_ptr<MsgsCommunicator> &msgsCommunicator,
                                  std::shared_ptr<IncomingMsgsStorage> &incomingMsgsStorage,
@@ -315,7 +316,7 @@ class PreProcessor {
   std::shared_ptr<IncomingMsgsStorage> incomingMsgsStorage_;
   std::shared_ptr<MsgHandlersRegistrator> msgHandlersRegistrator_;
   bftEngine::IRequestsHandler &requestsHandler_;
-  const InternalReplicaApi &myReplica_;
+  InternalReplicaApi &myReplica_;
   const ReplicaId myReplicaId_;
   const uint32_t maxExternalMsgSize_;
   const uint32_t maxPreExecResultSize_;

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -128,7 +128,7 @@ class DummyReplica : public InternalReplicaApi {
   SeqNum getPrimaryLastUsedSeqNum() const override { return 0; }
   uint64_t getRequestsInQueue() const override { return 0; }
   SeqNum getLastExecutedSeqNum() const override { return 0; }
-
+  void registerStopCallback(std::function<void(void)> stopCallback) override { (void)stopCallback; };
   void setPrimary(bool primary) { primary_ = primary; };
 
  private:

--- a/kvbc/include/ClientImp.h
+++ b/kvbc/include/ClientImp.h
@@ -40,7 +40,7 @@ class ClientImp : public IClient {
 
  protected:
   ClientImp() = default;
-  ~ClientImp() override = default;
+  ~ClientImp() override { delete comm_; };
 
   ClientConfig config_;
   std::unique_ptr<bftEngine::SeqNumberGeneratorForClientRequests> seqGen_;

--- a/tests/apollo/test_skvbc_state_transfer.py
+++ b/tests/apollo/test_skvbc_state_transfer.py
@@ -348,7 +348,8 @@ class SkvbcStateTransferTest(ApolloTest):
                 bft_network.all_replicas(),
                 num_of_checkpoints_to_add=2,
                 verify_checkpoint_persistency=False,
-                assert_state_transfer_not_started=False)
+                assert_state_transfer_not_started=False,
+                expected_starting_checkpoint=i * 2)
 
             if i > 0 and i % 2 == 0:
                 await op.latest_pruneable_block()

--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -29,7 +29,6 @@ import inspect
 import time
 from pathlib import Path
 from typing import Coroutine, Sequence, Callable
-import re
 import trio
 
 from util.test_base import repeat_test
@@ -892,16 +891,19 @@ class BftTestNetwork:
             'PlainUdp': bft_client.UdpClient
         }
 
-        communication_phrase = communication_str + ".*,"
         log_data = ""
         with open(replica_test_log_path, 'r') as replica_log:
             time_elapsed = 0
-            while re.search(communication_phrase, log_data) is None and \
+            while communication_str not in log_data and \
                     time_elapsed < timeout_seconds and \
                     len(log_data) < max_read_bytes:
                 log_data += replica_log.read(chunk_bytes)
                 time.sleep(sleep_seconds)
                 time_elapsed += sleep_seconds
+
+            # make sure we have read the whole communication phrase
+            if "," not in log_data[log_data.find(communication_str) + len(communication_str):]:
+                log_data += replica_log.read(chunk_bytes)
 
         assert communication_str in log_data, \
             f"Communication str not in {max_read_bytes + chunk_bytes} first bytes of the log, " \

--- a/tests/apollo/util/skvbc.py
+++ b/tests/apollo/util/skvbc.py
@@ -266,7 +266,8 @@ class SimpleKVBCProtocol:
             verify_checkpoint_persistency=True,
             assert_state_transfer_not_started=True,
             without_clients=None,
-            timeout=30):
+            timeout=30,
+            expected_starting_checkpoint=None):
         """
         A helper function used by tests to fill a window with data and then
         checkpoint it.
@@ -278,8 +279,12 @@ class SimpleKVBCProtocol:
         """
         with log.start_action(action_type="fill_and_wait_for_checkpoint"):
             client = self.bft_network.random_client(without_clients)
+            if expected_starting_checkpoint is not None:
+                expected_checkpoint_num = lambda cp: cp == expected_starting_checkpoint
+            else:
+                expected_checkpoint_num = None
             checkpoint_before = await self.bft_network.wait_for_checkpoint(
-                replica_id=random.choice(initial_nodes))
+                replica_id=random.choice(initial_nodes), expected_checkpoint_num=expected_checkpoint_num)
             # Write enough data to checkpoint and create a need for state transfer
             for i in range(1 + num_of_checkpoints_to_add * CHECKPOINT_SEQUENCES):
                 key = self.random_key()

--- a/util/include/SimpleThreadPool.hpp
+++ b/util/include/SimpleThreadPool.hpp
@@ -66,6 +66,8 @@ class SimpleThreadPool {
     return job_queue_.size();
   }
 
+  bool isStopped() const { return stopped_; };
+
  protected:
   bool load(Job*& outJob);
   void execute(Job*);

--- a/util/include/crypto/openssl/crypto.hpp
+++ b/util/include/crypto/openssl/crypto.hpp
@@ -40,6 +40,9 @@
 
 namespace concord::crypto::openssl {
 
+// unique_ptr custom deleter
+void _openssl_free(void* ptr);
+
 using UniqueContext = custom_deleter_unique_ptr<EVP_MD_CTX, EVP_MD_CTX_free>;
 using UniquePKEYContext = custom_deleter_unique_ptr<EVP_PKEY_CTX, EVP_PKEY_CTX_free>;
 using UniquePKEY = custom_deleter_unique_ptr<EVP_PKEY, EVP_PKEY_free>;
@@ -50,6 +53,7 @@ using UniqueBIGNUM = custom_deleter_unique_ptr<BIGNUM, BN_clear_free>;
 using UniqueBNCTX = custom_deleter_unique_ptr<BN_CTX, BN_CTX_free>;
 using UniqueECKEY = custom_deleter_unique_ptr<EC_KEY, EC_KEY_free>;
 using UniqueECPOINT = custom_deleter_unique_ptr<EC_POINT, EC_POINT_clear_free>;
+using UniqueOpenSSLString = custom_deleter_unique_ptr<char[], _openssl_free>;
 
 constexpr int OPENSSL_SUCCESS = 1;
 constexpr int OPENSSL_FAILURE = 0;

--- a/util/src/openssl/crypto.cpp
+++ b/util/src/openssl/crypto.cpp
@@ -441,4 +441,7 @@ string computeSHA256Hash(const char* data, size_t length) {
   return hash;
 }
 
+// Unique_ptr custom deleter. OPENSSL_FREE macro should be wrapped because of CRYPTO_free's signature inside
+void _openssl_free(void* ptr) { OPENSSL_free(ptr); }
+
 }  // namespace concord::crypto::openssl


### PR DESCRIPTION
* **Problem Overview**  
  This is the 3rd merge for the memory managment epic from a dev branch.
All changes were tested extensively, and reviewed by multiple people already.
It centers around solving additional leaks and making replica shut down correctly.

1. TesterReplica main.cpp: convert signal to sigaction
2. DbCheckpointManager:fix forced kill of concord (sleeping monitor thread)
3. Small fix in verify_matching_replica_client_communication() 
4. Fix leaks in openssl/integer.hpp and refactoring file 
5. Convert state-transfer messages to smart pointers 
6. Fix memory leak in communication ClientImp: On destruction of ClientImp, comm_ member was not deleted
7. fix bug: access to DB after DB adapter obj destroyed: 1. PreProcessor kept running asynchronous to Replica destruction while using its DB adapter obj 2. same case with post execution thread
8. Make the preprocessors vector a field in the ReplicaFactory class
9. ReplicaImp: reset smart pointer instead of explicit delete/release

* **Testing Done**  
Done per PR, Apollo and Maestro runs. Shutdown looks good with exit code 0, run is stable.
