### PR TITLE
Accomodating new fields added got GCM mode

### DIFF
--- a/libs/secrets/secret_data.h
+++ b/libs/secrets/secret_data.h
@@ -26,6 +26,7 @@ struct SecretData {
   uint32_t key_length;          // key size in bytes
   std::string additional_info;  // contains extra information needed
                                 // including error reasons when get API errors out
+  uint32_t tag_length;          // contains tag length in bits for GCM mode
 };
 
 }  // namespace concord::secretsmanager

--- a/libs/secrets/src/aes.cpp
+++ b/libs/secrets/src/aes.cpp
@@ -87,11 +87,7 @@ std::vector<uint8_t> AES_GCM::encrypt(std::string_view input) {
   if (input.empty()) {
     return {};
   }
-  int tagLength = 16;
-  if (!getAdditionalInfo().empty()) {
-    auto j = json::parse(getAdditionalInfo());
-    tagLength = (j["TAG_LENGTH_BITS"].get<int>()) / 8;  // from bits to bytes
-  }
+  int tagLength = static_cast<int>(getTagLengthInBits() / 8);  // cast to int to avoid warning in openssl api's
 
   auto ciphertext = std::make_unique<unsigned char[]>(input.size() + AES_BLOCK_SIZE);
   auto plaintext = std::make_unique<unsigned char[]>(input.size());
@@ -142,11 +138,8 @@ string AES_GCM::decrypt(const vector<uint8_t>& cipher) {
   if (cipher.capacity() == 0) {
     return {};
   }
-  int tagLength = 16;
-  if (!getAdditionalInfo().empty()) {
-    auto j = json::parse(getAdditionalInfo());
-    tagLength = (j["TAG_LENGTH_BITS"].get<int>()) / 8;  // from bits to bytes
-  }
+  int tagLength = static_cast<int>(getTagLengthInBits() / 8);  // cast to int to avoid warning in openssl api's
+
   const unsigned int cipherLength = cipher.size() - tagLength;
   std::vector<uint8_t> cipherText(cipher.begin(), cipher.end() - tagLength);
   std::vector<uint8_t> tag(cipher.begin() + cipherLength, cipher.end());

--- a/libs/secrets/src/aes.h
+++ b/libs/secrets/src/aes.h
@@ -26,22 +26,23 @@ namespace concord::secretsmanager {
 
 class IAesMode {
  public:
-  IAesMode(const KeyParams& params, const std::string& a_info = "") : params_{params}, additional_info(a_info) {}
+  IAesMode(const KeyParams& params, const uint32_t tagLengthBits = 128)
+      : params_{params}, tag_length_in_bits(tagLengthBits) {}
   virtual std::vector<uint8_t> encrypt(std::string_view input) = 0;
   virtual std::string decrypt(const std::vector<uint8_t>& cipher) = 0;
   const KeyParams getKeyParams() { return params_; }
-  const std::string getAdditionalInfo() { return additional_info; }
+  const uint32_t getTagLengthInBits() { return tag_length_in_bits; }
   // Not adding setters as these algo/modes must be set at construction time
   virtual ~IAesMode() = default;
 
  private:
   KeyParams params_;
-  std::string additional_info;
+  uint32_t tag_length_in_bits;
 };
 
 class AES_CBC : public IAesMode {
  public:
-  AES_CBC(const KeyParams& params, const std::string& a_info = "") : IAesMode(params, a_info) {}
+  AES_CBC(const KeyParams& params, const uint32_t tagLengthBits = 128) : IAesMode(params, tagLengthBits) {}
   std::vector<uint8_t> encrypt(std::string_view input) override;
   std::string decrypt(const std::vector<uint8_t>& cipher) override;
   ~AES_CBC() = default;
@@ -49,7 +50,7 @@ class AES_CBC : public IAesMode {
 
 class AES_GCM : public IAesMode {
  public:
-  AES_GCM(const KeyParams& params, const std::string& a_info = "") : IAesMode(params, a_info) {}
+  AES_GCM(const KeyParams& params, const uint32_t tagLengthBits = 128) : IAesMode(params, tagLengthBits) {}
   std::vector<uint8_t> encrypt(std::string_view input) override;
   std::string decrypt(const std::vector<uint8_t>& cipher) override;
   ~AES_GCM() = default;

--- a/libs/secrets/src/secret_retriever.cpp
+++ b/libs/secrets/src/secret_retriever.cpp
@@ -42,8 +42,9 @@ SecretData parseJson(json j) {
     auto iv = j["iv"].get<std::string>();
     auto algorithm = j["algorithm"].get<std::string>();
     auto key_length = j["key_length"].get<uint32_t>();
-
-    return SecretData{key, iv, algorithm, key_length, additional_info};
+    uint32_t tag_length = 128;
+    if (j.contains("tag_length")) tag_length = j["tag_length"].get<uint32_t>();
+    return SecretData{key, iv, algorithm, key_length, additional_info, tag_length};
 
   } catch (const std::exception &e) {
     LOG_ERROR(logger, "Failed to read JSON content '" << additional_info << "'");

--- a/libs/secrets/src/secrets_manager_enc.cpp
+++ b/libs/secrets/src/secrets_manager_enc.cpp
@@ -32,9 +32,9 @@ SecretsManagerEnc::SecretsManagerEnc(const SecretData& secrets)
 }
 std::unique_ptr<IAesMode> SecretsManagerEnc::getAESEncryptionMode() {
   if (initial_secret_data_.algo == "AES/GCM/NoPadding") {
-    return std::make_unique<AES_GCM>(*key_params_, initial_secret_data_.additional_info);
+    return std::make_unique<AES_GCM>(*key_params_, initial_secret_data_.tag_length);
   } else {
-    return std::make_unique<AES_CBC>(*key_params_, initial_secret_data_.additional_info);
+    return std::make_unique<AES_CBC>(*key_params_);
   }
 }
 bool SecretsManagerEnc::encryptFile(std::string_view file_path, const std::string& input) {

--- a/libs/secrets/test/secrets_manager_test.cpp
+++ b/libs/secrets/test/secrets_manager_test.cpp
@@ -58,7 +58,7 @@ SecretData getSecretData_GCM() {
   ret.key = "71df1518bb2330201985cfddbf3fb1f30c6f63b0a953b1ce633e48387b5093eb";
   ret.iv = "3d75354384953730b9701019f5d7a2e0";
   ret.key_length = 256;
-
+  ret.tag_length = 128;
   return ret;
 }
 

--- a/libs/secrets/test/secrets_manager_test.cpp
+++ b/libs/secrets/test/secrets_manager_test.cpp
@@ -131,7 +131,7 @@ TEST(SecretsManager, Internals_GCM_With_TagLength) {
   concord::secretsmanager::KeyParams key_params(secret_data.key, secret_data.iv);
 
   // Encrypt
-  concord::secretsmanager::AES_GCM e(key_params, "{\"TAG_LENGTH_BITS\" : 128}");
+  concord::secretsmanager::AES_GCM e(key_params, 128);
   auto cipher_text = e.encrypt(input);
   auto cipher_text_encoded = base64Enc(cipher_text);
   ASSERT_EQ(cipher_text_encoded, encrypted);


### PR DESCRIPTION
Problem Overview
Currently Concord supports AES_CBC as mode of encryption, which is vulnerable to oracle padding attack. More information can be found here(https://en.wikipedia.org/wiki/Padding_oracle_attack).
So added AES_GCM mode for all encryption/decryption functionalities. GCM is more secured and stable.

Previous PR([https://github.com/vmware/concord-bft/pull/2904]) is merged in which tag length was part of additional info. But after collective discussion from agent DA and concord, it was decided that new key value pair (tag_length : <val_in_bits > will be added. 
So, raising this PR for concord to handle this new parameter.

Testing Done
Unit testing is done and added in the PR.
A private build (IMAGE_TAG: 0.0.1.0.1597) is created and tested. Able to validate behaviour between agent and concord for GCM mode.. But transactions can't be done without DA changes.