### PR TITLE
bft.py: avoid input paths assertion when deployment already exist

### DIFF
--- a/tests/apollo/util/bft.py
+++ b/tests/apollo/util/bft.py
@@ -281,7 +281,9 @@ class BftTestNetwork:
     def __init__(self, is_existing, origdir, config, testdir, certdir, builddir, toolsdir,
                  procs, replicas, clients, metrics, client_factory, background_nursery, ro_replicas=[]):
         self.is_existing = is_existing
-        self.assert_dirs_exist([origdir, testdir, certdir, builddir, toolsdir])
+        # An existing deployment might pass some of the folders paths as empty so we skip the next assertion.
+        if not is_existing:
+            self.assert_dirs_exist([origdir, testdir, certdir, builddir, toolsdir])
 
         self.origdir = origdir
         self.config = config


### PR DESCRIPTION
An existing deployment might pass some of the folders paths as empty so we skip the next assertion (see BftTestNetwork.existing()).

* **Problem Overview**  
An existing deployment (e.g) doesn't pass all paths non-empty to Apollo infra. Assertions in assert_dirs_exist should done only for Apollo tests
* **Testing Done**  
Ran Relevant Hermes tests and check that they pass.
