### PR TITLE
Fix the PreProcessor crash on graceful shutdown

### DIFF
--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -31,6 +31,8 @@ class ReplicasInfo;
 class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
 {
  public:
+  virtual ~InternalReplicaApi() = default;
+
   virtual const ReplicasInfo& getReplicasInfo() const = 0;
   virtual bool isValidClient(NodeIdType clientId) const = 0;
   virtual bool isIdOfReplica(NodeIdType id) const = 0;
@@ -55,15 +57,11 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual std::pair<PrePrepareMsg*, bool> buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) {
     return std::make_pair(nullptr, false);
   }
-
+  virtual void stop() = 0;
   virtual IncomingMsgsStorage& getIncomingMsgsStorage() = 0;
   virtual concord::util::SimpleThreadPool& getInternalThreadPool() = 0;
-
   virtual bool isCollectingState() const = 0;
-
   virtual const ReplicaConfig& getReplicaConfig() const = 0;
-
-  virtual ~InternalReplicaApi() = default;
 };
 
 }  // namespace impl

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -315,21 +315,6 @@ bool PreProcessor::validateMessage(MessageBase *msg) const {
   }
 }
 
-void PreProcessor::stop() {
-  if (!msgLoopDone_) {
-    msgLoopDone_ = true;
-    msgLoopSignal_.notify_all();
-    cancelTimers();
-  }
-
-  if (!threadPool_.isStopped()) {
-    threadPool_.stop();
-    if (msgLoopThread_.joinable()) {
-      msgLoopThread_.join();
-    }
-  }
-}
-
 PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                            shared_ptr<IncomingMsgsStorage> &incomingMsgsStorage,
                            shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
@@ -424,18 +409,33 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   addTimers();
 }
 
+void PreProcessor::stop() {
+  LOG_DEBUG(logger(), "Going to stop PreProcessor");
+  if (!msgLoopDone_) {
+    {
+      std::unique_lock<std::mutex> l(msgLock_);
+      msgLoopDone_ = true;
+    }
+    msgLoopSignal_.notify_all();
+    cancelTimers();
+  }
+  if (!threadPool_.isStopped()) {
+    threadPool_.stop();
+    if (msgLoopThread_.joinable()) {
+      msgLoopThread_.join();
+    }
+  }
+  LOG_DEBUG(logger(), "PreProcessor stopped");
+}
+
 PreProcessor::~PreProcessor() {
-  LOG_TRACE(logger(), "~PreProcessor start");
-
-  stop();
-
+  LOG_DEBUG(logger(), "~PreProcessor start");
   if (!memoryPoolEnabled_) {
     for (const auto &result : preProcessResultBuffers_) {
       delete[] result->buffer;
     }
   }
-  while (msgs_.read_available()) delete msgs_.front();
-  LOG_TRACE(logger(), "~PreProcessor done");
+  LOG_DEBUG(logger(), "~PreProcessor done");
 }
 
 void PreProcessor::addTimers() {
@@ -1183,13 +1183,17 @@ void PreProcessor::onMessage<PreProcessBatchReplyMsg>(PreProcessBatchReplyMsgUni
 
 template <typename T>
 void PreProcessor::messageHandler(unique_ptr<MessageBase> msg) {
-  if (!msgs_.write_available()) {
-    LOG_WARN(logger(), "PreProcessor queue is full, returning message");
-    incomingMsgsStorage_->pushExternalMsg(std::move(msg));
+  if (!msgLoopDone_) {
+    if (msgs_.write_available()) {
+      msgs_.push(msg.release());
+      msgLoopSignal_.notify_one();
+    } else {
+      LOG_WARN(logger(), "PreProcessor queue is full, returning message");
+      incomingMsgsStorage_->pushExternalMsg(std::move(msg));
+    }
     return;
   }
-  msgs_.push(msg.release());
-  msgLoopSignal_.notify_one();
+  LOG_DEBUG(logger(), "Ignore incoming message - the message loop has been stopped");
 }
 
 void PreProcessor::msgProcessingLoop() {
@@ -1267,7 +1271,11 @@ void PreProcessor::msgProcessingLoop() {
           LOG_ERROR(logger(), "Unknown message" << KVLOG(msg->type()));
       }
       delete msg;
-    }
+    }  // while (!msgLoopDone_ && msgs_.read_available())
+  }    // while (!msgLoopDone_)
+  while (msgs_.read_available()) {
+    LOG_DEBUG(logger(), "Cleaning non-processed incoming messages");
+    delete msgs_.front();
   }
 }
 


### PR DESCRIPTION
* **Problem Overview**  
On a graceful shutdown, replica crashes in the PreProcessor destructor with a core dump.
1. Ignore incoming messages that arrive at the PreProcessor when the message processing loop has been stopped.
2. Delete non-processed messages from the PreProcessor queue in the context of the dispatcher thread.
* **Testing Done**  
Tested on a reserved system + 5 days Maestro regression run.
