### PR TITLE
Make state transfer use the actual number of reserved pages

### DIFF
--- a/bftengine/include/bftengine/ReservedPagesClient.hpp
+++ b/bftengine/include/bftengine/ReservedPagesClient.hpp
@@ -77,6 +77,7 @@ class ResPagesClient : public ReservedPagesClientBase, public IReservedPages {
   }
   /**
    * Should be called at initialization if number of pages is not known at compile time
+   * This function must be called only from the ReplicaForStateTransfer constructor before stateTransfer->init().
    */
   static void setNumResPages(const uint32_t numPages) {
     Registry& reg = registry();

--- a/bftengine/src/bcstatetransfer/BCStateTran.hpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.hpp
@@ -273,10 +273,10 @@ class BCStateTran : public IStateTransfer {
   ///////////////////////////////////////////////////////////////////////////
   const Config config_;
   const set<uint16_t> replicas_;
-  const uint32_t maxVBlockSize_;
-  const uint32_t maxItemSize_;
-  const uint32_t maxNumOfChunksInAppBlock_;
-  const uint32_t maxNumOfChunksInVBlock_;
+  uint32_t maxVBlockSize_{0};
+  uint32_t maxItemSize_{0};
+  uint32_t maxNumOfChunksInAppBlock_{0};
+  uint32_t maxNumOfChunksInVBlock_{0};
 
   uint64_t maxNumOfStoredCheckpoints_;
   std::atomic_uint64_t numberOfReservedPages_;


### PR DESCRIPTION
Instead of maxNumOfReservedPages configuration, state transfer uses the actual number of reserved pages to make
maxNumOfReservedPages config more stable.

* **Problem Overview**  
  maxNumOfReservedPages was used by ST to calculate max Vblock size and ST item size, and allocations were done accordingly. With that approach, maxNumOfReservedPages had to be kept as closed as possible to the actual number of reserved pages. But the number of reserved pages is affected by many configurations, so it is not a stable permanent number.
  With this PR, ST now uses the actual registered reserved pages instead, and that allows us setting the maxNumOfReservedPages to be higher and as a result more stable.

* **Testing Done**  
  Apollo
