### PR TITLE
Remove cre-corebft cyclic deps

### DIFF
--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -26,7 +26,7 @@ if(BUILD_SLOWDOWN)
     target_compile_definitions(preprocessor PUBLIC USE_SLOWDOWN)
 endif()
 
-target_link_libraries(preprocessor PUBLIC diagnostics util bftcommunication yaml-cpp)
+target_link_libraries(preprocessor PUBLIC diagnostics util bftcommunication yaml-cpp corebft)
 
 if (BUILD_TESTING)
     add_subdirectory(tests)

--- a/client/bftclient/include/bftclient/config.h
+++ b/client/bftclient/include/bftclient/config.h
@@ -22,6 +22,7 @@
 #include "bftclient/base_types.h"
 #include "bftclient/quorums.h"
 #include "secrets/secret_data.h"
+#include "crypto/crypto.hpp"
 
 using namespace std::chrono_literals;
 
@@ -70,6 +71,7 @@ struct ClientConfig {
   std::optional<std::string> transaction_signing_private_key_file_path = std::nullopt;
   std::optional<concord::secretsmanager::SecretData> secrets_manager_config = std::nullopt;
   std::optional<std::string> replicas_master_key_folder_path = "./replicas_rsa_keys";
+  concord::crypto::SignatureAlgorithm message_sigs_algorithm = concord::crypto::SignatureAlgorithm::EdDSA;
 };
 
 // Generic per-request configuration shared by reads and writes.

--- a/client/reconfiguration/CMakeLists.txt
+++ b/client/reconfiguration/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(cre PUBLIC
         bftclient_new
         cmf_messages
         concord-crypto
-        logging
         util)
 
 if (BUILD_TESTING)

--- a/client/reconfiguration/CMakeLists.txt
+++ b/client/reconfiguration/CMakeLists.txt
@@ -12,7 +12,6 @@ target_include_directories(cre PUBLIC
         ${bftengine_SOURCE_DIR}/include/bftengine)
 
 target_link_libraries(cre PUBLIC
-        corebft
         bftclient_new
         cmf_messages
         util)

--- a/client/reconfiguration/CMakeLists.txt
+++ b/client/reconfiguration/CMakeLists.txt
@@ -8,12 +8,13 @@ add_library(cre
         )
 
 target_include_directories(cre PUBLIC 
-        include
-        ${bftengine_SOURCE_DIR}/include/bftengine)
+        include)
 
 target_link_libraries(cre PUBLIC
         bftclient_new
         cmf_messages
+        concord-crypto
+        logging
         util)
 
 if (BUILD_TESTING)

--- a/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
+++ b/client/reconfiguration/include/client/reconfiguration/default_handlers.hpp
@@ -13,6 +13,7 @@
 
 #include "cre_interfaces.hpp"
 #include "secrets/secrets_manager_plain.h"
+#include "crypto/crypto.hpp"
 
 #include <memory>
 #include <vector>
@@ -42,7 +43,8 @@ class ClientTlsKeyExchangeHandler : public IStateHandler {
                               const std::vector<uint32_t>& bft_clients,
                               uint16_t clientservice_pid,
                               bool use_unified_certificates,
-                              std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm);
+                              std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+                              crypto::SignatureAlgorithm sig_algorithm);
   bool validate(const State&) const override;
   bool execute(const State&, WriteState&) override;
   void exchangeTlsKeys(const std::string& pkey_path, const std::string& cert_path, const uint64_t blockid);
@@ -62,6 +64,7 @@ class ClientTlsKeyExchangeHandler : public IStateHandler {
   uint64_t init_last_tls_update_block_;
   concord::secretsmanager::SecretsManagerPlain psm_;
   std::string version_path_;
+  crypto::SignatureAlgorithm sig_algorithm_;
 };
 
 class ClientMasterKeyExchangeHandler : public IStateHandler {
@@ -69,6 +72,7 @@ class ClientMasterKeyExchangeHandler : public IStateHandler {
   ClientMasterKeyExchangeHandler(uint32_t client_id,
                                  const std::string& master_key_path,
                                  std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+                                 crypto::SignatureAlgorithm sig_algorithm,
                                  uint64_t last_update_block);
   bool validate(const State&) const override;
   bool execute(const State&, WriteState&) override;
@@ -81,6 +85,7 @@ class ClientMasterKeyExchangeHandler : public IStateHandler {
   uint32_t client_id_;
   std::string master_key_path_;
   std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm_;
+  crypto::SignatureAlgorithm sig_algorithm_;
   uint64_t init_last_update_block_;
   concord::secretsmanager::SecretsManagerPlain psm_;
 };

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -13,6 +13,7 @@
 #include "bftclient/StateControl.hpp"
 #include "concord.cmf.hpp"
 #include "crypto/openssl/certificates.hpp"
+#include "util/kvstream.h"
 
 #include <variant>
 #include <util/filesystem.hpp>

--- a/client/reconfiguration/src/default_handlers.cpp
+++ b/client/reconfiguration/src/default_handlers.cpp
@@ -12,8 +12,6 @@
 #include "client/reconfiguration/default_handlers.hpp"
 #include "bftclient/StateControl.hpp"
 #include "concord.cmf.hpp"
-#include "crypto/crypto.hpp"
-#include "ReplicaConfig.hpp"
 #include "crypto/openssl/certificates.hpp"
 
 #include <variant>
@@ -22,7 +20,6 @@
 
 namespace concord::client::reconfiguration::handlers {
 
-using bftEngine::ReplicaConfig;
 using concord::crypto::SignatureAlgorithm;
 using concord::crypto::EdDSAHexToPem;
 using concord::crypto::generateSelfSignedCert;
@@ -75,8 +72,7 @@ void ClientTlsKeyExchangeHandler::exchangeTlsKeys(const std::string& pkey_path,
   std::string master_key = sm_->decryptFile(master_key_path_).value_or(std::string());
   if (master_key.empty()) master_key = psm_.decryptFile(master_key_path_).value_or(std::string());
   if (master_key.empty()) LOG_FATAL(getLogger(), "unable to read the node master key");
-  auto cert = generateSelfSignedCert(
-      cert_path, new_cert_keys.second, master_key, ReplicaConfig::instance().replicaMsgSigningAlgo);
+  auto cert = generateSelfSignedCert(cert_path, new_cert_keys.second, master_key, sig_algorithm_);
 
   sm_->encryptFile(pkey_path, new_cert_keys.first);
   psm_.encryptFile(cert_path, cert);
@@ -123,14 +119,16 @@ ClientTlsKeyExchangeHandler::ClientTlsKeyExchangeHandler(
     const std::vector<uint32_t>& bft_clients,
     uint16_t clientservice_pid,
     bool use_unified_certificates,
-    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm)
+    std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+    SignatureAlgorithm sig_algorithm)
     : master_key_path_{master_key_path},
       cert_folder_{cert_folder},
       enc_{enc},
       sm_{sm},
       bft_clients_{bft_clients},
       clientservice_pid_{clientservice_pid},
-      use_unified_certificates_{use_unified_certificates} {
+      use_unified_certificates_{use_unified_certificates},
+      sig_algorithm_{sig_algorithm} {
   version_path_ = cert_folder + "/version";
   if (!fs::exists(version_path_)) fs::create_directories(version_path_);
   version_path_ += "/exchange.version";
@@ -141,8 +139,13 @@ ClientMasterKeyExchangeHandler::ClientMasterKeyExchangeHandler(
     uint32_t client_id,
     const std::string& master_key_path,
     std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> sm,
+    SignatureAlgorithm sig_algorithm,
     uint64_t last_update_block)
-    : client_id_{client_id}, master_key_path_{master_key_path}, sm_{sm}, init_last_update_block_{last_update_block} {}
+    : client_id_{client_id},
+      master_key_path_{master_key_path},
+      sm_{sm},
+      sig_algorithm_{sig_algorithm},
+      init_last_update_block_{last_update_block} {}
 bool ClientMasterKeyExchangeHandler::validate(const State& state) const {
   concord::messages::ClientStateReply crep;
   concord::messages::deserialize(state.data, crep);
@@ -159,7 +162,7 @@ bool ClientMasterKeyExchangeHandler::execute(const State& state, WriteState& out
   std::pair<std::string, std::string> hex_keys;
   std::pair<std::string, std::string> pem_keys;
 
-  if (ReplicaConfig::instance().replicaMsgSigningAlgo == SignatureAlgorithm::EdDSA) {
+  if (sig_algorithm_ == SignatureAlgorithm::EdDSA) {
     hex_keys = concord::crypto::generateEdDSAKeyPair();
     pem_keys = EdDSAHexToPem(hex_keys);
   }

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -260,11 +260,13 @@ int main(int argc, char** argv) {
       bft_clients,
       creParams.bftConfig.id.val,
       creParams.bftConfig.use_unified_certs,
-      sm_));
+      sm_,
+      ReplicaConfig::instance().replicaMsgSigningAlgo));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientMasterKeyExchangeHandler>(
       creParams.CreConfig.id_,
       creParams.bftConfig.transaction_signing_private_key_file_path.value(),
       sm_,
+      ReplicaConfig::instance().replicaMsgSigningAlgo,
       last_pk_status));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientRestartHandler>(
       last_resatrt_status, creParams.CreConfig.id_));

--- a/tests/simpleKVBC/TesterCRE/main.cpp
+++ b/tests/simpleKVBC/TesterCRE/main.cpp
@@ -261,12 +261,12 @@ int main(int argc, char** argv) {
       creParams.bftConfig.id.val,
       creParams.bftConfig.use_unified_certs,
       sm_,
-      ReplicaConfig::instance().replicaMsgSigningAlgo));
+      creParams.bftConfig.message_sigs_algorithm));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientMasterKeyExchangeHandler>(
       creParams.CreConfig.id_,
       creParams.bftConfig.transaction_signing_private_key_file_path.value(),
       sm_,
-      ReplicaConfig::instance().replicaMsgSigningAlgo,
+      creParams.bftConfig.message_sigs_algorithm,
       last_pk_status));
   cre.registerHandler(std::make_shared<concord::client::reconfiguration::handlers::ClientRestartHandler>(
       last_resatrt_status, creParams.CreConfig.id_));


### PR DESCRIPTION
* **Problem Overview**  
  CRE is linked to corebft in order to use ReplicaConfig. On the other side, replicas are using cre for running the internal state transfer cre.
Also, using ReplicaConfig is incorrect in the client context because no one initializes this component on the client side.
* **Testing Done**  
  CI
