### PR TITLE
Add customizable admin and wallet server host/port in privacy feature

### DIFF
--- a/utt/admin-cli/src/admin.cpp
+++ b/utt/admin-cli/src/admin.cpp
@@ -18,9 +18,20 @@
 using namespace vmware::concord::utt::admin::api::v1;
 
 Admin::Connection Admin::newConnection() {
-  std::string grpcServerAddr = "127.0.0.1:49000";
+  std::string grpcServerAddr;
+  auto serverAddr = std::getenv("GRPC_ADMIN_SERVER_ADDR");
+  auto serverPort = std::getenv("PRIVACY_WALLET_ADMIN_GRPC_PORT");
+  if (!serverAddr)
+    grpcServerAddr = "127.0.0.1";
+  else
+    grpcServerAddr = std::string(serverAddr);
+  grpcServerAddr += ":";
+  if (!serverPort)
+    grpcServerAddr += "49000";
+  else
+    grpcServerAddr += std::string(serverPort);
 
-  std::cout << "Connecting to gRPC server at " << grpcServerAddr << "... ";
+  std::cout << "Connecting to gRPC server at " << grpcServerAddr << "... " << std::endl;
 
   auto chan = grpc::CreateChannel(grpcServerAddr, grpc::InsecureChannelCredentials());
 

--- a/utt/wallet-cli/src/wallet.cpp
+++ b/utt/wallet-cli/src/wallet.cpp
@@ -26,9 +26,20 @@ Wallet::Wallet(std::string userId, utt::client::TestUserPKInfrastructure& pki, c
 }
 
 Wallet::Connection Wallet::newConnection() {
-  std::string grpcServerAddr = "127.0.0.1:49001";
+  std::string grpcServerAddr;
+  auto serverAddr = std::getenv("GRPC_WALLET_SERVER_ADDR");
+  auto serverPort = std::getenv("PRIVACY_WALLET_APP_GRPC_PORT");
+  if (!serverAddr)
+    grpcServerAddr = "127.0.0.1";
+  else
+    grpcServerAddr = std::string(serverAddr);
+  grpcServerAddr += ":";
+  if (!serverPort)
+    grpcServerAddr += "49001";
+  else
+    grpcServerAddr += std::string(serverPort);
 
-  std::cout << "Connecting to gRPC server at " << grpcServerAddr << "... ";
+  std::cout << "Connecting to gRPC server at " << grpcServerAddr << "... " << std::endl;
 
   auto chan = grpc::CreateChannel(grpcServerAddr, grpc::InsecureChannelCredentials());
 


### PR DESCRIPTION
* **Problem Overview**  
  In order to split components of privacy feature testing (admin server, wallet server, test scenario handler) addresses that wallet-cli and admin-cli shall not be hardcoded. This PR enables changing the endpoint to which wallet-cli and admin-cli connect using `GRPC_ADMIN_SERVER_ADDR`, `PRIVACY_WALLET_ADMIN_GRPC_PORT`, `GRPC_WALLET_SERVER_ADDR` and `PRIVACY_WALLET_APP_GRPC_PORT` env variables.
* **Testing Done**  
  Manual testing: 
- demo flow
- automated script with contenerized components
- docker-compose setup
