### PR TITLE
Fix leak caused by a non-deleted original message

### DIFF
--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -177,7 +177,7 @@ void ReplicaImp::registerMsgHandlers() {
 template <typename T>
 void ReplicaImp::messageHandler(std::unique_ptr<MessageBase> msg) {
   auto trueTypeObj = std::make_unique<T>(msg.get());
-  delete msg.release();
+  msg.reset();
   if (isCollectingState()) {
     // Extract only required information and handover to ST thread
     if (validateMessage(trueTypeObj.get())) {

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1299,8 +1299,8 @@ void PreProcessor::msgProcessingLoop() {
         }
         default:
           LOG_ERROR(logger(), "Unknown message" << KVLOG(msg->type()));
-          delete msg;
       }
+      delete msg;
     }
   }
 }


### PR DESCRIPTION
* **Problem Overview**  
In order to call the correct overloaded 'validate' function, incoming PreProcessor messages should be created through 'new' or 'make_unique' operators, which should be followed by the removal of the original message. The removal was missing and this caused a memory leak.
* **Testing Done**  
Tested through Maestro 5 days blockchain run.
