### PR TITLE
Memory management raw pointers convertions

### DIFF
--- a/bftengine/src/bcstatetransfer/BCStateTran.cpp
+++ b/bftengine/src/bcstatetransfer/BCStateTran.cpp
@@ -378,7 +378,7 @@ void BCStateTran::initImpl(uint64_t maxNumOfRequiredStoredCheckpoints,
 #endif
 
     LOG_INFO(logger_,
-             "Init BCStateTran object789:" << KVLOG(
+             "Init BCStateTran object:" << KVLOG(
                  maxNumOfStoredCheckpoints_, numberOfReservedPages_, config_.sizeOfReservedPage));
 
     if (psd_->initialized()) {

--- a/bftengine/src/bftengine/InternalReplicaApi.hpp
+++ b/bftengine/src/bftengine/InternalReplicaApi.hpp
@@ -17,6 +17,9 @@
 #include "PrimitiveTypes.hpp"
 #include "IncomingMsgsStorage.hpp"
 
+using PrePrepareMsgUPtr = std::unique_ptr<PrePrepareMsg>;
+using PrePrepareMsgCreationResult = std::pair<PrePrepareMsgUPtr, bool>;
+
 class IThresholdVerifier;
 namespace concord::util {
 class SimpleThreadPool;
@@ -44,15 +47,15 @@ class InternalReplicaApi  // TODO(GG): rename + clean + split to several classes
   virtual SeqNum getPrimaryLastUsedSeqNum() const = 0;
   virtual uint64_t getRequestsInQueue() const = 0;
   virtual SeqNum getLastExecutedSeqNum() const = 0;
-  virtual std::pair<PrePrepareMsg*, bool> buildPrePrepareMessage() { return std::make_pair(nullptr, false); }
+  virtual PrePrepareMsgCreationResult buildPrePrepareMessage() { return std::make_pair(nullptr, false); }
   virtual bool tryToSendPrePrepareMsg(bool batchingLogic) { return false; }
   // register a components' stop function to be run at the beginning of ReplicaImp's stop function.
   // all components dependent on ReplicaImp running (and only those components) must register a stop func
   virtual void registerStopCallback(std::function<void(void)> stopCallback) = 0;
-  virtual std::pair<PrePrepareMsg*, bool> buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
+  virtual PrePrepareMsgCreationResult buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) {
     return std::make_pair(nullptr, false);
   }
-  virtual std::pair<PrePrepareMsg*, bool> buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) {
+  virtual PrePrepareMsgCreationResult buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) {
     return std::make_pair(nullptr, false);
   }
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -114,8 +114,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   SeqNum maxSeqNumTransferredFromPrevViews = 0;
 
   // requests queue (used by the primary)
-  std::queue<ClientRequestMsg*> requestsQueueOfPrimary;  // only used by the primary
-  size_t primaryCombinedReqSize = 0;                     // only used by the primary
+  std::queue<std::unique_ptr<ClientRequestMsg>> requestsQueueOfPrimary;  // only used by the primary
+  size_t primaryCombinedReqSize = 0;                                     // only used by the primary
 
   std::map<uint64_t, std::pair<Time, ClientRequestMsg*>>
       requestsOfNonPrimary;  // used to retransmit client requests by a non primary replica
@@ -146,7 +146,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   // fetching of requests from the queue happens when we are getting to it as part of finishExecutePrePrepareMsg which
   // can happen only in main thread since its being called when FinishPrePrepareExecutionInternalMsg fetched m the
   // internal msgs queue.
-  std::deque<ClientRequestMsg*> deferredRORequests_;
+  std::deque<std::unique_ptr<ClientRequestMsg>> deferredRORequests_;
   // if we have active executions and the main thread fetches request we will defer the message and store it in this
   // queue, we will handle these requests after the post execution finishes
   // This queue should not be thread safe because we add requests only in several onMessages which can be
@@ -502,7 +502,7 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
 
   void sendPartialProof(SeqNumInfo&);
 
-  ClientRequestMsg* addRequestToPrePrepareMessage(ClientRequestMsg*& nextRequest,
+  ClientRequestMsg* addRequestToPrePrepareMessage(ClientRequestMsg* nextRequest,
                                                   PrePrepareMsg& prePrepareMsg,
                                                   uint32_t maxStorageForRequests);
 

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -396,10 +396,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   SeqNum getPrimaryLastUsedSeqNum() const override { return primaryLastUsedSeqNum; }
   uint64_t getRequestsInQueue() const override { return requestsQueueOfPrimary.size(); }
   SeqNum getLastExecutedSeqNum() const override { return lastExecutedSeqNum; }
-  std::pair<PrePrepareMsg*, bool> buildPrePrepareMessage() override;
+  PrePrepareMsgCreationResult buildPrePrepareMessage() override;
   bool tryToSendPrePrepareMsg(bool batchingLogic = false) override;
-  std::pair<PrePrepareMsg*, bool> buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) override;
-  std::pair<PrePrepareMsg*, bool> buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) override;
+  PrePrepareMsgCreationResult buildPrePrepareMsgBatchByRequestsNum(uint32_t requiredRequestsNum) override;
+  PrePrepareMsgCreationResult buildPrePrepareMsgBatchByOverallSize(uint32_t requiredBatchSizeInBytes) override;
   void handleDeferredRequests();
   void onExecutionFinish();
   void finalizeExecution();
@@ -481,10 +481,10 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   void onInternalMsg(InternalMessage&& msg);
   void onInternalMsg(GetStatus& msg) const;
 
-  std::pair<PrePrepareMsg*, bool> finishAddingRequestsToPrePrepareMsg(PrePrepareMsg*& prePrepareMsg,
-                                                                      uint32_t maxSpaceForReqs,
-                                                                      uint32_t requiredRequestsSize,
-                                                                      uint32_t requiredRequestsNum);
+  PrePrepareMsgCreationResult finishAddingRequestsToPrePrepareMsg(PrePrepareMsgUPtr prePrepareMsg,
+                                                                  uint32_t maxSpaceForReqs,
+                                                                  uint32_t requiredRequestsSize,
+                                                                  uint32_t requiredRequestsNum);
 
   bool handledByRetransmissionsManager(const ReplicaId sourceReplica,
                                        const ReplicaId destReplica,
@@ -506,13 +506,13 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
                                                   PrePrepareMsg& prePrepareMsg,
                                                   uint32_t maxStorageForRequests);
 
-  PrePrepareMsg* createPrePrepareMessage();
+  PrePrepareMsgUPtr createPrePrepareMessage();
 
-  std::pair<PrePrepareMsg*, bool> buildPrePrepareMessageByRequestsNum(uint32_t requiredRequestsNum);
+  PrePrepareMsgCreationResult buildPrePrepareMessageByRequestsNum(uint32_t requiredRequestsNum);
 
-  std::pair<PrePrepareMsg*, bool> buildPrePrepareMessageByBatchSize(uint32_t requiredBatchSizeInBytes);
+  PrePrepareMsgCreationResult buildPrePrepareMessageByBatchSize(uint32_t requiredBatchSizeInBytes);
 
-  void validatePrePrepareMsg(std::unique_ptr<PrePrepareMsg> ppm);
+  void validatePrePrepareMsg(PrePrepareMsgUPtr ppm);
 
   template <typename MSG>
   void asyncValidateMessage(std::unique_ptr<MSG>);

--- a/bftengine/src/bftengine/ReplicaImp.hpp
+++ b/bftengine/src/bftengine/ReplicaImp.hpp
@@ -627,8 +627,8 @@ class ReplicaImp : public InternalReplicaApi, public ReplicaForStateTransfer {
   concord::util::CallbackRegistry<> stopCallbacks_;
 
   void addTimers();
-  void startConsensusProcess(PrePrepareMsg* pp, bool isCreatedEarlier);
-  void startConsensusProcess(PrePrepareMsg* pp);
+  void startConsensusProcess(PrePrepareMsgUPtr pp, bool isCreatedEarlier);
+  void startConsensusProcess(PrePrepareMsgUPtr pp);
   /**
    * Updates both seqNumInfo and slow_path metric
    * @param seqNumInfo

--- a/bftengine/src/bftengine/RequestsBatchingLogic.cpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.cpp
@@ -57,9 +57,9 @@ void RequestsBatchingLogic::onBatchFlushTimer(Timers::Handle) {
   }
 }
 
-std::pair<PrePrepareMsg *, bool> RequestsBatchingLogic::batchRequestsSelfAdjustedPolicy(SeqNum primaryLastUsedSeqNum,
-                                                                                        uint64_t requestsInQueue,
-                                                                                        SeqNum lastExecutedSeqNum) {
+PrePrepareMsgCreationResult RequestsBatchingLogic::batchRequestsSelfAdjustedPolicy(SeqNum primaryLastUsedSeqNum,
+                                                                                   uint64_t requestsInQueue,
+                                                                                   SeqNum lastExecutedSeqNum) {
   if (requestsInQueue > maxNumberOfPendingRequestsInRecentHistory_)
     maxNumberOfPendingRequestsInRecentHistory_ = requestsInQueue;
 
@@ -111,11 +111,11 @@ void RequestsBatchingLogic::adjustPreprepareSize() {
   LOG_INFO(GL, "increasing maxBatchSize to:" << maxNumOfRequestsInBatch_);
 }
 
-std::pair<PrePrepareMsg *, bool> RequestsBatchingLogic::batchRequests() {
+PrePrepareMsgCreationResult RequestsBatchingLogic::batchRequests() {
   const auto requestsInQueue = replica_.getRequestsInQueue();
   if (requestsInQueue == 0) return std::make_pair(nullptr, false);
 
-  std::pair<PrePrepareMsg *, bool> prePrepareMsgWithResult{nullptr, false};
+  PrePrepareMsgCreationResult prePrepareMsgWithResult{nullptr, false};
   switch (batchingPolicy_) {
     case BATCH_SELF_ADJUSTED:
       prePrepareMsgWithResult = batchRequestsSelfAdjustedPolicy(

--- a/bftengine/src/bftengine/RequestsBatchingLogic.hpp
+++ b/bftengine/src/bftengine/RequestsBatchingLogic.hpp
@@ -33,13 +33,13 @@ class RequestsBatchingLogic {
   uint32_t getMaxNumberOfPendingRequestsInRecentHistory() const { return maxNumberOfPendingRequestsInRecentHistory_; }
   uint32_t getBatchingFactor() const { return batchingFactor_; }
 
-  std::pair<PrePrepareMsg *, bool> batchRequests();
+  PrePrepareMsgCreationResult batchRequests();
 
  private:
   void onBatchFlushTimer(concordUtil::Timers::Handle timer);
-  std::pair<PrePrepareMsg *, bool> batchRequestsSelfAdjustedPolicy(SeqNum primaryLastUsedSeqNum,
-                                                                   uint64_t requestsInQueue,
-                                                                   SeqNum lastExecutedSeqNum);
+  PrePrepareMsgCreationResult batchRequestsSelfAdjustedPolicy(SeqNum primaryLastUsedSeqNum,
+                                                              uint64_t requestsInQueue,
+                                                              SeqNum lastExecutedSeqNum);
   void adjustPreprepareSize();
 
  private:

--- a/bftengine/src/bftengine/SeqNumInfo.hpp
+++ b/bftengine/src/bftengine/SeqNumInfo.hpp
@@ -38,10 +38,10 @@ class SeqNumInfo {
   void resetCommitSignatures(CommitPath cPath);
   void resetPrepareSignatures();
   void resetAndFree();  // TODO(GG): name
-  void getAndReset(PrePrepareMsg*& outPrePrepare, PrepareFullMsg*& outCombinedValidSignatureMsg);
+  std::pair<PrePrepareMsg*, PrepareFullMsg*> getAndReset();
 
-  bool addMsg(PrePrepareMsg* m, bool directAdd = false, bool isTimeCorrect = true);
-  bool addSelfMsg(PrePrepareMsg* m, bool directAdd = false);
+  bool addMsg(PrePrepareMsgUPtr m, bool directAdd = false, bool isTimeCorrect = true);
+  bool addSelfMsg(PrePrepareMsgUPtr m, bool directAdd = false);
 
   bool addMsg(PreparePartialMsg* m);
   bool addSelfMsg(PreparePartialMsg* m, bool directAdd = false);
@@ -243,7 +243,7 @@ class SeqNumInfo {
 
   InternalReplicaApi* replica = nullptr;
 
-  PrePrepareMsg* prePrepareMsg;
+  PrePrepareMsgUPtr prePrepareMsg;
 
   // Slow path
   CollectorOfThresholdSignatures<PreparePartialMsg, PrepareFullMsg, ExFuncForPrepareCollector>* prepareSigCollector;

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -1609,7 +1609,7 @@ class SkvbcReconfigurationTest(ApolloTest):
         for r in bft_network.all_replicas():
             nb_fast_path = await bft_network.get_metric(r, bft_network, "Counters", "totalFastPaths")
             self.assertGreater(nb_fast_path, 0)
-    
+
     @with_trio
     @with_bft_network(start_replica_cmd, bft_configs=[BFTConfig(n=4, f=1, c=0)], publish_master_keys=True)
     async def test_add_nodes_with_failures(self, bft_network):


### PR DESCRIPTION
* **Problem Overview**  
Few raw pointers to smart pointers code refactoring commits.

1. ReplicaAsksToLeaveViewMsg,startConsensusProcessConvert, createPrePrepareMessage - convert  raw pointers to smart
2. Convert PrePrepareMsg to smart pointer
3. Convert raw pointers to smart in ReplicaImp::onMessage

* **Testing Done**  
Have not added new tests, we did some heaptrack tests, and masestro tests to check for leaks and stability.
