### PR TITLE
Adding AES_GCM encryption mode to overcome AES_CBC limitations

### DIFF
--- a/libs/secrets/secrets_manager_enc.h
+++ b/libs/secrets/secrets_manager_enc.h
@@ -24,7 +24,7 @@
 namespace concord::secretsmanager {
 
 struct KeyParams;
-class iAES_Mode;
+class IAesMode;
 // SecretsManagerEnc handles encryption and decryption of files.
 // The following flow is used for encryption:
 // 1. SecretData are the input parameters for SecretsManagerEnc. They contain an algorithm name, symmetric key and IV.
@@ -47,7 +47,7 @@ class SecretsManagerEnc : public ISecretsManagerImpl {
   std::optional<std::string> decryptFile(std::string_view path) override;
   std::optional<std::string> decryptFile(const std::ifstream& file) override;
   std::optional<std::string> decryptString(const std::string& input) override;
-  std::unique_ptr<iAES_Mode> getEncryptionMode();
+  std::unique_ptr<IAesMode> getAESEncryptionMode();
 
   // = default won't work here. The destructor needs to be defined in the cpp due to the forward declarations and
   // unique_ptr

--- a/libs/secrets/secrets_manager_enc.h
+++ b/libs/secrets/secrets_manager_enc.h
@@ -17,7 +17,6 @@
 #include <memory>
 #include <set>
 #include <functional>
-
 #include "log/logger.hpp"
 #include "secrets_manager_impl.h"
 #include "secret_data.h"
@@ -25,7 +24,7 @@
 namespace concord::secretsmanager {
 
 struct KeyParams;
-
+class iAES_Mode;
 // SecretsManagerEnc handles encryption and decryption of files.
 // The following flow is used for encryption:
 // 1. SecretData are the input parameters for SecretsManagerEnc. They contain an algorithm name, symmetric key and IV.
@@ -48,13 +47,14 @@ class SecretsManagerEnc : public ISecretsManagerImpl {
   std::optional<std::string> decryptFile(std::string_view path) override;
   std::optional<std::string> decryptFile(const std::ifstream& file) override;
   std::optional<std::string> decryptString(const std::string& input) override;
+  std::unique_ptr<iAES_Mode> getEncryptionMode();
 
   // = default won't work here. The destructor needs to be defined in the cpp due to the forward declarations and
   // unique_ptr
   ~SecretsManagerEnc();
 
  private:
-  const std::set<std::string> supported_encs_{"AES/CBC/PKCS5Padding", "AES/CBC/PKCS7Padding"};
+  const std::set<std::string> supported_encs_{"AES/CBC/PKCS5Padding", "AES/CBC/PKCS7Padding", "AES/GCM/NoPadding"};
 
   logging::Logger logger_ = logging::getLogger("concord.bft.secrets-manager-enc");
   const std::unique_ptr<KeyParams> key_params_;

--- a/libs/secrets/src/aes.cpp
+++ b/libs/secrets/src/aes.cpp
@@ -12,7 +12,6 @@
 // file.
 //
 // This convenience header combines different block implementations.
-
 #include "aes.h"
 #include "crypto/openssl/crypto.hpp"
 #include "assertUtils.hpp"
@@ -25,7 +24,7 @@ using concord::crypto::openssl::OPENSSL_SUCCESS;
 using concord::crypto::openssl::UniqueCipherContext;
 
 vector<uint8_t> AES_CBC::encrypt(std::string_view input) {
-  if (algo_ == concord::crypto::SignatureAlgorithm::EdDSA) {
+  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
     if (input.empty()) {
       return {};
     }
@@ -41,8 +40,9 @@ vector<uint8_t> AES_CBC::encrypt(std::string_view input) {
     int c_len{0};
     int f_len{0};
 
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, params_.key.data(), params_.iv.data()));
+    ConcordAssert(
+        OPENSSL_SUCCESS ==
+        EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, getKeyParams().key.data(), getKeyParams().iv.data()));
     ConcordAssert(OPENSSL_SUCCESS ==
                   EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &c_len, plaintext.get(), input.size()));
     ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptFinal_ex(ctx.get(), ciphertext.get() + c_len, &f_len));
@@ -56,7 +56,7 @@ vector<uint8_t> AES_CBC::encrypt(std::string_view input) {
 }
 
 string AES_CBC::decrypt(const vector<uint8_t>& cipher) {
-  if (algo_ == concord::crypto::SignatureAlgorithm::EdDSA) {
+  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
     if (cipher.capacity() == 0) {
       return {};
     }
@@ -68,8 +68,9 @@ string AES_CBC::decrypt(const vector<uint8_t>& cipher) {
     UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
     ConcordAssert(nullptr != ctx);
 
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, params_.key.data(), params_.iv.data()));
+    ConcordAssert(
+        OPENSSL_SUCCESS ==
+        EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, getKeyParams().key.data(), getKeyParams().iv.data()));
     EVP_CIPHER_CTX_set_key_length(ctx.get(), EVP_MAX_KEY_LENGTH);
     ConcordAssert(
         OPENSSL_SUCCESS ==
@@ -85,4 +86,97 @@ string AES_CBC::decrypt(const vector<uint8_t>& cipher) {
   }
   return {};
 }
+
+std::vector<uint8_t> AES_GCM::encrypt(std::string_view input) {
+  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
+    if (input.empty()) {
+      return {};
+    }
+    const unsigned int tagLength = 16;
+    auto ciphertext = std::make_unique<unsigned char[]>(input.size() + AES_BLOCK_SIZE);
+    auto plaintext = std::make_unique<unsigned char[]>(input.size());
+
+    std::copy(input.begin(), input.end(), plaintext.get());
+
+    UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
+    ConcordAssert(nullptr != ctx);
+
+    int c_len{0};
+    int f_len{0};
+
+    /* Set cipher type and mode */
+    ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_gcm(), NULL, NULL, NULL));
+    /* Set IV length if default 96 bits is not appropriate */
+    ConcordAssert(OPENSSL_SUCCESS ==
+                  EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_IVLEN, getKeyParams().iv.size(), NULL));
+    /* Initialise key and IV */
+    ConcordAssert(OPENSSL_SUCCESS ==
+                  EVP_EncryptInit_ex(ctx.get(), NULL, NULL, getKeyParams().key.data(), getKeyParams().iv.data()));
+    /*
+     * Provide the message to be encrypted, and obtain the encrypted output.
+     * EVP_EncryptUpdate can be called multiple times if necessary
+     */
+    ConcordAssert(OPENSSL_SUCCESS ==
+                  EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &c_len, plaintext.get(), input.size()));
+
+    /*
+     * Finalise the encryption. Normally ciphertext bytes may be written at
+     * this stage, but this does not occur in GCM mode
+     */
+    ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptFinal_ex(ctx.get(), ciphertext.get() + c_len, &f_len));
+
+    const int encryptedMsgLen = c_len + f_len;
+    // allocating memory for cipher as well as tag
+    vector<uint8_t> cipher(encryptedMsgLen + tagLength);
+    memcpy(cipher.data(), ciphertext.get(), encryptedMsgLen);
+    /* Get the tag */
+    auto c_tag = std::make_unique<unsigned char[]>(tagLength);
+    EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_GET_TAG, tagLength, c_tag.get());
+    // adding tag to cipher text
+    memcpy(cipher.data() + encryptedMsgLen, c_tag.get(), tagLength);
+    return cipher;
+  }
+  return {};
+}
+/* In GCM mode, cipher includes cipher text  + authenticated tag
+ */
+string AES_GCM::decrypt(const vector<uint8_t>& cipher) {
+  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
+    if (cipher.capacity() == 0) {
+      return {};
+    }
+    const unsigned int tagLength = 16;
+    const unsigned int cipherLength = cipher.size() - tagLength;
+    std::vector<uint8_t> cipherText(cipher.begin(), cipher.end() - tagLength);
+    std::vector<uint8_t> tag(cipher.begin() + cipherLength, cipher.end());
+    int c_len{0}, f_len{0};
+    auto plaintext = std::make_unique<unsigned char[]>(cipher.capacity());
+    UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
+    ConcordAssert(nullptr != ctx);
+    /* Select cipher */
+    ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_gcm(), NULL, NULL, NULL));
+    /* Set IV length, omit for 96 bits */
+    ConcordAssert(OPENSSL_SUCCESS ==
+                  EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_IVLEN, getKeyParams().iv.size(), NULL));
+    /* Specify key and IV */
+    ConcordAssert(OPENSSL_SUCCESS ==
+                  EVP_DecryptInit_ex(ctx.get(), NULL, NULL, getKeyParams().key.data(), getKeyParams().iv.data()));
+    /* Decrypt plaintext */
+    ConcordAssert(
+        OPENSSL_SUCCESS ==
+        EVP_DecryptUpdate(ctx.get(), plaintext.get(), &c_len, (const unsigned char*)cipherText.data(), cipherLength));
+    /* Set expected tag value. */
+    ConcordAssert(OPENSSL_SUCCESS == EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_TAG, tagLength, tag.data()));
+
+    ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptFinal_ex(ctx.get(), plaintext.get() + c_len, &f_len));
+    const int plainMsgLen = c_len + f_len;
+    plaintext.get()[plainMsgLen] = 0;
+
+    vector<uint8_t> plaintxt(plainMsgLen);
+    memcpy(plaintxt.data(), plaintext.get(), plainMsgLen);
+    return string(plaintxt.begin(), plaintxt.end());
+  }
+  return {};
+}
+
 }  // namespace concord::secretsmanager

--- a/libs/secrets/src/aes.cpp
+++ b/libs/secrets/src/aes.cpp
@@ -16,167 +16,166 @@
 #include "crypto/openssl/crypto.hpp"
 #include "assertUtils.hpp"
 #include <openssl/aes.h>
+#include <nlohmann/json.hpp>
 
 namespace concord::secretsmanager {
 using std::vector;
 using std::string;
 using concord::crypto::openssl::OPENSSL_SUCCESS;
 using concord::crypto::openssl::UniqueCipherContext;
+using json = nlohmann::json;
 
 vector<uint8_t> AES_CBC::encrypt(std::string_view input) {
-  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
-    if (input.empty()) {
-      return {};
-    }
-
-    auto ciphertext = std::make_unique<unsigned char[]>(input.size() + AES_BLOCK_SIZE);
-    auto plaintext = std::make_unique<unsigned char[]>(input.size());
-
-    std::copy(input.begin(), input.end(), plaintext.get());
-
-    UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
-    ConcordAssert(nullptr != ctx);
-
-    int c_len{0};
-    int f_len{0};
-
-    ConcordAssert(
-        OPENSSL_SUCCESS ==
-        EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, getKeyParams().key.data(), getKeyParams().iv.data()));
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &c_len, plaintext.get(), input.size()));
-    ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptFinal_ex(ctx.get(), ciphertext.get() + c_len, &f_len));
-
-    const int encryptedMsgLen = c_len + f_len;
-    vector<uint8_t> cipher(encryptedMsgLen);
-    memcpy(cipher.data(), ciphertext.get(), encryptedMsgLen);
-    return cipher;
+  if (input.empty()) {
+    return {};
   }
-  return {};
+
+  auto ciphertext = std::make_unique<unsigned char[]>(input.size() + AES_BLOCK_SIZE);
+  auto plaintext = std::make_unique<unsigned char[]>(input.size());
+
+  std::copy(input.begin(), input.end(), plaintext.get());
+
+  UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
+  ConcordAssert(nullptr != ctx);
+
+  int c_len{0};
+  int f_len{0};
+
+  ConcordAssert(
+      OPENSSL_SUCCESS ==
+      EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, getKeyParams().key.data(), getKeyParams().iv.data()));
+  ConcordAssert(OPENSSL_SUCCESS ==
+                EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &c_len, plaintext.get(), input.size()));
+  ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptFinal_ex(ctx.get(), ciphertext.get() + c_len, &f_len));
+
+  const int encryptedMsgLen = c_len + f_len;
+  vector<uint8_t> cipher(encryptedMsgLen);
+  memcpy(cipher.data(), ciphertext.get(), encryptedMsgLen);
+  return cipher;
 }
 
 string AES_CBC::decrypt(const vector<uint8_t>& cipher) {
-  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
-    if (cipher.capacity() == 0) {
-      return {};
-    }
-
-    const int cipherLength = cipher.capacity();
-    int c_len{0}, f_len{0};
-
-    auto plaintext = std::make_unique<unsigned char[]>(cipherLength);
-    UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
-    ConcordAssert(nullptr != ctx);
-
-    ConcordAssert(
-        OPENSSL_SUCCESS ==
-        EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, getKeyParams().key.data(), getKeyParams().iv.data()));
-    EVP_CIPHER_CTX_set_key_length(ctx.get(), EVP_MAX_KEY_LENGTH);
-    ConcordAssert(
-        OPENSSL_SUCCESS ==
-        EVP_DecryptUpdate(ctx.get(), plaintext.get(), &c_len, (const unsigned char*)cipher.data(), cipherLength));
-    ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptFinal_ex(ctx.get(), plaintext.get() + c_len, &f_len));
-
-    const int plainMsgLen = c_len + f_len;
-    plaintext.get()[plainMsgLen] = 0;
-
-    vector<uint8_t> plaintxt(plainMsgLen);
-    memcpy(plaintxt.data(), plaintext.get(), plainMsgLen);
-    return string(plaintxt.begin(), plaintxt.end());
+  if (cipher.capacity() == 0) {
+    return {};
   }
-  return {};
+
+  const int cipherLength = cipher.capacity();
+  int c_len{0}, f_len{0};
+
+  auto plaintext = std::make_unique<unsigned char[]>(cipherLength);
+  UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
+  ConcordAssert(nullptr != ctx);
+
+  ConcordAssert(
+      OPENSSL_SUCCESS ==
+      EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_cbc(), nullptr, getKeyParams().key.data(), getKeyParams().iv.data()));
+  EVP_CIPHER_CTX_set_key_length(ctx.get(), EVP_MAX_KEY_LENGTH);
+  ConcordAssert(
+      OPENSSL_SUCCESS ==
+      EVP_DecryptUpdate(ctx.get(), plaintext.get(), &c_len, (const unsigned char*)cipher.data(), cipherLength));
+  ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptFinal_ex(ctx.get(), plaintext.get() + c_len, &f_len));
+
+  const int plainMsgLen = c_len + f_len;
+  plaintext.get()[plainMsgLen] = 0;
+
+  vector<uint8_t> plaintxt(plainMsgLen);
+  memcpy(plaintxt.data(), plaintext.get(), plainMsgLen);
+  return string(plaintxt.begin(), plaintxt.end());
 }
 
 std::vector<uint8_t> AES_GCM::encrypt(std::string_view input) {
-  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
-    if (input.empty()) {
-      return {};
-    }
-    const unsigned int tagLength = 16;
-    auto ciphertext = std::make_unique<unsigned char[]>(input.size() + AES_BLOCK_SIZE);
-    auto plaintext = std::make_unique<unsigned char[]>(input.size());
-
-    std::copy(input.begin(), input.end(), plaintext.get());
-
-    UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
-    ConcordAssert(nullptr != ctx);
-
-    int c_len{0};
-    int f_len{0};
-
-    /* Set cipher type and mode */
-    ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_gcm(), NULL, NULL, NULL));
-    /* Set IV length if default 96 bits is not appropriate */
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_IVLEN, getKeyParams().iv.size(), NULL));
-    /* Initialise key and IV */
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_EncryptInit_ex(ctx.get(), NULL, NULL, getKeyParams().key.data(), getKeyParams().iv.data()));
-    /*
-     * Provide the message to be encrypted, and obtain the encrypted output.
-     * EVP_EncryptUpdate can be called multiple times if necessary
-     */
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &c_len, plaintext.get(), input.size()));
-
-    /*
-     * Finalise the encryption. Normally ciphertext bytes may be written at
-     * this stage, but this does not occur in GCM mode
-     */
-    ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptFinal_ex(ctx.get(), ciphertext.get() + c_len, &f_len));
-
-    const int encryptedMsgLen = c_len + f_len;
-    // allocating memory for cipher as well as tag
-    vector<uint8_t> cipher(encryptedMsgLen + tagLength);
-    memcpy(cipher.data(), ciphertext.get(), encryptedMsgLen);
-    /* Get the tag */
-    auto c_tag = std::make_unique<unsigned char[]>(tagLength);
-    EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_GET_TAG, tagLength, c_tag.get());
-    // adding tag to cipher text
-    memcpy(cipher.data() + encryptedMsgLen, c_tag.get(), tagLength);
-    return cipher;
+  if (input.empty()) {
+    return {};
   }
-  return {};
+  int tagLength = 16;
+  if (!getAdditionalInfo().empty()) {
+    auto j = json::parse(getAdditionalInfo());
+    tagLength = (j["TAG_LENGTH_BITS"].get<int>()) / 8;  // from bits to bytes
+  }
+
+  auto ciphertext = std::make_unique<unsigned char[]>(input.size() + AES_BLOCK_SIZE);
+  auto plaintext = std::make_unique<unsigned char[]>(input.size());
+
+  std::copy(input.begin(), input.end(), plaintext.get());
+
+  UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
+  ConcordAssert(nullptr != ctx);
+
+  int c_len{0};
+  int f_len{0};
+
+  /* Set cipher type and mode */
+  ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_gcm(), NULL, NULL, NULL));
+  /* Set IV length if default 96 bits is not appropriate */
+  ConcordAssert(OPENSSL_SUCCESS ==
+                EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_AEAD_SET_IVLEN, getKeyParams().iv.size(), NULL));
+  /* Initialise key and IV */
+  ConcordAssert(OPENSSL_SUCCESS ==
+                EVP_EncryptInit_ex(ctx.get(), NULL, NULL, getKeyParams().key.data(), getKeyParams().iv.data()));
+  /*
+   * Provide the message to be encrypted, and obtain the encrypted output.
+   * EVP_EncryptUpdate can be called multiple times if necessary
+   */
+  ConcordAssert(OPENSSL_SUCCESS ==
+                EVP_EncryptUpdate(ctx.get(), ciphertext.get(), &c_len, plaintext.get(), input.size()));
+
+  /*
+   * Finalise the encryption. Normally ciphertext bytes may be written at
+   * this stage, but this does not occur in GCM mode
+   */
+  ConcordAssert(OPENSSL_SUCCESS == EVP_EncryptFinal_ex(ctx.get(), ciphertext.get() + c_len, &f_len));
+
+  const int encryptedMsgLen = c_len + f_len;
+  // allocating memory for cipher as well as tag
+  vector<uint8_t> cipher(encryptedMsgLen + tagLength);
+  memcpy(cipher.data(), ciphertext.get(), encryptedMsgLen);
+  /* Get the tag */
+  auto c_tag = std::make_unique<unsigned char[]>(tagLength);
+  EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_GET_TAG, tagLength, c_tag.get());
+  // adding tag to cipher text
+  memcpy(cipher.data() + encryptedMsgLen, c_tag.get(), tagLength);
+  return cipher;
 }
 /* In GCM mode, cipher includes cipher text  + authenticated tag
  */
 string AES_GCM::decrypt(const vector<uint8_t>& cipher) {
-  if (getAlgorithm() == concord::crypto::SignatureAlgorithm::EdDSA) {
-    if (cipher.capacity() == 0) {
-      return {};
-    }
-    const unsigned int tagLength = 16;
-    const unsigned int cipherLength = cipher.size() - tagLength;
-    std::vector<uint8_t> cipherText(cipher.begin(), cipher.end() - tagLength);
-    std::vector<uint8_t> tag(cipher.begin() + cipherLength, cipher.end());
-    int c_len{0}, f_len{0};
-    auto plaintext = std::make_unique<unsigned char[]>(cipher.capacity());
-    UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
-    ConcordAssert(nullptr != ctx);
-    /* Select cipher */
-    ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_gcm(), NULL, NULL, NULL));
-    /* Set IV length, omit for 96 bits */
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_IVLEN, getKeyParams().iv.size(), NULL));
-    /* Specify key and IV */
-    ConcordAssert(OPENSSL_SUCCESS ==
-                  EVP_DecryptInit_ex(ctx.get(), NULL, NULL, getKeyParams().key.data(), getKeyParams().iv.data()));
-    /* Decrypt plaintext */
-    ConcordAssert(
-        OPENSSL_SUCCESS ==
-        EVP_DecryptUpdate(ctx.get(), plaintext.get(), &c_len, (const unsigned char*)cipherText.data(), cipherLength));
-    /* Set expected tag value. */
-    ConcordAssert(OPENSSL_SUCCESS == EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_TAG, tagLength, tag.data()));
-
-    ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptFinal_ex(ctx.get(), plaintext.get() + c_len, &f_len));
-    const int plainMsgLen = c_len + f_len;
-    plaintext.get()[plainMsgLen] = 0;
-
-    vector<uint8_t> plaintxt(plainMsgLen);
-    memcpy(plaintxt.data(), plaintext.get(), plainMsgLen);
-    return string(plaintxt.begin(), plaintxt.end());
+  if (cipher.capacity() == 0) {
+    return {};
   }
-  return {};
+  int tagLength = 16;
+  if (!getAdditionalInfo().empty()) {
+    auto j = json::parse(getAdditionalInfo());
+    tagLength = (j["TAG_LENGTH_BITS"].get<int>()) / 8;  // from bits to bytes
+  }
+  const unsigned int cipherLength = cipher.size() - tagLength;
+  std::vector<uint8_t> cipherText(cipher.begin(), cipher.end() - tagLength);
+  std::vector<uint8_t> tag(cipher.begin() + cipherLength, cipher.end());
+  int c_len{0}, f_len{0};
+  auto plaintext = std::make_unique<unsigned char[]>(cipher.capacity());
+  UniqueCipherContext ctx(EVP_CIPHER_CTX_new());
+  ConcordAssert(nullptr != ctx);
+  /* Select cipher */
+  ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_gcm(), NULL, NULL, NULL));
+  /* Set IV length, omit for 96 bits */
+  ConcordAssert(OPENSSL_SUCCESS ==
+                EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_IVLEN, getKeyParams().iv.size(), NULL));
+  /* Specify key and IV */
+  ConcordAssert(OPENSSL_SUCCESS ==
+                EVP_DecryptInit_ex(ctx.get(), NULL, NULL, getKeyParams().key.data(), getKeyParams().iv.data()));
+  /* Decrypt plaintext */
+  ConcordAssert(
+      OPENSSL_SUCCESS ==
+      EVP_DecryptUpdate(ctx.get(), plaintext.get(), &c_len, (const unsigned char*)cipherText.data(), cipherLength));
+  /* Set expected tag value. */
+  ConcordAssert(OPENSSL_SUCCESS == EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_TAG, tagLength, tag.data()));
+
+  ConcordAssert(OPENSSL_SUCCESS == EVP_DecryptFinal_ex(ctx.get(), plaintext.get() + c_len, &f_len));
+  const int plainMsgLen = c_len + f_len;
+  plaintext.get()[plainMsgLen] = 0;
+
+  vector<uint8_t> plaintxt(plainMsgLen);
+  memcpy(plaintxt.data(), plaintext.get(), plainMsgLen);
+  return string(plaintxt.begin(), plaintxt.end());
 }
 
 }  // namespace concord::secretsmanager

--- a/libs/secrets/src/aes.h
+++ b/libs/secrets/src/aes.h
@@ -24,38 +24,32 @@
 
 namespace concord::secretsmanager {
 
-class iAES_Mode {
+class IAesMode {
  public:
-  iAES_Mode(const KeyParams& params,
-            concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
-      : params_{params}, algo_{algo} {}
+  IAesMode(const KeyParams& params, const std::string& a_info = "") : params_{params}, additional_info(a_info) {}
   virtual std::vector<uint8_t> encrypt(std::string_view input) = 0;
   virtual std::string decrypt(const std::vector<uint8_t>& cipher) = 0;
   const KeyParams getKeyParams() { return params_; }
-  const concord::crypto::SignatureAlgorithm getAlgorithm() { return algo_; }
+  const std::string getAdditionalInfo() { return additional_info; }
   // Not adding setters as these algo/modes must be set at construction time
-  virtual ~iAES_Mode() = default;
+  virtual ~IAesMode() = default;
 
  private:
   KeyParams params_;
-  concord::crypto::SignatureAlgorithm algo_;
+  std::string additional_info;
 };
 
-class AES_CBC : public iAES_Mode {
+class AES_CBC : public IAesMode {
  public:
-  AES_CBC(const KeyParams& params,
-          concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
-      : iAES_Mode(params, algo) {}
+  AES_CBC(const KeyParams& params, const std::string& a_info = "") : IAesMode(params, a_info) {}
   std::vector<uint8_t> encrypt(std::string_view input) override;
   std::string decrypt(const std::vector<uint8_t>& cipher) override;
   ~AES_CBC() = default;
 };
 
-class AES_GCM : public iAES_Mode {
+class AES_GCM : public IAesMode {
  public:
-  AES_GCM(const KeyParams& params,
-          concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
-      : iAES_Mode(params, algo) {}
+  AES_GCM(const KeyParams& params, const std::string& a_info = "") : IAesMode(params, a_info) {}
   std::vector<uint8_t> encrypt(std::string_view input) override;
   std::string decrypt(const std::vector<uint8_t>& cipher) override;
   ~AES_GCM() = default;

--- a/libs/secrets/src/aes.h
+++ b/libs/secrets/src/aes.h
@@ -24,17 +24,41 @@
 
 namespace concord::secretsmanager {
 
-class AES_CBC {
+class iAES_Mode {
  public:
-  AES_CBC(const KeyParams& params,
-          concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
+  iAES_Mode(const KeyParams& params,
+            concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
       : params_{params}, algo_{algo} {}
-  std::vector<uint8_t> encrypt(std::string_view input);
-  std::string decrypt(const std::vector<uint8_t>& cipher);
+  virtual std::vector<uint8_t> encrypt(std::string_view input) = 0;
+  virtual std::string decrypt(const std::vector<uint8_t>& cipher) = 0;
+  const KeyParams getKeyParams() { return params_; }
+  const concord::crypto::SignatureAlgorithm getAlgorithm() { return algo_; }
+  // Not adding setters as these algo/modes must be set at construction time
+  virtual ~iAES_Mode() = default;
 
  private:
   KeyParams params_;
   concord::crypto::SignatureAlgorithm algo_;
+};
+
+class AES_CBC : public iAES_Mode {
+ public:
+  AES_CBC(const KeyParams& params,
+          concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
+      : iAES_Mode(params, algo) {}
+  std::vector<uint8_t> encrypt(std::string_view input) override;
+  std::string decrypt(const std::vector<uint8_t>& cipher) override;
+  ~AES_CBC() = default;
+};
+
+class AES_GCM : public iAES_Mode {
+ public:
+  AES_GCM(const KeyParams& params,
+          concord::crypto::SignatureAlgorithm algo = concord::crypto::SignatureAlgorithm::EdDSA)
+      : iAES_Mode(params, algo) {}
+  std::vector<uint8_t> encrypt(std::string_view input) override;
+  std::string decrypt(const std::vector<uint8_t>& cipher) override;
+  ~AES_GCM() = default;
 };
 
 }  // namespace concord::secretsmanager

--- a/libs/secrets/src/secrets_manager_enc.cpp
+++ b/libs/secrets/src/secrets_manager_enc.cpp
@@ -14,7 +14,6 @@
 // This convenience header combines different block implementations.
 
 #include "secrets/secrets_manager_enc.h"
-
 #include "aes.h"
 #include "base64.h"
 #include "assertUtils.hpp"
@@ -31,7 +30,13 @@ SecretsManagerEnc::SecretsManagerEnc(const SecretData& secrets)
     throw std::runtime_error("Unsupported encryption algorithm " + secrets.algo + "Supported encryptions: " + encs);
   }
 }
-
+std::unique_ptr<iAES_Mode> SecretsManagerEnc::getEncryptionMode() {
+  if (initial_secret_data_.algo == "AES/GCM/NoPadding") {
+    return std::make_unique<AES_GCM>(*key_params_);
+  } else {
+    return std::make_unique<AES_CBC>(*key_params_);
+  }
+}
 bool SecretsManagerEnc::encryptFile(std::string_view file_path, const std::string& input) {
   if (file_path.empty()) {
     return false;
@@ -88,9 +93,9 @@ std::optional<std::string> SecretsManagerEnc::decrypt(const std::string& data) {
   }
   try {
     // AES_CBC is created on each call for thread safety
-    auto aes = AES_CBC(*key_params_);
+    auto aes = getEncryptionMode();
     auto cipher_text = base64Dec(data);
-    auto pt = aes.decrypt(cipher_text);
+    auto pt = aes->decrypt(cipher_text);
     return std::optional<std::string>{pt};
   } catch (std::exception& e) {
     LOG_ERROR(logger_, "Decryption error: " << e.what());
@@ -104,8 +109,8 @@ std::optional<std::string> SecretsManagerEnc::encrypt(const std::string& data) {
   }
   try {
     // AES_CBC is created on each call fir thread safety
-    auto aes = AES_CBC(*key_params_);
-    auto cipher_text = aes.encrypt(data);
+    auto aes = getEncryptionMode();
+    auto cipher_text = aes->encrypt(data);
     return std::optional<std::string>{base64Enc(cipher_text)};
   } catch (std::exception& e) {
     LOG_ERROR(logger_, "Encryption error: " << e.what());

--- a/libs/secrets/test/secrets_manager_test.cpp
+++ b/libs/secrets/test/secrets_manager_test.cpp
@@ -123,6 +123,29 @@ TEST(SecretsManager, Internals_GCM) {
   ASSERT_EQ(plain_text, input);
 }
 
+TEST(SecretsManager, Internals_GCM_With_TagLength) {
+  const std::string input{"I would be encrypted"};
+  const std::string encrypted{"s54vIO4fPg0MVvmihQtpTtO2alQXHwwTVWkFbEH93TQ5Kg0E\n"};
+
+  auto secret_data = getSecretData_GCM();
+  concord::secretsmanager::KeyParams key_params(secret_data.key, secret_data.iv);
+
+  // Encrypt
+  concord::secretsmanager::AES_GCM e(key_params, "{\"TAG_LENGTH_BITS\" : 128}");
+  auto cipher_text = e.encrypt(input);
+  auto cipher_text_encoded = base64Enc(cipher_text);
+  ASSERT_EQ(cipher_text_encoded, encrypted);
+
+  // Decrypt
+  auto dec = base64Dec(cipher_text_encoded);
+
+  std::cout << std::endl;
+  ASSERT_EQ(dec, cipher_text);
+
+  auto plain_text = e.decrypt(cipher_text);
+  ASSERT_EQ(plain_text, input);
+}
+
 TEST(SecretsManager, Base64) {
   const std::vector<uint8_t> cipher_text{
       0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};


### PR DESCRIPTION
* **Problem Overview**  
  Currently Concord supports AES_CBC as mode of encryption, which is vulnerable to oracle padding attack. More information can be found here(https://en.wikipedia.org/wiki/Padding_oracle_attack).
So added AES_GCM mode for all encryption/decryption functionalities. GCM is more secured and stable.
* **Testing Done**  
  Unit testing is done and added in the PR.
