### PR TITLE
remove separate asio lib usage

### DIFF
--- a/client/client_pool/include/client/client_pool/client_pool_timer.hpp
+++ b/client/client_pool/include/client/client_pool/client_pool_timer.hpp
@@ -16,8 +16,8 @@
 #include <chrono>
 #include <future>
 
-#include <asio/steady_timer.hpp>
-#include <asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "log/logger.hpp"
 
@@ -86,8 +86,8 @@ class Timer {
       return;
     }
     client_ = client;
-    auto handler = [this](const asio::error_code& error) {
-      if (error != asio::error::operation_aborted) {
+    auto handler = [this](const boost::system::error_code& error) {
+      if (error != boost::asio::error::operation_aborted) {
         on_timeout_(std::move(client_));
       }
     };
@@ -120,7 +120,7 @@ class Timer {
  private:
   void work() {
     // Add a work guard so that io_context_.run() keeps running even if there is no work item
-    asio::executor_work_guard<asio::io_context::executor_type> work_guard(io_context_.get_executor());
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard(io_context_.get_executor());
     io_context_.run();
   }
 
@@ -130,8 +130,8 @@ class Timer {
 
   const std::chrono::milliseconds timeout_;
   std::function<void(ClientT&&)> on_timeout_;
-  asio::io_context io_context_;
-  asio::steady_timer timer_;
+  boost::asio::io_context io_context_;
+  boost::asio::steady_timer timer_;
   std::chrono::steady_clock::time_point start_timer_;
   logging::Logger logger_;
 };

--- a/communication/src/PlainTcpCommunication.cpp
+++ b/communication/src/PlainTcpCommunication.cpp
@@ -40,7 +40,7 @@
 #include "assertUtils.hpp"
 
 using namespace std;
-using namespace boost::asio;
+using namespace boost::asio::;
 using namespace boost::asio::ip;
 using namespace boost::posix_time;
 

--- a/communication/src/TlsConnectionManager.h
+++ b/communication/src/TlsConnectionManager.h
@@ -9,7 +9,7 @@
 // terms. Your use of these subcomponents is subject to the terms and conditions of the
 // subcomponent's license, as noted in the LICENSE file.
 
-#include <asio.hpp>
+#include <boost/asio.hpp>
 #include <atomic>
 #include <thread>
 
@@ -34,7 +34,7 @@ class ConnectionManager {
   friend class AsyncTlsConnection;
 
  public:
-  ConnectionManager(const TlsTcpConfig &, asio::io_context &);
+  ConnectionManager(const TlsTcpConfig &, boost::asio::io_context &);
 
   //
   // Methods required by ICommunication
@@ -59,8 +59,8 @@ class ConnectionManager {
   // Perform synchronous DNS resolution. This really only works for the listen socket, since after that we want to do a
   // new lookup on every connect operation in case the underlying IP of the DNS address changes.
   //
-  // Throws an asio::system_error if it fails to resolve
-  asio::ip::tcp::endpoint syncResolve();
+  // Throws an boost::system::system_error if it fails to resolve
+  boost::asio::ip::tcp::endpoint syncResolve();
 
   // Starts async dns resolution on a tcp socket.
   //
@@ -72,18 +72,18 @@ class ConnectionManager {
   // Replicas only connect to replicas with smaller node ids.
   // This method is called at startup and also on a periodic timer tick.
   void connect();
-  void connect(NodeNum, const asio::ip::tcp::endpoint &);
+  void connect(NodeNum, const boost::asio::ip::tcp::endpoint &);
 
   // Start a steady_timer in order to trigger needed `connect` operations.
   void startConnectTimer();
 
   // Trigger the asio async_handshake calls.
-  void startServerSSLHandshake(asio::ip::tcp::socket &&);
-  void startClientSSLHandshake(asio::ip::tcp::socket &&socket, NodeNum destination);
+  void startServerSSLHandshake(boost::asio::ip::tcp::socket &&);
+  void startClientSSLHandshake(boost::asio::ip::tcp::socket &&socket, NodeNum destination);
 
   // Callbacks triggered when asio async_handshake completes for an incoming or outgoing connection.
-  void onServerHandshakeComplete(const asio::error_code &ec, size_t accepted_connection_id);
-  void onClientHandshakeComplete(const asio::error_code &ec, NodeNum destination);
+  void onServerHandshakeComplete(const boost::system::error_code &ec, size_t accepted_connection_id);
+  void onClientHandshakeComplete(const boost::system::error_code &ec, NodeNum destination);
 
   // If onServerHandshake completed successfully, this function will get called and add the AsyncTlsConnection to
   // `connections_`.
@@ -128,11 +128,11 @@ class ConnectionManager {
   // progress connections when cert validation completes
   size_t total_accepted_connections_ = 0;
 
-  asio::io_context &io_context_;
-  asio::strand<asio::io_context::executor_type> strand_;
-  asio::ip::tcp::acceptor acceptor_;
-  asio::ip::tcp::resolver resolver_;
-  asio::steady_timer connect_timer_;
+  boost::asio::io_context &io_context_;
+  boost::asio::strand<boost::asio::io_context::executor_type> strand_;
+  boost::asio::ip::tcp::acceptor acceptor_;
+  boost::asio::ip::tcp::resolver resolver_;
+  boost::asio::steady_timer connect_timer_;
 
   // This tracks outstanding attempts at DNS resolution for outgoing connections.
   std::set<NodeNum> resolving_;
@@ -140,7 +140,7 @@ class ConnectionManager {
   // Sockets that are in progress of connecting.
   // When these connections complete, an AsyncTlsConnection will be created and moved into
   // `connected_waiting_for_handshake_`.Each socket have a connection timeout.
-  std::unordered_map<NodeNum, std::pair<asio::ip::tcp::socket, asio::steady_timer>> connecting_;
+  std::unordered_map<NodeNum, std::pair<boost::asio::ip::tcp::socket, boost::asio::steady_timer>> connecting_;
 
   // Connections that are in progress of waiting for a handshake to complete.
   // When the handshake completes these will be moved into `connections_`.

--- a/communication/src/TlsRunner.h
+++ b/communication/src/TlsRunner.h
@@ -9,7 +9,7 @@
 // terms. Your use of these subcomponents is subject to the terms and conditions of the
 // subcomponent's license, as noted in the LICENSE file.
 
-#include <asio.hpp>
+#include <boost/asio.hpp>
 #include <thread>
 
 #include "log/logger.hpp"
@@ -20,7 +20,7 @@
 
 namespace bft::communication::tls {
 
-// The runner creates an `asio::io_context` and a pool of threads to serve that context.
+// The runner creates an `boost::asio::io_context` and a pool of threads to serve that context.
 class Runner {
  public:
   Runner(const TlsTcpConfig& config, const size_t num_threads);
@@ -42,7 +42,7 @@ class Runner {
   mutable std::mutex start_stop_mutex_;
   // A pool of threads from which completion handlers may be invoked.
   std::vector<std::thread> io_threads_;
-  asio::io_context io_context_;
+  boost::asio::io_context io_context_;
   ConnectionManager connectionManager_;
 };
 

--- a/install_deps_release.sh
+++ b/install_deps_release.sh
@@ -250,21 +250,6 @@ install_opentracing_lib() {
 
 }
 
-# ASIO only (without boost). This allows us to upgrade ASIO independently.
-install_asio() {
-    cd ${HOME}
-    wget ${WGET_FLAGS} \
-    https://sourceforge.net/projects/asio/files/asio/1.18.1%20%28Stable%29/asio-1.18.1.tar.bz2 && \
-        tar -xf asio-1.18.1.tar.bz2 && \
-        cd asio-1.18.1 && \
-        ./configure && \
-        make -j$(nproc) && \
-        make install && \
-        cd ${HOME} && \
-        rm -rf asio*
-
-}
-
 # Get the newest openSSL installation (as of 9/2020)
 install_openssl() {
     OPENSSL_VER='1.1.1g'
@@ -451,7 +436,6 @@ install_rocksdb_lib
 install_rapidcheck
 install_minio
 install_opentracing_lib
-install_asio
 install_openssl
 install_grpc
 install_prometheus


### PR DESCRIPTION
This PR removes separate asio installation and usage from concord-bft.
Currently we have upgraded to the recent boost version, so a separate asio lib shouldn’t be used anymore.
Current boost has asio included as well.
