### PR TITLE
Makefile: merge both build-image commands into one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,32 +435,33 @@ codecoverage: ## Generate Code Coverage report for Apollo tests
                 "./scripts/run-codecoverage.sh"
 	@echo "Completed make codecoverage"
 
-.PHONY: build-docker-image-release
-build-docker-image-release: ## Build a release image. It has the minimal installations needed. Note: without caching.
-	docker build --rm --no-cache=true -t ${CONCORD_BFT_DOCKER_IMAGE_RELEASE}:latest \
-		-f ./${CONCORD_BFT_DOCKERFILE_RELEASE} .
-	@echo
-	@echo "Build finished. Docker image name: \"${CONCORD_BFT_DOCKER_IMAGE_RELEASE}:latest\"."
-	@echo "Before you push it to Docker Hub, please tag it(CONCORD_BFT_DOCKER_IMAGE_VERSION_RELEASE + 1)."
-	@echo "If you want the image to be the default, please update the following variables:"
-	@echo "${CURDIR}/Makefile: CONCORD_BFT_DOCKER_IMAGE_VERSION_RELEASE"
-
-build-docker-image-debug: SHELL:=/bin/bash
-.PHONY: build-docker-image-debug
-build-docker-image-debug: ## Build a debug image. It has additional tools used for performance analysis, sanitizing and debugging. Note: without caching.
-	@if [[ "$(shell docker images -q ${CONCORD_BFT_DOCKER_IMAGE_FULL_PATH_RELEASE})" == "" ]]; then \
-		bash -c "docker pull ${CONCORD_BFT_DOCKER_IMAGE_FULL_PATH_RELEASE}" &> /dev/null; \
-		if [ $$? -ne 0 ]; then \
-  		echo "Error: docker image ${CONCORD_BFT_DOCKER_IMAGE_FULL_PATH_RELEASE} must exist," \
-				"please run target build-docker-image-release first!"; \
-			exit 1; \
-		fi \
+BUILD_IMAGE_MODE=ALL
+build-docker-images: SHELL:=/bin/bash
+.PHONY: build-docker-images
+build-docker-images: ## First, build a release image and tag it as ${CONCORD_BFT_DOCKER_IMAGE_RELEASE}:latest, then build a debug image based on the just-built release image, and tag it as ${CONCORD_BFT_DOCKER_IMAGE_DEBUG}:latest. By default, both images are built. To build only a release image set BUILD_IMAGE_MODE=RELEASE. to build only debug image set BUILD_IMAGE_MODE=DEBUG. When a debug image is built, it relys on an existing concord-bft:latest image. To have an output image being used (as default) by Makefile: tag it with docker, and then modify CONCORD_BFT_DOCKER_IMAGE_RELEASE + CONCORD_BFT_DOCKER_IMAGE_VERSION_RELEASE in Makefile for a release image, and CONCORD_BFT_DOCKER_IMAGE_DEBUG + CONCORD_BFT_DOCKER_IMAGE_VERSION_DEBUG for a debug image.
+	@if [ '${BUILD_IMAGE_MODE}' != 'RELEASE' ] && [ '${BUILD_IMAGE_MODE}' != 'DEBUG' ] && [ '${BUILD_IMAGE_MODE}' != 'ALL' ]; then \
+		echo "Error: BUILD_IMAGE_MODE must be one of the values: ALL,DEBUG,RELEASE!"; \
+		exit 1; \
 	fi
-	docker build --rm --no-cache=true -t ${CONCORD_BFT_DOCKER_IMAGE_DEBUG}:latest \
-		--build-arg CONCORD_BFT_DOCKER_IMAGE_FULL_PATH_RELEASE="${CONCORD_BFT_DOCKER_IMAGE_FULL_PATH_RELEASE}" \
-		-f ./${CONCORD_BFT_DOCKERFILE_DEBUG} .
-	@echo
-	@echo "Build finished. Debug Docker image name: \"${CONCORD_BFT_DOCKER_IMAGE_DEBUG}:latest\"."
-	@echo "Before you push it to Docker Hub, please tag it(CONCORD_BFT_DOCKER_IMAGE_VERSION_DEBUG + 1)."
-	@echo "If you want the image to be the default, please update the following variables:"
-	@echo "${CURDIR}/Makefile: CONCORD_BFT_DOCKER_IMAGE_VERSION_DEBUG"
+	@if [ '${BUILD_IMAGE_MODE}' = 'RELEASE' ] || [ '${BUILD_IMAGE_MODE}' = 'ALL' ]; then \
+		docker build --rm --no-cache=true -t ${CONCORD_BFT_DOCKER_IMAGE_RELEASE}:latest \
+			-f ./${CONCORD_BFT_DOCKERFILE_RELEASE} . ; \
+	fi
+	@if [ '${BUILD_IMAGE_MODE}' = 'DEBUG' ] || [ '${BUILD_IMAGE_MODE}' = 'ALL' ]; then \
+		docker build --rm --no-cache=true -t ${CONCORD_BFT_DOCKER_IMAGE_DEBUG}:latest \
+			--build-arg CONCORD_BFT_DOCKER_IMAGE_FULL_PATH_RELEASE="${CONCORD_BFT_DOCKER_IMAGE_RELEASE}:latest" \
+			-f ./${CONCORD_BFT_DOCKERFILE_DEBUG} . ; \
+	fi
+	@if [ '${BUILD_IMAGE_MODE}' = 'RELEASE' ] || [ '${BUILD_IMAGE_MODE}' = 'ALL' ]; then \
+		printf "\nDone building release image!\n" ; \
+		echo "Release Docker image name: ${CONCORD_BFT_DOCKER_IMAGE_RELEASE}:latest"; \
+		echo "If you want the image to be the default, please tag it first, and then update the following variables:"; \
+		echo "${CURDIR}/Makefile: CONCORD_BFT_DOCKER_IMAGE_VERSION_RELEASE, and CONCORD_BFT_DOCKER_IMAGE_RELEASE";\
+	fi
+	@if [ '${BUILD_IMAGE_MODE}' = 'DEBUG' ] || [ '${BUILD_IMAGE_MODE}' = 'ALL' ]; then \
+		printf "\nDone building debug image!\n" ; \
+		echo "Debug Docker image name: ${CONCORD_BFT_DOCKER_IMAGE_DEBUG}:latest"; \
+		echo "If you want the image to be the default, please tag it first, and then update the following variables:"; \
+		echo "${CURDIR}/Makefile: CONCORD_BFT_DOCKER_IMAGE_VERSION_DEBUG, and CONCORD_BFT_DOCKER_IMAGE_DEBUG";\
+	fi
+	@printf "\nBefore you push an image to Docker Hub, please tag it(CONCORD_BFT_DOCKER_IMAGE_VERSION_<DEBUG|RELEASE> + 1).\n"

--- a/README.md
+++ b/README.md
@@ -136,20 +136,24 @@ The CI builds and runs tests in a docker container. To add a new dependency or t
 * Rebase against master
 * In order to add/remove dependencies update the file
   [install_deps_release.sh](https://github.com/vmware/concord-bft/blob/master/install_deps_release.sh)
-* Build a new image: `make build-docker-image-release`
-* Check image current version in the
-  [Makefile](https://github.com/vmware/concord-bft/blob/master/Makefile#L3)
-* Tag the new image: `docker tag concord-bft:latest concordbft/concord-bft:<version>`,
+* Build new release/debug images: `make build-docker-images`
+* Check images current version in
+  [Makefile](https://github.com/vmware/concord-bft/blob/master/Makefile#L5)
+  and
+  [Makefile](https://github.com/vmware/concord-bft/blob/master/Makefile#L10)
+* Tag the new images:
+  * For release: `docker tag concord-bft:latest concordbft/concord-bft:<version>`
+  * For debug: `docker tag concord-bft-debug:latest concordbft/concord-bft-debug:<version>`
   <br>where version is `current version + 1`.
 * Update the version in the Makefile
-* Make sure that Concord-BFT is built and tests pass with the new image: `make
-  stop-c build test`
+* Make sure that Concord-BFT is built and tests pass with the new images: `RUN_WITH_DEBUG_IMAGE=TRUE make
+  clean build test`
 * Ask one of the maintainers for a temporary write permission to Docker Hub
   repository(you need to have a [Docker ID](https://docs.docker.com/docker-id/))
 * Push the image: `docker push concordbft/concord-bft:<version>`
 * Create a PR for the update:
     * The PR must contain only changes related to the updates in the image
-    * PR's summary has to be similar to `Docker update to version <new version>`
+    * PR's summary has to be similar to `Docker update to version release=<new version> debug=<new version>`
     * PR's message has to list the changes made in the image content and
       preferably the reason
     * Submit the PR
@@ -213,12 +217,12 @@ Please see [here](example/README.md) for more information about the example/demo
 
 
 - [bftengine](./bftengine): concord-bft codebase
-	- [include](./bftengine/include): external interfaces of concord-bft (to be used by client applications)
-	- [src](./bftengine/src): internal implementation of concord-bft
+  - [include](./bftengine/include): external interfaces of concord-bft (to be used by client applications)
+  - [src](./bftengine/src): internal implementation of concord-bft
     - [tests](./bftengine/tests): tests and usage examples
 - [threshsign](./threshsign): crypto library that supports digital threshold signatures
-	- [include](./threshsign/include): external interfaces of threshsign (to be used by client applications)
-	- [src](./threshsign/src): internal implementation of threshsign
+  - [include](./threshsign/include): external interfaces of threshsign (to be used by client applications)
+  - [src](./threshsign/src): internal implementation of threshsign
     - [tests](./threshsign/tests): tests and usage examples
 - [scripts](./scripts): build scripts
 - [tests](./tests): BFT engine system tests


### PR DESCRIPTION
When we build release image, we must buidld (and push to docker hub) a matching release image, since it is dependent on release. Here we merge both commands into one, and update the README.md file.

I've added an option to run each build command independently.

* **Problem Overview**  
This fix is supposed t simplify the way we create new concord-bft debug/release images.
* **Testing Done**  
NA
