### PR TITLE
Introduce new preprocessor memory pool and with retries

### DIFF
--- a/bftengine/include/bftengine/IRequestHandler.hpp
+++ b/bftengine/include/bftengine/IRequestHandler.hpp
@@ -53,6 +53,7 @@ class IRequestsHandler {
     uint16_t reqIndexInClientBatch = 0;
     uint32_t outExecutionStatus = 1;  // UNKNOWN
     uint32_t outActualReplySize = 0;
+    uint32_t outRequiredReplySize = 0;  // In case of a failure e.g OperationResult::EXEC_DATA_TOO_LARGE
     uint32_t outReplicaSpecificInfoSize = 0;
     uint64_t blockId = 0;
   };

--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -261,10 +261,10 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
   CONFIG_PARAM(enableEventGroups, bool, false, "A flag to specify whether event groups are enabled or not.");
 
-  CONFIG_PARAM(enablePreProcessorMemoryPool,
-               bool,
-               true,
-               "A flag to specify whether to use a memory pool in PreProcessor or not");
+  CONFIG_PARAM(preProcessorMemoryPoolMode,
+               uint32_t,
+               1,
+               "0: do not use a memory pool in PreProcessor, 1: use multi size buffer pool, 2: use raw memory pool");
 
   CONFIG_PARAM(diagnosticsServerPort,
                int,
@@ -412,7 +412,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, config_params_);
     serialize(outStream, enableMultiplexChannel);
     serialize(outStream, enableEventGroups);
-    serialize(outStream, enablePreProcessorMemoryPool);
+    serialize(outStream, preProcessorMemoryPoolMode);
     serialize(outStream, diagnosticsServerPort);
     serialize(outStream, useUnifiedCertificates);
     serialize(outStream, kvBlockchainVersion);
@@ -512,7 +512,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, config_params_);
     deserialize(inStream, enableMultiplexChannel);
     deserialize(inStream, enableEventGroups);
-    deserialize(inStream, enablePreProcessorMemoryPool);
+    deserialize(inStream, preProcessorMemoryPoolMode);
     deserialize(inStream, diagnosticsServerPort);
     deserialize(inStream, useUnifiedCertificates);
     deserialize(inStream, kvBlockchainVersion);
@@ -609,7 +609,7 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.enableMultiplexChannel,
               rc.enableEventGroups,
               rc.operatorEnabled_,
-              rc.enablePreProcessorMemoryPool,
+              rc.preProcessorMemoryPoolMode,
               rc.diagnosticsServerPort,
               rc.useUnifiedCertificates,
               rc.kvBlockchainVersion,

--- a/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
+++ b/bftengine/src/bftengine/IncomingMsgsStorageImp.hpp
@@ -99,15 +99,13 @@ class IncomingMsgsStorageImp : public IncomingMsgsStorage {
     Recorders() {
       auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
       const auto component = "incomingMsgsStorageImp";
-      if (!registrar.perf.isRegisteredComponent(component)) {
-        registrar.perf.registerComponent(component,
-                                         {external_queue_len_at_swap,
-                                          internal_queue_len_at_swap,
-                                          evaluate_timers,
-                                          take_lock,
-                                          wait_for_cv,
-                                          dropped_msgs_in_a_row});
-      }
+      registrar.perf.registerComponent(component,
+                                       {external_queue_len_at_swap,
+                                        internal_queue_len_at_swap,
+                                        evaluate_timers,
+                                        take_lock,
+                                        wait_for_cv,
+                                        dropped_msgs_in_a_row});
     }
     DEFINE_SHARED_RECORDER(external_queue_len_at_swap, 1, 10000, 3, concord::diagnostics::Unit::COUNT);
     DEFINE_SHARED_RECORDER(internal_queue_len_at_swap, 1, 10000, 3, concord::diagnostics::Unit::COUNT);

--- a/bftengine/src/bftengine/SimpleClientImp.cpp
+++ b/bftengine/src/bftengine/SimpleClientImp.cpp
@@ -370,8 +370,10 @@ OperationResult SimpleClientImp::sendRequest(uint8_t flags,
     if (correctReply->replyLength() <= lenOfReplyBuffer) {
       memcpy(replyBuffer, correctReply->replyBuf(), correctReply->replyLength());
       actualReplyLength = correctReply->replyLength();
-    } else
+    } else {
+      LOG_ERROR(logger_, "Insufficient buffer size!" << KVLOG(correctReply->replyLength(), lenOfReplyBuffer));
       res = OperationResult::EXEC_DATA_TOO_LARGE;
+    }
     reset();
     return res;
   } else if (requestTimedOut) {

--- a/bftengine/src/preprocessor/CMakeLists.txt
+++ b/bftengine/src/preprocessor/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(yaml-cpp ${YAML_CPP_VERSION} REQUIRED)
 
 set(preprocessor_source_files
     PreProcessor.cpp
@@ -21,14 +22,11 @@ get_property(util_include GLOBAL PROPERTY UTIL_INCLUDE_DIR)
 get_property(kvbc_include GLOBAL PROPERTY KVBC_INCLUDE_DIR)
 target_include_directories(preprocessor PUBLIC ${perf_include} ${util_include} ${kvbc_include})
 
-target_link_libraries(preprocessor PUBLIC diagnostics)
-
 if(BUILD_SLOWDOWN)
     target_compile_definitions(preprocessor PUBLIC USE_SLOWDOWN)
 endif()
 
-target_link_libraries(preprocessor PUBLIC util)
-target_link_libraries(preprocessor PUBLIC bftcommunication)
+target_link_libraries(preprocessor PUBLIC diagnostics util bftcommunication yaml-cpp)
 
 if (BUILD_TESTING)
     add_subdirectory(tests)

--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -317,6 +317,16 @@ bool PreProcessor::validateMessage(MessageBase *msg) const {
   }
 }
 
+bool PreProcessor::validateSubpoolsConfig() {
+  for (const auto &spConfig : subpoolsConfig_) {
+    if ((spConfig.bufferSize == 0) || (spConfig.bufferSize > kMaxSubpoolBuffersize_)) {
+      LOG_ERROR(logger(), "Invalid configuration:" << KVLOG(spConfig.bufferSize, kMaxSubpoolBuffersize_));
+      return false;
+    }
+  }
+  return true;
+}
+
 PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                            shared_ptr<IncomingMsgsStorage> &incomingMsgsStorage,
                            shared_ptr<MsgHandlersRegistrator> &msgHandlersRegistrator,
@@ -331,12 +341,50 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       myReplica_(myReplica),
       myReplicaId_(myReplica.getReplicaConfig().replicaId),
       maxExternalMsgSize_(myReplica.getReplicaConfig().maxExternalMessageSize),
-      maxPreExecResultSize_(maxExternalMsgSize_ - sizeof(uint64_t)),
+      responseSizeInternalOverhead_{/* for conflict detection BlockId */ sizeof(uint64_t)},
       numOfReplicas_(myReplica.getReplicaConfig().numReplicas + myReplica.getReplicaConfig().numRoReplicas),
       numOfClientProxies_(myReplica.getReplicaConfig().numOfClientProxies),
       clientBatchingEnabled_(myReplica.getReplicaConfig().clientBatchingEnabled),
       threadPool_("PreProcessor::threadPool"),
-      memoryPool_(maxExternalMsgSize_, timers),
+      timers_{timers},
+      // TODO - this is a temporary in-place configuration - should be replaced with a future task to take it from
+      // replica config
+      subpoolsConfig_{
+          {1 << 16, 0, 1400},  // 64KB
+          {1 << 17, 0, 1400},  // 128KB
+          {1 << 18, 0, 1400},  // 256KB
+          {1 << 19, 0, 1400},  // 512KB
+          {1 << 20, 0, 1400},  // 1MB
+          {1 << 21, 0, 1400},  // 2MB
+          {1 << 22, 0, 700},   // 4MB
+          {1 << 23, 0, 700},   // 8MB
+          {1 << 24, 0, 80},    // 16MB
+          {1 << 25, 0, 80},    // 32MB
+      },
+      // TODO - this is a temporary in-place configuration - should be replaced with a future task to take it from
+      // replica config
+      bufferPool_{myReplica_.getReplicaConfig().enablePreProcessorMemoryPool
+                      ? std::make_unique<concordUtil::MultiSizeBufferPool>(
+                            "PreProcessor::memoryPool",
+                            timers_,
+                            subpoolsConfig_,
+                            concordUtil::MultiSizeBufferPool::Config{// maxAllocatedBytes
+                                                                     10ULL * (1 << 30),
+                                                                     // purgeEvaluationFrequency
+                                                                     0,
+                                                                     // statusReportFrequency
+                                                                     60,
+                                                                     // histogramsReportFrequency
+                                                                     60,
+                                                                     // metricsReportFrequency
+                                                                     5,
+                                                                     // enableStatusReportChangesOnly
+                                                                     true,
+                                                                     // subpoolSelectorEvaluationNumRetriesMinThreshold
+                                                                     3,
+                                                                     // subpoolSelectorEvaluationNumRetriesMaxThreshold
+                                                                     10})
+                      : nullptr},
       metricsComponent_{concordMetrics::Component("preProcessor", std::make_shared<concordMetrics::Aggregator>())},
       metricsLastDumpTime_(0),
       metricsDumpIntervalInSec_{myReplica_.getReplicaConfig().metricsDumpIntervalSeconds},
@@ -356,14 +404,18 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
       totalPreProcessingTime_(true),
       launchAsyncJobTimeAvg_(true),
       preExecReqStatusCheckPeriodMilli_(myReplica_.getReplicaConfig().preExecReqStatusCheckTimerMillisec),
-      timers_{timers},
       totalPreExecDurationRecorder_{histograms_.totalPreExecutionDuration},
       launchAsyncPreProcessJobRecorder_{histograms_.launchAsyncPreProcessJob},
-      pm_{pm},
-      memoryPoolEnabled_(myReplica_.getReplicaConfig().enablePreProcessorMemoryPool) {
+      pm_{pm} {
+  // Validate subpoolsConfig_
+  if (!validateSubpoolsConfig()) {
+    string err{
+        "Invalid subpools Configuration! Check buffer sizes, they might be 0 or exceeding maximal supported size!"};
+    LOG_ERROR(logger(), err);
+    throw std::invalid_argument(__PRETTY_FUNCTION__ + err);
+  }
   // register a stop call back for the new preprocessor in order to stop it before replica is destroyed
   myReplica_.registerStopCallback([this]() { this->stop(); });
-
   clientMaxBatchSize_ = clientBatchingEnabled_ ? myReplica.getReplicaConfig().clientBatchingMaxMsgsNbr : 1,
   registerMsgHandlers();
   metricsComponent_.Register();
@@ -372,10 +424,6 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
   for (uint16_t i = 0; i < numOfReqEntries; i++) {
     // Placeholders for all clients including batches
     preProcessResultBuffers_.emplace_back(make_shared<SafeResultBuffer>());
-  }
-  if (memoryPoolEnabled_) {
-    // Initially, allocate a memory for all batches of one client (clientMaxBatchSize_)
-    memoryPool_.allocatePool(clientMaxBatchSize_, numOfReqEntries);
   }
   const uint16_t firstClientId = numOfReplicas_ + numOfClientProxies_;
   for (uint16_t i = 0; i < numOfExternalClients; i++) {
@@ -402,7 +450,8 @@ PreProcessor::PreProcessor(shared_ptr<MsgsCommunicator> &msgsCommunicator,
                                                    firstClientId,
                                                    clientBatchingEnabled_,
                                                    clientMaxBatchSize_,
-                                                   maxPreExecResultSize_,
+                                                   kMaxSubpoolBuffersize_,
+                                                   responseSizeInternalOverhead_,
                                                    preExecReqStatusCheckPeriodMilli_,
                                                    numOfThreads,
                                                    ReplicaConfig::instance().preExecutionResultAuthEnabled));
@@ -432,7 +481,7 @@ void PreProcessor::stop() {
 
 PreProcessor::~PreProcessor() {
   LOG_DEBUG(logger(), "~PreProcessor start");
-  if (!memoryPoolEnabled_) {
+  if (!bufferPool_) {
     for (const auto &result : preProcessResultBuffers_) {
       delete[] result->buffer;
     }
@@ -603,17 +652,18 @@ void PreProcessor::sendRejectPreProcessReplyMsg(NodeIdType clientId,
                                                 uint64_t reqRetryId,
                                                 const string &cid,
                                                 const string &ongoingCid) {
-  auto replyMsg = make_shared<PreProcessReplyMsg>(myReplicaId_,
-                                                  clientId,
-                                                  reqOffsetInBatch,
-                                                  reqSeqNum,
-                                                  reqRetryId,
-                                                  getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch),
-                                                  0,
-                                                  cid,
-                                                  STATUS_REJECT,
-                                                  OperationResult::NOT_READY,
-                                                  myReplica_.getCurrentView());
+  auto replyMsg =
+      make_shared<PreProcessReplyMsg>(myReplicaId_,
+                                      clientId,
+                                      reqOffsetInBatch,
+                                      reqSeqNum,
+                                      reqRetryId,
+                                      getPreProcessResultBufferEntry(clientId, reqSeqNum, reqOffsetInBatch).buffer,
+                                      0,
+                                      cid,
+                                      STATUS_REJECT,
+                                      OperationResult::NOT_READY,
+                                      myReplica_.getCurrentView());
   const auto &batchCid = ongoingReqBatches_[clientId]->getBatchCid();
   LOG_DEBUG(
       logger(),
@@ -1553,7 +1603,7 @@ void PreProcessor::releaseClientPreProcessRequest(const RequestStateSharedPtr &r
     if (!myReplica_.isCurrentPrimary() && (preProcessorMetrics_.preProcInFlyRequestsNum.Get().Get() > 0)) {
       preProcessorMetrics_.preProcInFlyRequestsNum--;
     }
-    if (memoryPoolEnabled_) releasePreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
+    if (bufferPool_) releasePreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
   }
 }
 
@@ -1682,7 +1732,10 @@ uint32_t PreProcessor::getBufferOffset(uint16_t clientId, ReqId reqSeqNum, uint1
   return reqOffset;
 }
 
-const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) {
+SafeResultBuffer &PreProcessor::getPreProcessResultBufferEntry(uint16_t clientId,
+                                                               ReqId reqSeqNum,
+                                                               uint16_t reqOffsetInBatch,
+                                                               uint32_t minBufferSize) {
   // Buffers structure scheme:
   // |first client's first buffer|...|first client's last buffer|......
   // |last client's first buffer|...|last client's last buffer|
@@ -1690,27 +1743,34 @@ const char *PreProcessor::getPreProcessResultBuffer(uint16_t clientId, ReqId req
   // First buffer offset = numOfReplicas_ * batchSize_
   // The number of buffers per client comes from the configuration parameter clientBatchingMaxMsgsNbr.
   const auto bufferOffset = getBufferOffset(clientId, reqSeqNum, reqOffsetInBatch);
-  std::unique_lock lock(preProcessResultBuffers_[bufferOffset]->mutex);
-  if (!preProcessResultBuffers_[bufferOffset]->buffer) {
-    if (memoryPoolEnabled_) {
-      preProcessResultBuffers_[bufferOffset]->buffer = memoryPool_.getChunk();
-      LOG_TRACE(logger(),
-                "Allocate memory from the pool" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
+  auto &resultBuffEntry = preProcessResultBuffers_[bufferOffset];
+  std::unique_lock lock(resultBuffEntry->mutex);
+  if (!resultBuffEntry->buffer) {
+    if (bufferPool_) {
+      std::tie(resultBuffEntry->buffer, resultBuffEntry->size) =
+          (minBufferSize == 0) ? bufferPool_->getBufferBySubpoolSelector()
+                               : bufferPool_->getBufferByMinBufferSize(minBufferSize);
+      LOG_TRACE(
+          logger(),
+          "Allocate memory from the pool" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset, minBufferSize));
     } else {
       preProcessResultBuffers_[bufferOffset]->buffer = new char[maxExternalMsgSize_];
+      resultBuffEntry->size = maxExternalMsgSize_;
       LOG_INFO(logger(), "Allocate raw memory" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
     }
   }
-  return preProcessResultBuffers_[bufferOffset]->buffer;
+  return *resultBuffEntry.get();
 }
 
 void PreProcessor::releasePreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) {
   const auto bufferOffset = getBufferOffset(clientId, reqSeqNum, reqOffsetInBatch);
-  std::unique_lock lock(preProcessResultBuffers_[bufferOffset]->mutex);
-  if (preProcessResultBuffers_[bufferOffset]->buffer) {
-    memoryPool_.returnChunk(preProcessResultBuffers_[bufferOffset]->buffer);
-    preProcessResultBuffers_[bufferOffset]->buffer = nullptr;
-    LOG_TRACE(logger(), "Returned memory to the pool" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
+  auto &resultBuffEntry = preProcessResultBuffers_[bufferOffset];
+  std::unique_lock lock(resultBuffEntry->mutex);
+  if (resultBuffEntry->buffer) {
+    bufferPool_->returnBuffer(resultBuffEntry->buffer);
+    resultBuffEntry->buffer = nullptr;
+    resultBuffEntry->size = 0;
+    LOG_TRACE(logger(), "Returned a buffer to the pool" << KVLOG(clientId, reqSeqNum, reqOffsetInBatch, bufferOffset));
   }
 }
 
@@ -1772,31 +1832,98 @@ OperationResult PreProcessor::launchReqPreProcessing(const string &batchCid,
                                << GlobalData::current_block_id << "] delta [" << GlobalData::block_delta << "]");
     GlobalData::increment_step = true;
   }
-  auto preProcessResultBuffer = (char *)getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
-  IRequestsHandler::ExecutionRequest request = bftEngine::IRequestsHandler::ExecutionRequest{
-      clientId,
-      reqSeqNum,
-      reqCid,
-      PRE_PROCESS_FLAG,
-      preProcessReqMsg->requestLength(),
-      preProcessReqMsg->requestBuf(),
-      std::string(preProcessReqMsg->requestSignature(), preProcessReqMsg->requestSignatureLength()),
-      maxPreExecResultSize_,
-      preProcessResultBuffer,
-      reqSeqNum,
-      reqOffsetInBatch,
-      preProcessReqMsg->result()};
-  requestsHandler_.preExecute(request, std::nullopt, reqCid, span);
-  auto preProcessResult = static_cast<OperationResult>(request.outExecutionStatus);
-  resultLen = request.outActualReplySize;
-  if (preProcessResult != OperationResult::SUCCESS) {
+  auto resultBufferEntry = std::ref(getPreProcessResultBufferEntry(clientId, reqSeqNum, reqOffsetInBatch));
+  OperationResult preProcessResult{OperationResult::UNKNOWN};
+  IRequestsHandler::ExecutionRequest request;
+
+  // Try to send the request to execution twice - 1st time with default size. If it fails (e.g buffer size is
+  // insufficient), send with a buffer size that must fit.
+  for (size_t i{}; i < 2; ++i) {
+    // reduce internal overheads from buffer size for execution engine response
+    const auto maxReplySize = resultBufferEntry.get().size - responseSizeInternalOverhead_;
+    request = bftEngine::IRequestsHandler::ExecutionRequest{
+        clientId,
+        reqSeqNum,
+        reqCid,
+        PRE_PROCESS_FLAG,
+        preProcessReqMsg->requestLength(),
+        preProcessReqMsg->requestBuf(),
+        std::string(preProcessReqMsg->requestSignature(), preProcessReqMsg->requestSignatureLength()),
+        maxReplySize,
+        resultBufferEntry.get().buffer,
+        reqSeqNum,
+        reqOffsetInBatch,
+        preProcessReqMsg->result()};
+    requestsHandler_.preExecute(request, std::nullopt, reqCid, span);
+    preProcessResult = static_cast<OperationResult>(request.outExecutionStatus);
+    resultLen = request.outActualReplySize;
+
+    if (preProcessResult == OperationResult::SUCCESS) {
+      break;
+    }
     LOG_ERROR(logger(),
-              "Pre-execution failed" << KVLOG(
-                  clientId, reqSeqNum, batchCid, reqCid, reqOffsetInBatch, (uint32_t)preProcessResult, resultLen));
-  }
+              "Pre-execution failed" << KVLOG(clientId,
+                                              reqSeqNum,
+                                              batchCid,
+                                              reqCid,
+                                              reqOffsetInBatch,
+                                              (uint32_t)preProcessResult,
+                                              resultLen,
+                                              request.outActualReplySize,
+                                              request.outRequiredReplySize,
+                                              maxReplySize,
+                                              resultBufferEntry.get().buffer,
+                                              request.maxReplySize,
+                                              request.requestSize));
+    if (!bufferPool_ || (OperationResult::EXEC_DATA_TOO_LARGE != preProcessResult)) {
+      // do not retry pre-execute if not using a memory pool OR if error is not due to response buffer size
+      break;
+    }
+
+    // If we are here: using memory pool and the error is due to insufficient buffer size
+    const auto maxSupportedBufferSize = subpoolsConfig_.back().bufferSize;
+    auto args = KVLOG(i,
+                      reqSeqNum,
+                      request.maxReplySize,
+                      request.outRequiredReplySize,
+                      request.outActualReplySize,
+                      maxSupportedBufferSize);
+    if (i == 0) {  // 1st attempt
+      if (request.outRequiredReplySize <= request.maxReplySize) {
+        // break since this is an unexpected error - we can't handle it and there is no use to retry, since buffer size
+        // was sufficient
+        LOG_ERROR(logger(), "Won't retry to pre-execute:" << args);
+        break;
+      }
+      if (request.outRequiredReplySize > maxSupportedBufferSize) {
+        // Largest buffer in queue cannot support the request output!
+        LOG_ERROR(logger(), "Won't retry to pre-execute, since this buffer size is not supported!" << args);
+        break;
+      }
+
+      // we can assume that request.outRequiredReplySize <= maxSupportedBufferSize (supported buffer size)
+      LOG_INFO(logger(), "Retry pre-execution with a larger buffer:" << args);
+      bufferPool_->reportBufferUsage(resultBufferEntry.get().buffer, request.outRequiredReplySize);
+      releasePreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch);
+      // buffer returned from pool should be at least of size as required by execution engine + the response internal
+      // overhead
+      resultBufferEntry = getPreProcessResultBufferEntry(
+          clientId, reqSeqNum, reqOffsetInBatch, request.outRequiredReplySize + responseSizeInternalOverhead_);
+    }  // end 1st attempt
+    else if (i == 1) {
+      // 2nd attempt: Failure on second attempt due to buffer size should not happen, since we always expect the
+      // execution engine to produce the same results
+      LOG_FATAL(
+          logger(),
+          "Unexpected failure on retry due to insufficient buffer size (this error should never happen)!" << args);
+      ConcordAssert(false);
+    }
+  }  // for
+
+  // Done with pre-execution - result might be success or failure
   if (request.outActualReplySize == 0) {
     const string err{"Executed data is empty"};
-    strcpy(preProcessResultBuffer, err.c_str());
+    strcpy(resultBufferEntry.get().buffer, err.c_str());
     resultLen = err.size();
     preProcessResult = OperationResult::EXEC_DATA_EMPTY;
     LOG_ERROR(logger(),
@@ -1804,11 +1931,19 @@ OperationResult PreProcessor::launchReqPreProcessing(const string &batchCid,
                   clientId, batchCid, reqSeqNum, reqCid, reqOffsetInBatch, reqSeqNum, (uint32_t)preProcessResult));
   }
   // Append the conflict detection block id and add its size to the resulting length.
-  memcpy(preProcessResultBuffer + resultLen, reinterpret_cast<char *>(&blockId), sizeof(uint64_t));
+  memcpy(resultBufferEntry.get().buffer + resultLen, reinterpret_cast<char *>(&blockId), sizeof(uint64_t));
+  bufferPool_->reportBufferUsage(resultBufferEntry.get().buffer, request.outActualReplySize);
   resultLen += sizeof(uint64_t);
   LOG_INFO(logger(),
-           "Pre-execution operation has been successfully completed by Execution engine"
-               << KVLOG(clientId, batchCid, reqSeqNum, reqCid, reqOffsetInBatch, blockId));
+           "Pre-execution operation has been completed by Execution engine" << KVLOG(clientId,
+                                                                                     batchCid,
+                                                                                     reqSeqNum,
+                                                                                     reqCid,
+                                                                                     reqOffsetInBatch,
+                                                                                     blockId,
+                                                                                     (uint32_t)preProcessResult,
+                                                                                     resultLen,
+                                                                                     request.outActualReplySize));
   return preProcessResult;
 }
 
@@ -1840,7 +1975,9 @@ void PreProcessor::handleReqPreProcessedByPrimary(const PreProcessRequestMsgShar
     lock_guard<mutex> lock(reqEntry->mutex);
     if (reqEntry->reqProcessingStatePtr) {
       reqEntry->reqProcessingStatePtr->handlePrimaryPreProcessed(
-          getPreProcessResultBuffer(clientId, reqEntry->reqProcessingStatePtr->getReqSeqNum(), reqOffsetInBatch),
+          getPreProcessResultBufferEntry(
+              clientId, reqEntry->reqProcessingStatePtr->getReqSeqNum(), reqOffsetInBatch, resultBufLen)
+              .buffer,
           resultBufLen,
           preProcessResult);
       result = reqEntry->reqProcessingStatePtr->definePreProcessingConsensusResult();
@@ -1876,17 +2013,18 @@ void PreProcessor::handleReqPreProcessedByNonPrimary(uint16_t clientId,
                                                      OperationResult preProcessResult) {
   concord::diagnostics::TimeRecorder scoped_timer(*histograms_.handlePreProcessedReqByNonPrimary);
   const auto status = (preProcessResult == OperationResult::SUCCESS) ? STATUS_GOOD : STATUS_FAILED;
-  auto replyMsg = make_shared<PreProcessReplyMsg>(myReplicaId_,
-                                                  clientId,
-                                                  reqOffsetInBatch,
-                                                  reqSeqNum,
-                                                  reqRetryId,
-                                                  getPreProcessResultBuffer(clientId, reqSeqNum, reqOffsetInBatch),
-                                                  resBufLen,
-                                                  reqCid,
-                                                  status,
-                                                  preProcessResult,
-                                                  myReplica_.getCurrentView());
+  auto replyMsg = make_shared<PreProcessReplyMsg>(
+      myReplicaId_,
+      clientId,
+      reqOffsetInBatch,
+      reqSeqNum,
+      reqRetryId,
+      getPreProcessResultBufferEntry(clientId, reqSeqNum, reqOffsetInBatch, resBufLen).buffer,
+      resBufLen,
+      reqCid,
+      status,
+      preProcessResult,
+      myReplica_.getCurrentView());
   const auto &batchEntry = ongoingReqBatches_[clientId];
   if (batchEntry->isBatchInProcess()) {
     batchEntry->releaseReqsAndSendBatchedReplyIfCompleted(replyMsg);

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -299,6 +299,9 @@ class PreProcessor : public bftEngine::IExternalObject {
     return logger_;
   }
 
+  concordUtil::MultiSizeBufferPool::SubpoolsConfig calcSubpoolsConfig();
+  std::unique_ptr<concordUtil::MultiSizeBufferPool> createbufferPool();
+
  private:
   const uint32_t MAX_MSGS = 10000;
   const uint32_t WAIT_TIMEOUT_MILLI = 100;
@@ -333,7 +336,7 @@ class PreProcessor : public bftEngine::IExternalObject {
   // engine supported size is kMaxSubpoolBuffersize_ - responseSizeInternalOverhead_
   static constexpr uint32_t kMaxSubpoolBuffersize_{1UL << 25};
   // Must be sorted in an ascending order, by bufferSize
-  const std::vector<concordUtil::MultiSizeBufferPool::SubpoolConfig> subpoolsConfig_;
+  const concordUtil::MultiSizeBufferPool::SubpoolsConfig subpoolsConfig_;
   std::unique_ptr<concordUtil::MultiSizeBufferPool> bufferPool_;
 
   concordMetrics::Component metricsComponent_;

--- a/bftengine/src/preprocessor/PreProcessor.hpp
+++ b/bftengine/src/preprocessor/PreProcessor.hpp
@@ -28,7 +28,7 @@
 #include "PerformanceManager.hpp"
 #include "RollingAvgAndVar.hpp"
 #include "SharedTypes.hpp"
-#include "RawMemoryPool.hpp"
+#include "MultiSizeBufferPool.hpp"
 #include "GlobalData.hpp"
 #include "PerfMetrics.hpp"
 #include "Replica.hpp"
@@ -58,6 +58,7 @@ struct RequestState {
 struct SafeResultBuffer {
   std::mutex mutex;
   char *buffer = nullptr;
+  uint32_t size{};
 };
 
 using SafeResultBufferSharedPtr = std::shared_ptr<SafeResultBuffer>;
@@ -140,7 +141,7 @@ class PreProcessor : public bftEngine::IExternalObject {
 
   void setAggregator(const std::shared_ptr<concordMetrics::Aggregator> &a) override {
     metricsComponent_.SetAggregator(a);
-    memoryPool_.setAggregator(a);
+    bufferPool_->setAggregator(a);
   }
 
  protected:
@@ -221,7 +222,13 @@ class PreProcessor : public bftEngine::IExternalObject {
                                     const std::string &reqCid,
                                     const std::string &ongoingCid);
   uint32_t getBufferOffset(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch) const;
-  const char *getPreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
+  // If minBufferSize is 0, default (minimal) buffer size is returned. Else, a buffer size of at least minBufferSize
+  // bytes is returned. If no such buffer size exist - function throws an exception.
+  // Returns: an entry to a buffer entry which holds the allocated result buffer and its size.
+  SafeResultBuffer &getPreProcessResultBufferEntry(uint16_t clientId,
+                                                   ReqId reqSeqNum,
+                                                   uint16_t reqOffsetInBatch,
+                                                   uint32_t minBufferSize = 0);
   void releasePreProcessResultBuffer(uint16_t clientId, ReqId reqSeqNum, uint16_t reqOffsetInBatch);
   void launchAsyncReqPreProcessingJob(const PreProcessRequestMsgSharedPtr &preProcessReqMsg,
                                       const std::string &batchCid,
@@ -286,7 +293,7 @@ class PreProcessor : public bftEngine::IExternalObject {
                                            const std::string &reqCid);
   void releaseReqAndSendReplyMsg(PreProcessReplyMsgSharedPtr replyMsg);
   bool handlePossiblyExpiredRequest(const RequestStateSharedPtr &reqStateEntry);
-
+  bool validateSubpoolsConfig();
   static logging::Logger &logger() {
     static logging::Logger logger_ = logging::getLogger("concord.preprocessor");
     return logger_;
@@ -310,16 +317,24 @@ class PreProcessor : public bftEngine::IExternalObject {
   InternalReplicaApi &myReplica_;
   const ReplicaId myReplicaId_;
   const uint32_t maxExternalMsgSize_;
-  const uint32_t maxPreExecResultSize_;
+  // Add overheads that should be reduced from the net space given for execution engine
+  const uint32_t responseSizeInternalOverhead_;
   const uint16_t numOfReplicas_;
   const uint16_t numOfClientProxies_;
   const bool clientBatchingEnabled_;
   inline static uint16_t clientMaxBatchSize_ = 0;
   concord::util::SimpleThreadPool threadPool_;
+  concordUtil::Timers &timers_;
   // One-time allocated buffers (one per client) for the pre-execution results storage
   PreProcessResultBuffers preProcessResultBuffers_;
   OngoingReqBatchesMap ongoingReqBatches_;  // clientId -> RequestsBatch
-  concordUtil::RawMemoryPool memoryPool_;
+  // Memory pool parameters:
+  // Maximal subpool size should support up to 32MB (including responseSizeInternalOverhead_). So the maximal execution
+  // engine supported size is kMaxSubpoolBuffersize_ - responseSizeInternalOverhead_
+  static constexpr uint32_t kMaxSubpoolBuffersize_{1UL << 25};
+  // Must be sorted in an ascending order, by bufferSize
+  const std::vector<concordUtil::MultiSizeBufferPool::SubpoolConfig> subpoolsConfig_;
+  std::unique_ptr<concordUtil::MultiSizeBufferPool> bufferPool_;
 
   concordMetrics::Component metricsComponent_;
   std::chrono::seconds metricsLastDumpTime_;
@@ -346,12 +361,10 @@ class PreProcessor : public bftEngine::IExternalObject {
   concordUtil::Timers::Handle requestsStatusCheckTimer_;
   concordUtil::Timers::Handle metricsTimer_;
   const uint64_t preExecReqStatusCheckPeriodMilli_;
-  concordUtil::Timers &timers_;
   PreProcessorRecorder histograms_;
   std::shared_ptr<concord::diagnostics::Recorder> totalPreExecDurationRecorder_;
   std::shared_ptr<concord::diagnostics::Recorder> launchAsyncPreProcessJobRecorder_;
   std::shared_ptr<concord::performance::PerformanceManager> pm_ = nullptr;
-  bool memoryPoolEnabled_;
 };
 
 //**************** Class AsyncPreProcessJob ****************//

--- a/bftengine/src/preprocessor/tests/preprocessor_test.cpp
+++ b/bftengine/src/preprocessor/tests/preprocessor_test.cpp
@@ -1152,7 +1152,7 @@ TEST(requestPreprocessingState_test, rejectMsgWithInvalidView) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   logging::initLogger("logging.properties");
-
+  logging::Logger::getInstance("preprocessor_test").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
   if (replicaConfig.replicaMsgSigningAlgo == SignatureAlgorithm::EdDSA) {
     replicaPrivKeys = replicaEdDSAPrivKeys;
     replicaPubKeys = replicaEdDSAPubKeys;

--- a/client/clientservice/include/client/clientservice/event_service.hpp
+++ b/client/clientservice/include/client/clientservice/event_service.hpp
@@ -54,15 +54,11 @@ struct Recorders {
 
   Recorders() {
     auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-    if (!registrar.perf.isRegisteredComponent("clientservice_event_service")) {
-      registrar.perf.registerComponent("clientservice_event_service", {processing_duration, write_duration});
-    }
+    registrar.perf.registerComponent("clientservice_event_service", {processing_duration, write_duration});
   }
   ~Recorders() {
     auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-    if (registrar.perf.isRegisteredComponent("clientservice_event_service")) {
-      registrar.perf.unRegisterComponent("clientservice_event_service");
-    }
+    registrar.perf.unRegisterComponent("clientservice_event_service");
   }
 
   DEFINE_SHARED_RECORDER(processing_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);

--- a/diagnostics/include/performance_handler.h
+++ b/diagnostics/include/performance_handler.h
@@ -353,9 +353,14 @@ struct HistogramData {
 
 class PerformanceHandler {
  public:
+  /*
+  If a component is already registered: print a warning and do nothing. This is the API definition, there is nothing
+  ill-defined here. For example std::vector::clear(), std::unique_ptr::reset() or std::set::insert() operates in the
+  same way. Same idea for the unregistered part.
+  */
   void registerComponent(const std::string& name, const std::vector<std::shared_ptr<Recorder>>&);
+  // If a component is already not registered: print a warning and do nothing.
   void unRegisterComponent(const std::string& name);
-  bool isRegisteredComponent(const std::string& name);
 
   // List all components
   std::string list() const;

--- a/diagnostics/src/performance_handler.cpp
+++ b/diagnostics/src/performance_handler.cpp
@@ -34,9 +34,11 @@ void Recorder::recordAtomic(int64_t val) {
 void PerformanceHandler::registerComponent(const std::string& name,
                                            const std::vector<std::shared_ptr<Recorder>>& recorders) {
   std::lock_guard<std::mutex> guard(mutex_);
+  // Comment: since registerComponent might be called from multiple threads, checking if registered before calling
+  // this function doesn't make sense. Do not terminate if component is already registered. just exit with warning.
   if (components_.count(name)) {
-    LOG_FATAL(DIAG_LOGGER, "Component already exists: " << name);
-    std::terminate();
+    LOG_WARN(DIAG_LOGGER, "Component already registered: " << name);
+    return;
   }
   Histograms histograms;
   for (const auto& recorder : recorders) {
@@ -47,16 +49,14 @@ void PerformanceHandler::registerComponent(const std::string& name,
 
 void PerformanceHandler::unRegisterComponent(const std::string& name) {
   std::lock_guard<std::mutex> guard(mutex_);
+
+  // Comment: since unRegisterComponent might be called from multiple threads, checking if registered before calling
+  // this function doesn't make sense. Do not terminate if component is not registered. just exit with warning.
   if (components_.count(name) == 0) {
-    LOG_FATAL(DIAG_LOGGER, "Component does not exist: " << name);
-    std::terminate();
+    LOG_WARN(DIAG_LOGGER, "Component is not registered: " << name);
+    return;
   }
   components_.erase(name);
-}
-
-bool PerformanceHandler::isRegisteredComponent(const std::string& name) {
-  std::lock_guard<std::mutex> guard(mutex_);
-  return components_.count(name) > 0;
 }
 
 std::string PerformanceHandler::list() const {

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -265,9 +265,7 @@ class Replica : public IReplica,
     const std::string component_ = "iappstate";
     Recorders() {
       auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      if (!registrar.perf.isRegisteredComponent(component_)) {
-        registrar.perf.registerComponent(component_, {get_block_duration, put_block_duration});
-      }
+      registrar.perf.registerComponent(component_, {get_block_duration, put_block_duration});
     }
 
     ~Recorders() {}

--- a/kvbc/include/kvbc_adapter/categorization/blocks_deleter_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/categorization/blocks_deleter_adapter.hpp
@@ -49,9 +49,7 @@ class BlocksDeleterAdapter : public concord::kvbc::IBlocksDeleter {
 
     Recorders() {
       auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      if (!registrar.perf.isRegisteredComponent(component_)) {
-        registrar.perf.registerComponent(component_, {delete_batch_blocks_duration});
-      }
+      registrar.perf.registerComponent(component_, {delete_batch_blocks_duration});
     }
 
     ~Recorders() {}

--- a/kvbc/include/kvbc_adapter/v4blockchain/blocks_deleter_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/v4blockchain/blocks_deleter_adapter.hpp
@@ -44,9 +44,7 @@ class BlocksDeleterAdapter : public IBlocksDeleter {
 
     Recorders() {
       auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      if (!registrar.perf.isRegisteredComponent(component_)) {
-        registrar.perf.registerComponent(component_, {delete_batch_blocks_duration});
-      }
+      registrar.perf.registerComponent(component_, {delete_batch_blocks_duration});
     }
 
     ~Recorders() {}

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.cpp
@@ -164,7 +164,7 @@ void InternalCommandsHandler::preExecute(IRequestsHandler::ExecutionRequest &req
   }
   res = verifyWriteCommand(req.requestSize, request_buffer_as_uint8, req.maxReplySize, req.outActualReplySize);
   if (res != OperationResult::SUCCESS) {
-    LOG_INFO(GL, "Operation result is not success in verifying write command");
+    LOG_ERROR(GL, "Operation result is not success in verifying write command");
   } else {
     SKVBCRequest deserialized_request;
     deserialize(request_buffer_as_uint8, request_buffer_as_uint8 + req.requestSize, deserialized_request);

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -12,6 +12,7 @@ set(util_source_files
     src/hex_tools.cpp
     src/OpenTracing.cpp
     src/throughput.cpp
+    src/RawMemoryPool.cpp
     src/MultiSizeBufferPool.cpp
     src/config_file_parser.cpp
     src/io.cpp)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -12,17 +12,20 @@ set(util_source_files
     src/hex_tools.cpp
     src/OpenTracing.cpp
     src/throughput.cpp
-    src/RawMemoryPool.cpp
+    src/MultiSizeBufferPool.cpp
     src/config_file_parser.cpp
     src/io.cpp)
     
 add_library(util STATIC ${util_source_files})
-
+target_link_libraries(util PUBLIC diagnostics)
 if(NOT BUILD_CONFIG_GEN_TOOL_FOR_MAC)
     target_link_libraries(util PUBLIC stdc++fs)
 endif()
 
-target_include_directories(util PUBLIC include ${Boost_INCLUDE_DIR})
+target_include_directories(util PUBLIC include
+  ${libdiagnostics_SOURCE_DIR}/include
+  ${Boost_INCLUDE_DIR}
+)
 if(BUILD_CONFIG_GEN_TOOL_FOR_MAC)
     target_include_directories(util PUBLIC ${OPENSSL_ROOT_DIR}/include)
 endif()

--- a/util/include/MultiSizeBufferPool.hpp
+++ b/util/include/MultiSizeBufferPool.hpp
@@ -1,0 +1,498 @@
+// Concord
+//
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may include a number of sub-components with separate copyright notices and license terms. Your use of
+// these sub-components is subject to the terms and conditions of the sub-component's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include "Timers.hpp"
+#include "Metrics.hpp"
+#include "assertUtils.hpp"
+#include "throughput.hpp"
+#include "diagnostics.h"
+#include "performance_handler.h"
+
+#include <boost/lockfree/queue.hpp>
+
+#include <string_view>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <set>
+#include <deque>
+
+/**
+ * Multi-Buffer Memory Pool (MultiSizeBufferPool):
+ *
+ * === For API: search for "Public API" ===
+ *
+ * Definitions:
+ * - Buffer: a continuous, fixed size array of bytes dedicated to a caller.
+ * - Chunk: Wraps a buffer. Pool deals internally with chunks, which include header and trailer metadata for internal
+ * use.
+ * - Used buffer/chunk: currently used by caller
+ * - Unused buffer/chunk: currently not-used by caller, and stored in the pool.
+ * - Allocated buffer/chunk: currently allocated by pool. Can be used or unused in that case.
+ * - Non-allocated buffer/chunk: currently not allocated by pool - pool reserves the right to allocate this chunk
+ * dynamically.
+ * - Subpool: holds a group of buffers of a fixed constant size. Each subpool has its own configuration and contention.
+ * lock-free domain: threads that try to get a buffer from subpool A, do not compete with threads that try to get a
+ * buffer from subpool B. This allow (with an additional very small implementation changes) to create multiple
+ * subpools with the same buffer size to reduce contention. Currently, all subpools should be different sizes.
+ * - Client - a user of the pool's API in order to use the memory pool buffer.
+ * - IPurger: a module that is responsible for purging the sub-queues, based on recently collected data. Can be
+ * disabled. Can be passed externally by pool creator. If not passed externally, the pool creates a default
+ * DefaultPurger. The main idea of the purger is to deallocate unused resources (chunks) from the pool to keep it
+ * minimal according to a given purging policy. Purger can be configured to treat different sub-pools (buffer sizes)
+ * in different ways.
+ * - ISubpoolSelector: a module that is responsible for selecting the most suitable sub-pool (buffer size), based on
+ * recently collected data. Can be disabled. It can be passed externally by the pool creator. If not passed externally,
+ * pool creates a default DefaultSubpoolSelector which chooses to smallest buffer size sub-pool always.
+ * - Pool - holds its configuration purger, subpool selector and an array of subpools (at least 1).
+ *
+ * Overview:
+ * This memory pool has the following attributes:
+ * - Thread safe for all of its operations (not thread safe, of course, when accessing the currently used buffers).
+ * - Supports advanced configuration, in particular caller can define any amount of sub-pools of any size with initial
+ * and maximal number of buffers for each subpool.
+ * A caller may control the overall size of the allocated bytes in the pool, this can give more 'freedom' per subpool,
+ * and restrict the total pool size.
+ * - Rich statistics:
+ * 1) Histograms (snapshots) reported to logs. Currently, histograms are for this pool can't be viewed
+ * from concord-ctl.
+ * 2) Metrics - reported to Wavefront.
+ * 3) Statistics - reported to log. It is very important to mention, that due to speed consideration, each of the
+ * statistics are "stand-alone" and atomic. That means, for a statistics report, you might find discrepancies between
+ * statistics of the same type, due to the nature of this multi-threaded pool (statistics are updated all the time by
+ * multiple clients in a non-atomic way). All types of statistics can be disabled/enabled.
+ * - Blocking - calls to get a buffer should never fail, unless requested buffer size is too big or there is no more
+ * memory - in rare cases user may get a larger buffer than requested, in more cases caller may block.
+ * Currently, there is no implementation for wait_for(..) e.g async mode.
+ * - Dynamic allocation - each pool allocates its initial chunks when created. In case there is no available
+ * chunks in a specific subpool, a new one gets dynamically allocated - up to a maximum number of chunks defined for
+ * this subpool.
+ * - Throwing - asserts are done to detect internal coding errors. In case of user input error or System error -
+ * an exception is thrown.
+ * - Borrowing - if all buffers of a certain sub-pool SP1 are allocated, a calling thread checks for a free chunk in the
+ * rest of the subpools (SP2, SP3 etc..) for speed, but won't try to allocate a new one on these subpools. If a buffer
+ * isn't found - it returns to wait for a chunk to be released by another thread on the original subpool SP1.
+ * - Unit-testing: done by GTest, see MultiSizeBufferPool_test.
+ * - Safety checks:
+ * 1) Pool assign magic flags on chunk's header and trailer. If they are changed - exception is thrown.
+ * 2) Check for leaks - pool can be configured to check that all buffers have been returned to it before destroying
+ * itself. If not, it throws.
+ *
+ * Locking is done only for conditional variables for this pool. This is in order to achieve speed. This pool currently
+ * faces thousands of calls per second for its main use-case. This leads to sub-optimized cases in both statistics and
+ * behavior. For example, the upper threshold for maximal pool size might cross more than user defined, due to the
+ * multi-threaded nature and since there is no locking. Another example is for purge limit: we might purge a "little
+ * more" than requested.
+ *
+ * Important comment about usage:
+ * It is the responsibilty iof the user to make sure that:
+ * 1) Pool is destroyed by a single thread
+ * 2) whn pool is destroyed all buffers have been returned
+ * 3) This implies that since all buffers have been returned, no more threads are waiting for buffers.
+ */
+
+namespace concordUtil {
+
+namespace test {
+class MultiSizeBufferPoolTestFixture;
+}
+
+class MultiSizeBufferPool {
+  friend class concordUtil::test::MultiSizeBufferPoolTestFixture;  // Should be strictly used for testing!
+
+ protected:
+  class MultiSizeBufferPoolMetrics {
+   public:
+    MultiSizeBufferPoolMetrics(const std::string& name)
+        : component_{std::string("MultiSizeBufferPoolMetrics") + name, std::make_shared<concordMetrics::Aggregator>()},
+          overallUsedBuffersFailure_{component_.RegisterAtomicGauge("overallUsedBuffersFailure", 0)},
+          overallUsedBuffersSuccess_{component_.RegisterAtomicGauge("overallUsedBuffersSuccess", 0)},
+          overallUsedBuffers_{component_.RegisterAtomicGauge("overallUsedBuffers", 0)},
+          overallMaxUsedBytes_{component_.RegisterAtomicGauge("overallMaxUsedBytes", 0)},
+          currentUsedBytes_{component_.RegisterAtomicGauge("currentUsedBytes", 0)} {
+      component_.Register();
+    }
+
+    void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
+      component_.SetAggregator(aggregator);
+    }
+    void updateAggregator() { component_.UpdateAggregator(); }
+    concordMetrics::Component component_;
+
+    // metrics handles
+
+    // Number of times a buffer was given to caller, but caller couldn't used it since buffer wasn't big enough
+    concordMetrics::AtomicGaugeHandle overallUsedBuffersFailure_;
+    // Number of times a buffer was given to caller and could be used
+    concordMetrics::AtomicGaugeHandle overallUsedBuffersSuccess_;
+    // overallUsedBuffersFailure_+ overallUsedBuffersSuccess_
+    concordMetrics::AtomicGaugeHandle overallUsedBuffers_;
+    // Maximum sum of bytes used by all callers: sum of all used buffers
+    concordMetrics::AtomicGaugeHandle overallMaxUsedBytes_;
+    // current sum of bytes used by all callers: sum of all used buffers
+    concordMetrics::AtomicGaugeHandle currentUsedBytes_;
+  };
+
+ public:
+  // Members of the following struct are non-const due to the fact that some users need SubpoolConfig read/write and
+  // some as read only. To set it as read only, use constness externally e 'const SubpoolConfig ...'
+  struct SubpoolConfig {
+    uint32_t bufferSize;         // size of data which can be used by a client
+    uint32_t numInitialBuffers;  // number of buffers to allocate on creation
+    uint32_t numMaxBuffers;      // maximum number of buffers that can be allocated (initially + dynamically)
+  };
+  using SubpoolsConfig = std::vector<MultiSizeBufferPool::SubpoolConfig>;
+
+  struct Config {
+    // The default timer interval, in seconds
+    static constexpr uint32_t kDefaultBasePeriodicTimerIntervalSec = 1;
+
+    // When maxAllocatedBytes is zero - do not enforce a limit on pool total size.
+    // When non-zero - sum of total allocated initial chunks sizes should never exceed this parameter.
+    // This parameter takes into account chunks = buffer size + header/trailer metadata.
+    const uint64_t maxAllocatedBytes;
+
+    // The next frequency-based members can be all disabled when set to 0. If non-zero: evaluation happens periodically
+    // in a frequency multiplied by kDefaultBasePeriodicTimerIntervalSec
+    const uint32_t purgeEvaluationFrequency;   // check if purge is needed
+    const uint32_t statusReportFrequency;      // report statistics to log
+    const uint32_t histogramsReportFrequency;  // take snapshot and write to log
+    const uint32_t metricsReportFrequency;     // update metrics and aggregator
+
+    // When true, log reporting is done for changes (vs previous report) only. If false, report is done no matter what.
+    const bool enableStatusReportChangesOnly;
+
+    /**
+     * Minimum and maximum thresholds in the closed range [X,Y] which may trigger the subpool selector to switch to a
+     * lower/higher level subpool.
+     * If number of retries in a given period retriesMeasurePeriod is less than
+     * subpoolSelectorEvaluationNumRetriesMinThreshold/subpoolSelectorEvaluationCounter, selector might decide to
+     * move to a subpool with a smaller buffer size.
+     * If number of retries in a given period is
+     * more than subpoolSelectorEvaluationNumRetriesMaxThreshold/subpoolSelectorEvaluationCounter, selector might decide
+     * to move to a subpool with a larger buffer size.
+     * subpoolSelectorEvaluationNumRetriesMinThreshold must be less than
+     * subpoolSelectorEvaluationNumRetriesMaxThreshold.
+     */
+    const uint32_t subpoolSelectorEvaluationNumRetriesMinThreshold;
+    const uint32_t subpoolSelectorEvaluationNumRetriesMaxThreshold;
+  };
+
+  class ISubpoolSelector {
+   public:
+    ISubpoolSelector(const SubpoolsConfig& config) : config_{config} { ConcordAssert(!config_.empty()); };
+    virtual ~ISubpoolSelector() = default;
+    // Returns the selected subpool, cased on reports
+    virtual const SubpoolConfig& selectSubpool() const = 0;
+    virtual std::string_view name() const = 0;
+    // Report about a buffer usage:
+    // usedBufferSize - the size of buffer that was used by the caller
+    // actualRequiredSize - the actual amount of bytes needed by caller. Usually less than usedBufferSize, but in case
+    // of failure might be greater.
+    virtual void reportBufferUsage(uint32_t usedBufferSize, uint32_t actualRequiredSize) = 0;
+
+   protected:
+    const SubpoolsConfig config_;
+  };
+
+  class IPurger {
+   public:
+    IPurger() = default;
+    virtual ~IPurger() = default;
+    virtual std::string_view name() const = 0;
+    // Called periodically to evaluate the pool/sub-pools state. If purge is needed, it may raise a purge flag and a
+    // purge limit during this evaluation. The decision if actual purging is done during evaluation, or only a flag is
+    // raised is left for the future (// TODO GL).
+    virtual void evaluate(MultiSizeBufferPool& pool) = 0;
+  };
+
+ protected:
+  class BasicPurger : public IPurger {
+   public:
+    std::string_view name() const override { return "BasicPurger"; }
+    void evaluate(MultiSizeBufferPool& pool) override{/* TODO, set purgeFlag_ and purgeLimit_ on each subpool */};
+  };
+
+  class MinimalSizeSubpoolSelector : public ISubpoolSelector {
+   public:
+    MinimalSizeSubpoolSelector(const SubpoolsConfig& config) : ISubpoolSelector(config) {}
+    // comment: config_ is sorted by buffer size
+    const SubpoolConfig& selectSubpool() const override { return *config_.begin(); }
+    std::string_view name() const override { return "MinimalSizeSubpoolSelector"; }
+    void reportBufferUsage(uint32_t usedBufferSize, uint32_t actualRequiredSize) override {
+      ConcordAssertNE(actualRequiredSize, 0);
+      // Ignore the report, since always choosing minimal
+    }
+  };
+
+  struct Statistics {
+    Statistics(bool enableStatusReportChangesOnly) : enableStatusReportChangesOnly_{enableStatusReportChangesOnly} {}
+    void onChunkBecomeUsed(uint64_t chunkSize, bool chunkAllocatedFromHeap);
+    enum class operationType { ALLOC, DELETE, PUSH };
+    void onChunkBecomeUnused(uint64_t chunkSize, operationType opType);
+    void onChunkAllocated(uint64_t chunkSize);
+    void onChunkDeleted(uint64_t chunkSize);
+    void onInit(uint32_t numMaxBuffers, uint32_t chunkSize);
+    void setLimits(uint64_t maxAllocatedBytes);
+
+    struct CurrentStateStatistics {
+      // Pool level:
+      // numAllocatedBytes_ + numNonAllocatedBytes_ = Config::maxAllocatedBytes + numAllocatedMetadataBytes_ (if non
+      // zero) in pool level.
+      // Subpool level:
+      // numAllocatedBytes_ + numNonAllocatedBytes_ = SubpoolConfig::numMaxBuffers * (SubpoolConfig::bufferSize +
+      // chunkMetadataSize())
+      std::atomic_uint64_t numAllocatedBytes_{};
+      std::atomic_uint64_t numNonAllocatedBytes_{};
+
+      // numAllocatedBytes_ = numUnusedBytes_ + numUsedBytes_
+      std::atomic_uint64_t numUsedBytes_{};
+      std::atomic_uint64_t numUnusedBytes_{};
+
+      // numAllocatedChunks_ + numNonAllocatedChunks_ = SubpoolConfig::numMaxBuffers
+      std::atomic_uint64_t numAllocatedChunks_{};
+      std::atomic_uint64_t numNonAllocatedChunks_{};
+
+      // numAllocatedChunks_ = numUsedChunks_ + numUnusedChunks_
+      std::atomic_uint64_t numUsedChunks_{};
+      std::atomic_uint64_t numUnusedChunks_{};
+    } current_;
+
+    // Overall statistics are accumulating
+    struct OverallStatistics {
+      std::atomic_uint64_t numAllocatedBytes_{};
+      std::atomic_uint64_t numDeletedBytes_{};
+      std::atomic_uint64_t numUsedBytes_{};
+
+      std::atomic_uint64_t numAllocatedChunks_{};
+      std::atomic_uint64_t numDeletedChunks_{};
+      std::atomic_uint64_t numUsedChunks_{};
+
+      // Amount of times where a chunk did not fit into the needed buffer size and returned to pool without use
+      std::atomic_uint64_t numBufferUsageFailed_{};
+      // Amount of times where a chunk fit into the needed buffer size and returned to pool without use
+      std::atomic_uint64_t numBufferUsageSuccess_{};
+
+      std::atomic_uint64_t maxNumAllocatedBytes_{};
+      std::atomic_uint64_t maxNumAllocatedChunks_{};
+    } overall_;
+
+    // relevant only if reportOnChangesOnly_ is true. Used to mark if the content need to be reported, only if there was
+    // a change
+    std::atomic_bool reportFlag_{false};
+    // Report only if there were changes. This is in order to prevent endless reports into log when system is idle.
+    const bool enableStatusReportChangesOnly_;
+  };
+
+  friend std::ostream& operator<<(std::ostream& os, const MultiSizeBufferPool::Statistics& s);
+
+  struct ChunkHeader {
+    ChunkHeader(uint32_t bufferSize) : magicField_{kMagicField}, bufferSize_(bufferSize) {}
+    static constexpr int kMagicField = 0xFCFCFCFA;
+    const int magicField_;
+    // buffer size to be used by client, does not include chunkHeaderSize() since this part is fixed.
+    const uint32_t bufferSize_;
+  };
+
+  struct ChunkTrailer {
+    ChunkTrailer() : magicField_{kMagicField} {}
+    static constexpr int kMagicField = 0xFAFAFAFC;
+    const int magicField_;
+  };
+
+  class SubPool {
+    friend class concordUtil::test::MultiSizeBufferPoolTestFixture;  // Should be strictly used for testing!
+    friend class IPurger;
+
+   public:
+    virtual ~SubPool();
+    SubPool() = delete;
+    SubPool(const SubPool&) = delete;
+    SubPool(SubPool&&) = delete;
+    SubPool& operator=(const SubPool&) = delete;
+    SubPool& operator=(SubPool&&) = delete;
+
+    SubPool(logging::Logger& logger,
+            const SubpoolConfig& config,
+            std::string&& name,
+            const MultiSizeBufferPool::Config& poolConfig,
+            Statistics& poolStats);
+
+   protected:
+    boost::lockfree::queue<char*, boost::lockfree::fixed_sized<true>> chunks_;
+    std::condition_variable waitForAvailChunkCond_;
+    std::mutex waitForAvailChunkMutex_;
+    const SubpoolConfig config_;
+
+    std::atomic_bool stopFlag_;
+    std::atomic_bool purgeFlag_;
+    std::atomic_uint64_t purgeLimit_;
+    const logging::Logger& logger_;
+    std::string name_;
+    const uint32_t chunkSize_;
+    Statistics stats_;
+    Statistics& poolStats_;
+
+   public:
+    enum class AllocationStatus { SUCCESS, EXCEED_MAX_BUFFERS, EXCEED_POOL_MAX_BYTES };
+    using AllocationResult = std::pair<char*, AllocationStatus>;
+
+    // TODO - we can extend this pool capabilities, and add timeoutMilli if needed (currently not implemented)
+    AllocationResult getChunk(bool wait, bool allocate);
+    void returnChunk(char* chunk);
+    AllocationResult allocateChunk();
+    void reportBufferUsage(char* chunk, uint32_t usageSize);
+    void statusReport();
+    void setPurgeState(bool purgeFlag, uint64_t purgeLimit = 0) {
+      purgeFlag_ = purgeFlag;
+      purgeLimit_ = purgeLimit;
+    }
+
+   protected:
+    using CurrentStateStatistics = MultiSizeBufferPool::Statistics::CurrentStateStatistics;
+    using OverallStatistics = MultiSizeBufferPool::Statistics::OverallStatistics;
+
+    void deleteChunk(char*& chunk);
+    void pushChunk(char* chunk);
+
+    const MultiSizeBufferPool::Config& poolConfig_;
+  };  // class SubPool
+
+ public:
+  using DefaultSubpoolSelector = MinimalSizeSubpoolSelector;
+  using DefaultPurger = BasicPurger;
+
+  /**
+   *       Public API
+   */
+
+  // SubpoolsConfig must apply the configurations in an ascending order by buffer size.
+  MultiSizeBufferPool(std::string_view name,
+                      Timers& timers,
+                      const SubpoolsConfig& subpoolsConfig,  // must be sorted by an ascending buffer size
+                      const MultiSizeBufferPool::Config& config,
+                      std::unique_ptr<ISubpoolSelector>&& subpoolSelector = nullptr,
+                      std::unique_ptr<IPurger>&& purger = nullptr);
+  virtual ~MultiSizeBufferPool();
+  MultiSizeBufferPool() = delete;
+  MultiSizeBufferPool(const MultiSizeBufferPool&) = delete;
+  MultiSizeBufferPool(MultiSizeBufferPool&&) = delete;
+  MultiSizeBufferPool& operator=(const MultiSizeBufferPool&) = delete;
+  MultiSizeBufferPool& operator=(MultiSizeBufferPool&&) = delete;
+
+  // Allocate by subpool selector - should be usually 1st choice of call. Should always succeed, never throw. Might
+  // block till buffer is freed by another thread if all buffers are occupied.
+  // Returns a pair: the allocated buffer and it's
+  // size.
+  std::pair<char*, uint32_t> getBufferBySubpoolSelector();
+
+  // Allocate by minimal size - should be usually 2nd choice of call (after failure to call getBufferBySubpoolSelector)
+  // minBufferSize is to make sure that returned buffer is at least of that given size. Throws if minBufferSize is
+  // greater than the maximal subpool buffer size defined on creation.
+  // Returns a pair: the allocated buffer and it's size.
+  std::pair<char*, uint32_t> getBufferByMinBufferSize(uint32_t minBufferSize);
+
+  // An optional call which can be used for statistics (internal fragmentation) or by the subpool selector and purger
+  // buffer must be a currently used buffer.
+  // buffer size is extracted from buffer:
+  // 1) if usageSize > buffer size, caller failed to use the given buffer.
+  // 2) if usageSize <= buffer size, caller succeed to use the given buffer.
+  void reportBufferUsage(char* buffer, uint32_t usageSize);
+
+  // Return a buffer to the pool
+  void returnBuffer(char* buffer);
+
+  // Used by purger: for a given subpool, set purge flag and purge limit. If purge flag is false, limit is irrelevant
+  void setPurgeState(uint64_t subPoolBufferSize, bool purgeFlag, uint64_t purgeLimit = 0);
+
+  // Return in an ascending order a vector of subpools buffer sizes
+  const std::vector<uint64_t>& getSubpoolsBufferSizes() const { return subPoolsBufferSizes_; }
+
+  void setAggregator(const std::shared_ptr<concordMetrics::Aggregator>& aggregator) {
+    metrics_.setAggregator(aggregator);
+  }
+
+ protected:
+  std::pair<char*, uint32_t> popBuffer(uint32_t bufferSize);
+  void statusReport();
+  void doPeriodic();
+  void validateConfiguration(const MultiSizeBufferPool::Config& config, const SubpoolsConfig& subpoolsConfig);
+  SubPool& getSubPool(uint32_t bufferSize) const;
+  // Chunk is used internally, and holds the user data + metadata
+  // buffer is the memory location (pointer) returned to user
+  static char* chunkToBuffer(const char* chunk) { return const_cast<char*>(chunk) + chunkHeaderSize(); }
+  static char* bufferToChunk(const char* buffer) { return const_cast<char*>(buffer) - chunkHeaderSize(); }
+  static ChunkTrailer* getChunkTrailer(const char* chunk, uint32_t chunkSize) {
+    return reinterpret_cast<ChunkTrailer*>(const_cast<char*>(chunk) + chunkSize - chunkTrailerSize());
+  }
+  static uint32_t getBufferSize(const char* buffer);  // assume buffer is valid
+  static uint32_t chunkHeaderSize() { return static_cast<uint32_t>(sizeof(ChunkHeader)); }
+  static uint32_t chunkTrailerSize() { return static_cast<uint32_t>(sizeof(ChunkTrailer)); }
+  static uint32_t chunkMetadataSize() { return chunkHeaderSize() + chunkTrailerSize(); }
+  static std::pair<bool, std::string> validateBuffer(const char* buffer);
+
+  struct HistogramRecorders {
+    static constexpr uint64_t MAX_BUFFER_SIZE = 32ULL * 1024ULL * 1024ULL;            // 32MB
+    static constexpr uint64_t MAX_DURATION_MICROSECONDS = 60ULL * 1000ULL * 1000ULL;  // 60 sec
+    HistogramRecorders(const std::string&& name) : name_(std::move(name)) {
+      auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+      // common component
+      registrar.perf.registerComponent(name,
+                                       {time_in_getBufferBySubpoolSelector,
+                                        time_in_getBufferByMinBufferSize,
+                                        time_in_reportBufferUsage,
+                                        time_in_returnBuffer,
+                                        // size of buffer given to caller
+                                        caller_allocated_buffer_size,
+                                        // actual size of buffer used by caller
+                                        caller_allocated_buffer_usage});
+    };
+
+    ~HistogramRecorders() {
+      auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+      registrar.perf.unRegisterComponent(name_);
+    }
+
+    DEFINE_SHARED_RECORDER(
+        time_in_getBufferBySubpoolSelector, 1, MAX_DURATION_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(
+        time_in_getBufferByMinBufferSize, 1, MAX_DURATION_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(
+        time_in_reportBufferUsage, 1, MAX_DURATION_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(
+        time_in_returnBuffer, 1, MAX_DURATION_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+    DEFINE_SHARED_RECORDER(caller_allocated_buffer_size, 1, MAX_BUFFER_SIZE, 3, concord::diagnostics::Unit::BYTES);
+    DEFINE_SHARED_RECORDER(caller_allocated_buffer_usage, 1, MAX_BUFFER_SIZE, 3, concord::diagnostics::Unit::BYTES);
+
+    std::string name_;
+  };
+
+ protected:
+  size_t periodicCounter_;
+  std::map<uint32_t, std::unique_ptr<SubPool>> subpools_;
+  logging::Logger logger_;
+  std::set<uint32_t> bufferSizes_;
+  std::string name_;
+  const Config config_;
+  const SubpoolsConfig subPoolsConfig_;
+  std::unique_ptr<ISubpoolSelector> subPoolSelector_;
+  std::unique_ptr<IPurger> purger_;
+  Statistics stats_;
+  HistogramRecorders histograms_;
+  MultiSizeBufferPoolMetrics metrics_;
+  Timers& timers_;
+  Timers::Handle periodicTimer_;
+  std::vector<uint64_t> subPoolsBufferSizes_;
+};  // class MultiSizeBufferPool
+
+}  // namespace concordUtil

--- a/util/src/MultiSizeBufferPool.cpp
+++ b/util/src/MultiSizeBufferPool.cpp
@@ -1,0 +1,696 @@
+// Concord
+//
+// Copyright (c) 2018-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in
+// compliance with the Apache 2.0 License.
+//
+// This product may iMultiSizeBufferPoolnclude a number of subcomponents with separate copyright notices and license
+// terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted
+// in the LICENSE file.
+
+#include "MultiSizeBufferPool.hpp"
+#include "kvstream.h"
+
+#include <thread>
+#include <future>
+#include <algorithm>
+#include <string_view>
+#include <cstdarg>
+#include <optional>
+
+namespace concordUtil {
+
+using namespace std;
+using namespace std::chrono;
+using TimeRecorder = concord::diagnostics::TimeRecorder<true>;
+
+// uncomment to add debug prints which are too expensive to skip during run time
+// #define MultiSizeBufferPool_DO_DEBUG
+#undef DEBUG_PRINT
+#ifdef MultiSizeBufferPool_DO_DEBUG
+#define DEBUG_PRINT(x, y) LOG_INFO(x, y)
+#else
+#define DEBUG_PRINT(x, y)
+#endif
+
+#define KVLOG_PREFIX name_, std::this_thread::get_id()
+
+/* ==========================================
+===
+===     Statics / Globals
+===
+========================================== */
+template <typename T>
+static void throwException(const logging::Logger& logger,
+                           const std::string& prefix_message,
+                           const std::string& args_formatted_string) {
+  LOG_ERROR(logger, prefix_message << args_formatted_string);
+  throw T(__PRETTY_FUNCTION__ + std::string(" :") + prefix_message + args_formatted_string);
+}
+
+static inline std::ostream& operator<<(std::ostream& os, const MultiSizeBufferPool::Config& c) {
+  os << " Configuration:"
+     << KVLOG(c.kDefaultBasePeriodicTimerIntervalSec,
+              c.maxAllocatedBytes,
+              c.purgeEvaluationFrequency,
+              c.statusReportFrequency,
+              c.histogramsReportFrequency,
+              c.metricsReportFrequency,
+              c.enableStatusReportChangesOnly,
+              c.subpoolSelectorEvaluationNumRetriesMinThreshold,
+              c.subpoolSelectorEvaluationNumRetriesMaxThreshold);
+  return os;
+}
+
+static inline std::ostream& operator<<(std::ostream& os, const MultiSizeBufferPool::SubpoolConfig& s) {
+  os << " SubpoolConfig:" << KVLOG(s.bufferSize, s.numInitialBuffers, s.numMaxBuffers);
+  return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const MultiSizeBufferPool::Statistics& s) {
+  const auto& c = s.current_;
+  const auto& o = s.overall_;
+  os << " Current Statistics: ["
+     << KVLOG(c.numAllocatedBytes_,
+              c.numNonAllocatedBytes_,
+              c.numUnusedBytes_,
+              c.numUsedBytes_,
+              c.numAllocatedChunks_,
+              c.numNonAllocatedChunks_,
+              c.numUsedChunks_,
+              c.numUnusedChunks_)
+     << "]";
+  os << " Overall Statistics: ["
+     << KVLOG(o.numAllocatedBytes_,
+              o.numDeletedBytes_,
+              o.numUsedBytes_,
+              o.numAllocatedChunks_,
+              o.numDeletedChunks_,
+              o.numUsedChunks_,
+              o.numBufferUsageFailed_,
+              o.numBufferUsageSuccess_,
+              o.maxNumAllocatedBytes_,
+              o.maxNumAllocatedChunks_)
+     << "]";
+  return os;
+}
+
+uint32_t MultiSizeBufferPool::getBufferSize(const char* buffer) {
+  char* chunk = bufferToChunk(buffer);
+  auto* chunkHeader = reinterpret_cast<MultiSizeBufferPool::ChunkHeader*>(chunk);
+  return chunkHeader->bufferSize_;
+}
+
+/* ==========================================
+===
+===     MultiSizeBufferPool Definition
+===
+========================================== */
+
+MultiSizeBufferPool::~MultiSizeBufferPool() {
+  timers_.cancel(periodicTimer_);
+  // This one triggers all subpools dtors
+  // Important: we assume here that this is user responsibilty to make sure no more waiting threads.
+  // Checking and warning if all chunks have been returned is done in Subpool dtor level, triggered in the next line.
+  subpools_.clear();
+  LOG_INFO(logger_, KVLOG(KVLOG_PREFIX) << " MultiSizeBufferPool destroyed");
+}
+
+void MultiSizeBufferPool::validateConfiguration(const MultiSizeBufferPool::Config& config,
+                                                const SubpoolsConfig& subpoolsConfig) {
+  if (subpoolsConfig.empty()) {
+    throwException<std::invalid_argument>(
+        logger_,
+        "Invalid subpools configuration: Must have at least a single subpool configuration!",
+        KVLOG(KVLOG_PREFIX));
+  }
+
+  // Make sure that initial allocation (in bytes) is less than configured maxAllocatedBytes (if enabled)
+  if (config_.maxAllocatedBytes != 0) {
+    uint64_t initialNumAllocatedChunksBytes{};
+    for (const auto& subpoolConfig : subpoolsConfig) {
+      initialNumAllocatedChunksBytes +=
+          (subpoolConfig.bufferSize + chunkMetadataSize()) * subpoolConfig.numInitialBuffers;
+    }
+    if (initialNumAllocatedChunksBytes > config_.maxAllocatedBytes) {
+      throwException<std::invalid_argument>(
+          logger_,
+          "Initial pool size is too large:",
+          KVLOG(KVLOG_PREFIX, initialNumAllocatedChunksBytes, config_.maxAllocatedBytes));
+    }
+  }
+
+  if ((config.subpoolSelectorEvaluationNumRetriesMaxThreshold <=
+       config.subpoolSelectorEvaluationNumRetriesMinThreshold) ||
+      (config.subpoolSelectorEvaluationNumRetriesMinThreshold == 0)) {
+    throwException<std::invalid_argument>(logger_,
+                                          "Invalid subpool selector configuration",
+                                          KVLOG(KVLOG_PREFIX,
+                                                config.subpoolSelectorEvaluationNumRetriesMaxThreshold,
+                                                config.subpoolSelectorEvaluationNumRetriesMinThreshold));
+  }
+
+  std::optional<uint32_t> lastBufferSize;
+  for (const auto& subpoolConfig : subpoolsConfig) {
+    if ((lastBufferSize != std::nullopt) && (subpoolConfig.bufferSize <= lastBufferSize)) {
+      throwException<std::invalid_argument>(logger_,
+                                            "Invalid pool subpools configuration: bufferSize must be ascending!",
+                                            KVLOG(KVLOG_PREFIX, subpoolConfig.bufferSize, lastBufferSize.value()));
+    }
+    lastBufferSize = subpoolConfig.bufferSize;
+  }
+}
+
+MultiSizeBufferPool::MultiSizeBufferPool(std::string_view name,
+                                         Timers& timers,
+                                         const SubpoolsConfig& subpoolsConfig,
+                                         const MultiSizeBufferPool::Config& config,
+                                         std::unique_ptr<ISubpoolSelector>&& subpoolSelector,
+                                         std::unique_ptr<IPurger>&& purger)
+    : logger_{logging::getLogger("concord.memory.pool")},
+      name_{name},
+      config_{config},
+      subPoolsConfig_{subpoolsConfig},
+      stats_(config_.enableStatusReportChangesOnly),
+      histograms_(std::string("multi_buffer_size_pool_") + std::string(name)),
+      metrics_{std::string(name)},
+      timers_{timers} {
+  std::string subPoolName;
+  std::optional<uint32_t> lastBufferSize;
+
+  validateConfiguration(config, subpoolsConfig);
+  for (const auto& subpoolConfig : subpoolsConfig) {
+    lastBufferSize = subpoolConfig.bufferSize;
+    bufferSizes_.insert(lastBufferSize.value());
+    subPoolName = name_ + "_" + to_string(lastBufferSize.value());
+
+    auto [_, insertFlag] =
+        subpools_.emplace(std::make_pair(lastBufferSize.value(),
+                                         std::make_unique<MultiSizeBufferPool::SubPool>(
+                                             logger_, subpoolConfig, std::move(subPoolName), config_, stats_)));
+    UNUSED(_);
+    ConcordAssert(insertFlag == true);
+  }  // for
+
+  // Set limits on statistics
+  stats_.setLimits(config_.maxAllocatedBytes);
+
+  if ((config_.purgeEvaluationFrequency != 0) || (config_.statusReportFrequency != 0) ||
+      (config_.histogramsReportFrequency != 0) || (config_.metricsReportFrequency != 0)) {
+    periodicTimer_ = timers.add(std::chrono::seconds{config_.kDefaultBasePeriodicTimerIntervalSec},
+                                Timers::Timer::RECURRING,
+                                [this](Timers::Handle h) { this->doPeriodic(); });
+  } else {
+    LOG_WARN(logger_, "Periodic timer is disabled!" << KVLOG(KVLOG_PREFIX));
+  }
+
+  // Set/create subpool selector and purger
+  subPoolSelector_ =
+      subpoolSelector ? std::move(subpoolSelector) : std::make_unique<DefaultSubpoolSelector>(subpoolsConfig);
+  purger_ = purger ? std::move(purger) : std::make_unique<DefaultPurger>();
+
+  // initialize subpools buffer sizes vector
+  for (const auto& spc : subPoolsConfig_) subPoolsBufferSizes_.push_back(spc.bufferSize);
+  std::sort(subPoolsBufferSizes_.begin(), subPoolsBufferSizes_.end());
+
+  LOG_INFO(logger_,
+           "Done creating pool and allocating all Sub-Memory Pools:"
+               << KVLOG(KVLOG_PREFIX, subpoolsConfig.size()) << config_
+               << ". Subpool Selector:" << subPoolSelector_->name() << ". Purger:" << purger_->name() << stats_);
+}
+
+MultiSizeBufferPool::SubPool& MultiSizeBufferPool::getSubPool(uint32_t bufferSize) const {
+  auto iter = subpools_.find(bufferSize);
+  ConcordAssert(iter != subpools_.end());  // internal bug or memory corrupted - caller must validate
+  return *iter->second.get();
+}
+
+std::pair<char*, uint32_t> MultiSizeBufferPool::popBuffer(uint32_t requestedBufferSize) {
+  SubPool::AllocationResult result{};
+  uint32_t allocatedBufferSize{};
+  bool allocate{true};
+
+  DEBUG_PRINT(logger_, "pop enter:" << KVLOG(KVLOG_PREFIX));
+  /** 1st stage: repetitive, until reaching the largest subpool:
+   * 1a) Attempt to obtain a chunk from the target subpool that matches bufferSize.
+   * 1b) If such chunk is found - return chunk and exit (success), If not continue to 1c.
+   * 1c) If there are no available chunks in the target subpool, try to allocate one from the next subpool (with a
+   * larger chunk size), repeat 1a->1c. If reached largest subpool, move to stage 2. 2nd stage: 2a) Go back to the
+   * target subpool (which matches bufferSize). 2b) Try to allocate a new chunk and/or wait for chunk to be released by
+   * another consumer. This stage is blocking so a chunk must be found at some time.
+   */
+  auto iter = bufferSizes_.find(requestedBufferSize);
+  ConcordAssertNE(iter, bufferSizes_.end());
+  if (iter == bufferSizes_.end())
+    throwException<std::invalid_argument>(logger_, "Invalid buffer size!", KVLOG(KVLOG_PREFIX, requestedBufferSize));
+
+  do {
+    result = getSubPool(*iter).getChunk(false, allocate);
+    if (result.first) {
+      allocatedBufferSize = *iter;
+      break;
+    }
+    // continue on all errors codes (try next subpool)
+    allocate = false;
+    ++iter;
+  } while (iter != bufferSizes_.end());
+
+  if (result.second == SubPool::AllocationStatus::EXCEED_POOL_MAX_BYTES) {
+    LOG_WARN(logger_,
+             "The pool has reached the maximum pool total bytes allocation threshold (net buffers size "
+             "plus metadata)!"
+                 << KVLOG(KVLOG_PREFIX, config_.maxAllocatedBytes) << stats_);
+  }
+  if (!result.first) {
+    // 2nd stage, if didn't get a buffer: wait infinitely on the initial subpool until a chunk is allocated
+    result = getSubPool(requestedBufferSize).getChunk(true, true);
+    allocatedBufferSize = requestedBufferSize;
+  }
+
+  DEBUG_PRINT(logger_, "pop exit:" << KVLOG(KVLOG_PREFIX));
+  if (result.first) {
+    ConcordAssertGT(allocatedBufferSize, 0);
+    return std::make_pair(chunkToBuffer(result.first), allocatedBufferSize);
+  }
+  return std::make_pair(nullptr, 0);
+}
+
+std::pair<char*, uint32_t> MultiSizeBufferPool::getBufferBySubpoolSelector() {
+  TimeRecorder scoped_timer(*histograms_.time_in_getBufferBySubpoolSelector);
+  DEBUG_PRINT(logger_, "getBufferBySubpoolSelector enter:" << KVLOG(KVLOG_PREFIX));
+  const auto& subpoolConfig{subPoolSelector_->selectSubpool()};
+  auto result = popBuffer(subpoolConfig.bufferSize);
+  DEBUG_PRINT(logger_, "getBufferBySubpoolSelector exit:" << KVLOG(KVLOG_PREFIX) << stats_);
+  return result;
+}
+
+void MultiSizeBufferPool::returnBuffer(char* buffer) {
+  TimeRecorder scoped_timer(*histograms_.time_in_returnBuffer);
+  DEBUG_PRINT(logger_, "returnBuffer enter:" << KVLOG(KVLOG_PREFIX));
+  if (auto [result, errMsg] = validateBuffer(buffer); !result) {
+    throwException<std::invalid_argument>(logger_, errMsg, KVLOG(KVLOG_PREFIX, (void*)buffer));
+  }
+  auto subpoolBufferSize = getBufferSize(buffer);
+  auto chunk = bufferToChunk(buffer);
+  getSubPool(subpoolBufferSize).returnChunk(chunk);
+  DEBUG_PRINT(logger_, "returnBuffer exit:" << KVLOG(KVLOG_PREFIX) << stats_);
+}
+
+// Used by purger: for a given subpool, set purge flag and purge limit. If purge flag is false, limit is irrelevant
+void MultiSizeBufferPool::setPurgeState(uint64_t subPoolBufferSize, bool purgeFlag, uint64_t purgeLimit) {
+  auto iter = subpools_.find(subPoolBufferSize);
+  if (iter == subpools_.end()) {
+    throwException<std::invalid_argument>(
+        logger_, "Invalid subPoolBufferSize!", KVLOG(KVLOG_PREFIX, subPoolBufferSize));
+  }
+  iter->second->setPurgeState(purgeFlag, purgeLimit);
+}
+
+void MultiSizeBufferPool::reportBufferUsage(char* buffer, uint32_t usageSize) {
+  TimeRecorder scoped_timer(*histograms_.time_in_reportBufferUsage);
+  if (usageSize == 0) {
+    throwException<std::invalid_argument>(logger_, "Invalid resultSize (must be non-zero)!", KVLOG(KVLOG_PREFIX));
+  }
+  if (auto [result, errMsg] = validateBuffer(buffer); !result) {
+    throwException<std::invalid_argument>(logger_, errMsg, KVLOG(KVLOG_PREFIX, (void*)buffer));
+  }
+
+  auto bufferSize = getBufferSize(buffer);
+  auto chunk = bufferToChunk(buffer);
+  getSubPool(bufferSize).reportBufferUsage(chunk, usageSize);
+  subPoolSelector_->reportBufferUsage(bufferSize, usageSize);
+  if (bufferSize >= usageSize) {
+    histograms_.caller_allocated_buffer_size->record(bufferSize);
+    histograms_.caller_allocated_buffer_usage->record(usageSize);
+  }
+}
+
+std::pair<char*, uint32_t> MultiSizeBufferPool::getBufferByMinBufferSize(uint32_t minBufferSize) {
+  TimeRecorder scoped_timer(*histograms_.time_in_getBufferByMinBufferSize);
+
+  // lower_bound returns an iterator to the 1st size in bufferSizes_ which is no less than  requested chunkSize
+  // if not such, it returns last iterator
+  DEBUG_PRINT(logger_, "getBufferByMinBufferSize enter:" << KVLOG(KVLOG_PREFIX));
+  auto lowestSizeToFitIter = bufferSizes_.lower_bound(minBufferSize);
+  if (lowestSizeToFitIter == bufferSizes_.end()) {
+    auto maxSubPoolBufferSize = *bufferSizes_.rbegin();
+    throwException<std::invalid_argument>(
+        logger_, "Invalid requested bufferSize:", KVLOG(KVLOG_PREFIX, minBufferSize, maxSubPoolBufferSize));
+  }
+  auto result = popBuffer(*lowestSizeToFitIter);
+  DEBUG_PRINT(logger_, "getBufferByMinBufferSize exit:" << KVLOG(KVLOG_PREFIX) << stats_);
+  return result;
+}
+
+void MultiSizeBufferPool::doPeriodic() {
+  // This is a timer callback: here the pool reports statistics and evaluate its state (for enabled attributes)
+  std::future<void> purgeFuture, statusReportFuture, histogramsReportFuture, metricsReportFuture;
+  ++periodicCounter_;
+  if ((config_.purgeEvaluationFrequency > 0) && (periodicCounter_ % config_.purgeEvaluationFrequency) == 0) {
+    purgeFuture = std::async(std::launch::async, [this]() {
+      purger_->evaluate(*this);  // TODO , an empty call, nothing passed yet and no API to pool defined.
+    });
+  }
+  if ((config_.statusReportFrequency > 0) && (periodicCounter_ % config_.statusReportFrequency) == 0) {
+    // Report statistics to log
+    statusReportFuture = std::async(std::launch::async, [this]() { this->statusReport(); });
+  }
+  if ((config_.histogramsReportFrequency > 0) && (periodicCounter_ % config_.histogramsReportFrequency) == 0) {
+    // report histograms to log
+    histogramsReportFuture = std::async(std::launch::async, [this]() {
+      auto& registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+      registrar.perf.snapshot(name_);
+      LOG_INFO(logger_, "Histograms report:" << registrar.perf.toString(registrar.perf.get(name_)));
+    });
+  }
+  if ((config_.metricsReportFrequency > 0) && (periodicCounter_ % config_.metricsReportFrequency) == 0) {
+    // update metrics /  update aggregator
+    metricsReportFuture = std::async(std::launch::async, [this]() {
+      metrics_.overallMaxUsedBytes_.Get().Set(stats_.overall_.maxNumAllocatedBytes_);
+      metrics_.currentUsedBytes_.Get().Set(stats_.current_.numUsedBytes_);
+      auto numBufferUsageFailed = stats_.overall_.numBufferUsageFailed_.load();
+      auto numBufferUsageSuccess = stats_.overall_.numBufferUsageSuccess_.load();
+      metrics_.overallUsedBuffersFailure_.Get().Set(numBufferUsageFailed);
+      metrics_.overallUsedBuffersSuccess_.Get().Set(numBufferUsageSuccess);
+      metrics_.overallUsedBuffers_.Get().Set(numBufferUsageFailed + numBufferUsageSuccess);
+      this->metrics_.updateAggregator();
+    });
+  }
+  // All was done by worker threads, now wait for all
+  if (purgeFuture.valid()) purgeFuture.wait();
+  if (statusReportFuture.valid()) statusReportFuture.wait();
+  if (histogramsReportFuture.valid()) histogramsReportFuture.wait();
+  if (metricsReportFuture.valid()) metricsReportFuture.wait();
+}
+
+void MultiSizeBufferPool::statusReport() {
+  if (!config_.enableStatusReportChangesOnly || stats_.reportFlag_) {
+    LOG_INFO(logger_, KVLOG(KVLOG_PREFIX) << " statusReport:" << stats_);
+    stats_.reportFlag_ = false;
+  }
+  for (const auto& [_, sp] : subpools_) {
+    UNUSED(_);
+    sp->statusReport();
+  }
+}
+
+std::pair<bool, std::string> MultiSizeBufferPool::validateBuffer(const char* buffer) {
+  if (!buffer) return {false, "buffer is null"};
+  auto chunk = bufferToChunk(buffer);
+  auto chunkHeader = reinterpret_cast<MultiSizeBufferPool::ChunkHeader*>(chunk);
+  auto chunkTrailer = getChunkTrailer(chunk, chunkHeader->bufferSize_ + chunkMetadataSize());
+  if (chunkHeader->bufferSize_ == 0) return {false, "bufferSize_ is 0"};
+  if (chunkHeader->magicField_ != MultiSizeBufferPool::ChunkHeader::kMagicField)
+    return {false, "invalid header magicField_!"};
+  if (chunkTrailer->magicField_ != MultiSizeBufferPool::ChunkTrailer::kMagicField)
+    return {false, "invalid trailer magicField_!"};
+  return {true, ""};
+}
+
+/* ==========================================
+===
+===     MultiSizeBufferPool::SubPool
+===
+========================================== */
+
+MultiSizeBufferPool::SubPool::SubPool(logging::Logger& logger,
+                                      const SubpoolConfig& config,
+                                      std::string&& name,
+                                      const MultiSizeBufferPool::Config& poolConfig,
+                                      Statistics& poolStats)
+    : chunks_{config.numMaxBuffers},
+      config_{config},
+      purgeFlag_{false},
+      purgeLimit_{},
+      logger_{logger},
+      name_{std::move(name)},
+      chunkSize_(config_.bufferSize + chunkMetadataSize()),
+      stats_{poolConfig.enableStatusReportChangesOnly},
+      poolStats_{poolStats},
+      poolConfig_{poolConfig} {
+  auto throwException_wrapper = [this](const std::string& msg) {
+    concordUtil::throwException<std::invalid_argument>(
+        logger_, msg, KVLOG(KVLOG_PREFIX, config_.bufferSize, config_.numInitialBuffers, config_.numMaxBuffers));
+  };
+  if (config_.bufferSize == 0) {
+    throwException_wrapper("Wrong parameters specified (bufferSize == 0):");
+  }
+  if (config_.numInitialBuffers > config_.numMaxBuffers)
+    throwException_wrapper("Wrong parameters specified (numInitialBuffers > numMaxBuffers):");
+  if ((config_.numInitialBuffers == 0) && (config_.numMaxBuffers == config_.numInitialBuffers))
+    throwException_wrapper("Wrong parameters specified (numInitialBuffers == numMaxBuffers == 0):");
+  stats_.onInit(config_.numMaxBuffers, chunkSize_);
+  stats_.setLimits(poolConfig_.maxAllocatedBytes);
+  poolStats.onInit(config_.numMaxBuffers, chunkSize_);
+  for (size_t i{}; i < config_.numInitialBuffers; ++i) {
+    // Allocate a buffer of size chunkSize_ and store a pointer for the user in the pool
+    const auto result = allocateChunk();
+    ConcordAssertAND(result.first != nullptr, result.second == AllocationStatus::SUCCESS);
+    stats_.onChunkBecomeUnused(chunkSize_, Statistics::operationType::ALLOC);
+    poolStats_.onChunkBecomeUnused(chunkSize_, Statistics::operationType::ALLOC);
+    pushChunk(result.first);
+  }
+  LOG_INFO(logger_, "Done creating Sub-Memory Pool" << KVLOG(KVLOG_PREFIX, chunkSize_) << config_ << stats_);
+}
+
+MultiSizeBufferPool::SubPool::~SubPool() {
+  {
+    std::lock_guard<std::mutex> lock(waitForAvailChunkMutex_);
+    for (SubPool::AllocationResult result = getChunk(false, false); result.first != nullptr;
+         result = getChunk(false, false)) {
+      deleteChunk(result.first);
+    }
+  }
+
+  // important comment: subpool is destroyed. It is the user responsibilty to make sure there are not waiting threads.
+  // If not -assume we have 2 groups of threads. group A is waiting threads (on conditional variable) and B is the
+  // consuming threads which currently user the buffers. B will leak and crash. so no reason to free A. pool is doomed
+  // (it is destroyed now) due to improper use.
+
+  // check for a leak / inconsistency
+  if (stats_.current_.numUnusedChunks_ != 0) {
+    LOG_FATAL(logger_, "numUnusedChunks_ is non-zero!" << KVLOG(KVLOG_PREFIX) << stats_);
+    ConcordAssert(false);
+  }
+  // we can still only leak of no waiting threads, at least warn. Cannot throw here.
+  if (stats_.current_.numAllocatedChunks_ != stats_.current_.numUnusedChunks_) {
+    auto kvlogArgs = KVLOG(stats_.current_.numAllocatedChunks_, stats_.current_.numUnusedChunks_);
+    LOG_ERROR(logger_, "There is probably a memory leak! Not all chunks returned to subpool:" << kvlogArgs);
+  }
+  LOG_DEBUG(logger_, "Subpool destroyed:" << KVLOG(KVLOG_PREFIX, config_.bufferSize));
+}
+
+void MultiSizeBufferPool::SubPool::reportBufferUsage(char* chunk, uint32_t usageSize) {
+  auto* chunkHeader = reinterpret_cast<MultiSizeBufferPool::ChunkHeader*>(chunk);
+  DEBUG_PRINT(logger_, "Report buffer usage:" << KVLOG(KVLOG_PREFIX, chunkHeader->bufferSize_, usageSize));
+  if (usageSize > chunkHeader->bufferSize_) {
+    ++stats_.overall_.numBufferUsageFailed_;
+    ++poolStats_.overall_.numBufferUsageFailed_;
+  } else {
+    ++stats_.overall_.numBufferUsageSuccess_;
+    ++poolStats_.overall_.numBufferUsageSuccess_;
+  }
+}
+
+void MultiSizeBufferPool::SubPool::deleteChunk(char*& chunk) {
+  DEBUG_PRINT(logger_, "deleteChunk enter:" << KVLOG(KVLOG_PREFIX, (void*)chunk));
+  delete[] chunk;
+  stats_.onChunkDeleted(chunkSize_);
+  poolStats_.onChunkDeleted(chunkSize_);
+
+  DEBUG_PRINT(logger_, "deleteChunk exit:" << KVLOG(KVLOG_PREFIX, (void*)chunk) << stats_);
+  chunk = nullptr;
+}
+
+MultiSizeBufferPool::SubPool::AllocationResult MultiSizeBufferPool::SubPool::getChunk(bool wait, bool allocate) {
+  AllocationResult result{nullptr, AllocationStatus::SUCCESS};
+  auto& chunk = result.first;
+  bool chunkAllocatedFromHeap{false};
+
+  DEBUG_PRINT(logger_, "getChunk enter" << KVLOG(KVLOG_PREFIX));
+
+  if (!chunks_.pop(chunk)) {
+    // No available chunks => allocate a new one from the heap, if permitted
+    if (allocate) {
+      // allowed to allocate case:
+      result = allocateChunk();
+      chunkAllocatedFromHeap = (chunk != nullptr);
+    }
+    if (!chunk && wait) {
+      // allowed to wait case:
+      // Pool size limit has been reached: wait until some chunk gets released. The wait is done infinity, until a
+      // chunk is freed by another thread.
+      // why not stop? Since the only simple way to make a thread to go out is by pushing back a chunk.
+      unique_lock<mutex> lock(waitForAvailChunkMutex_);
+      bool isChunkAvailable{false};
+      const auto waitFunc = [&, this]() {
+        isChunkAvailable = chunks_.pop(chunk);
+        return isChunkAvailable;
+      };
+
+      DEBUG_PRINT(logger_, "Wait for chunk:" << KVLOG(KVLOG_PREFIX));
+      waitForAvailChunkCond_.wait(lock, waitFunc);
+      DEBUG_PRINT(logger_, "Done wait for chunk:" << KVLOG(KVLOG_PREFIX));
+    }
+  }
+  if (chunk) {
+    stats_.onChunkBecomeUsed(chunkSize_, chunkAllocatedFromHeap);
+    poolStats_.onChunkBecomeUsed(chunkSize_, chunkAllocatedFromHeap);
+    DEBUG_PRINT(logger_, "Chunk popped for use:" << KVLOG(KVLOG_PREFIX, (void*)chunk) << stats_);
+  }
+  DEBUG_PRINT(logger_, "getChunk exit" << KVLOG(KVLOG_PREFIX));
+  return result;
+}
+
+void MultiSizeBufferPool::SubPool::returnChunk(char* chunk) {
+  DEBUG_PRINT(logger_, "returnChunk enter" << KVLOG(KVLOG_PREFIX));
+  if ((stats_.current_.numUsedChunks_ == 0) || (stats_.current_.numUnusedChunks_ == config_.numMaxBuffers)) {
+    std::stringstream ss;
+    ss << KVLOG(KVLOG_PREFIX, config_.numMaxBuffers, (void*)chunk) << stats_;
+    throwException<std::runtime_error>(logger_, "No more chunks are marked as unused:", ss.str());
+  }
+
+  bool shouldPurge = (purgeFlag_ && (stats_.current_.numAllocatedChunks_ > purgeLimit_));
+  auto opType = shouldPurge ? Statistics::operationType::DELETE : Statistics::operationType::PUSH;
+  stats_.onChunkBecomeUnused(chunkSize_, opType);
+  poolStats_.onChunkBecomeUnused(chunkSize_, opType);
+  // Comment: no locking over numAllocatedChunks_ vs here - worst case - purge a little more
+  if (shouldPurge)
+    deleteChunk(chunk);
+  else
+    pushChunk(chunk);
+  DEBUG_PRINT(logger_, "returnChunk exit" << KVLOG(KVLOG_PREFIX));
+}
+
+void MultiSizeBufferPool::SubPool::pushChunk(char* chunk) {
+  DEBUG_PRINT(logger_, "pushChunk enter" << KVLOG(KVLOG_PREFIX));
+  {
+    std::lock_guard<std::mutex> lock(waitForAvailChunkMutex_);
+    ConcordAssert(chunks_.push(chunk));
+  }
+  DEBUG_PRINT(logger_, "Chunk push:" << KVLOG(KVLOG_PREFIX, (void*)chunk) << stats_);
+  waitForAvailChunkCond_.notify_one();
+  DEBUG_PRINT(logger_, "pushChunk exit" << KVLOG(KVLOG_PREFIX));
+}
+
+std::pair<char*, MultiSizeBufferPool::SubPool::AllocationStatus> MultiSizeBufferPool::SubPool::allocateChunk() {
+  char* chunk = nullptr;
+  const auto& numAllocatedChunks{stats_.current_.numAllocatedChunks_};
+
+  DEBUG_PRINT(logger_, "allocateChunk enter" << KVLOG(KVLOG_PREFIX));
+  if (numAllocatedChunks >= config_.numMaxBuffers) {
+    LOG_WARN(logger_,
+             "The sub-pool size has reached the maximum buffer allocation threshold!"
+                 << KVLOG(KVLOG_PREFIX, numAllocatedChunks) << config_ << stats_);
+    DEBUG_PRINT(logger_, "allocateChunk exit" << KVLOG(KVLOG_PREFIX));
+    return std::make_pair(nullptr, AllocationStatus::EXCEED_MAX_BUFFERS);
+  }
+  if ((poolConfig_.maxAllocatedBytes != 0) &&
+      ((poolStats_.current_.numAllocatedBytes_ + chunkSize_) > poolConfig_.maxAllocatedBytes)) {
+    LOG_WARN(logger_, "allocateChunk exit" << KVLOG(KVLOG_PREFIX));
+    return std::make_pair(nullptr, AllocationStatus::EXCEED_POOL_MAX_BYTES);
+  }
+
+  ConcordAssertGT(chunkSize_, config_.bufferSize);
+  chunk = new char[chunkSize_];
+  new (chunk) MultiSizeBufferPool::ChunkHeader(config_.bufferSize);              // placement new to header
+  new (getChunkTrailer(chunk, chunkSize_)) MultiSizeBufferPool::ChunkTrailer();  // placement new to trailer
+
+  stats_.onChunkAllocated(chunkSize_);
+  poolStats_.onChunkAllocated(chunkSize_);
+  DEBUG_PRINT(logger_, "allocateChunk exit:" << KVLOG(KVLOG_PREFIX, (void*)chunk) << stats_);
+  return std::make_pair(chunk, AllocationStatus::SUCCESS);
+}
+
+void MultiSizeBufferPool::SubPool::statusReport() {
+  if (!poolConfig_.enableStatusReportChangesOnly || stats_.reportFlag_) {
+    LOG_INFO(logger_, KVLOG(KVLOG_PREFIX) << " statusReport: " << stats_);
+    stats_.reportFlag_ = false;
+  }
+}
+
+/* ==========================================
+===
+===     MultiSizeBufferPool::Statistics
+===
+========================================== */
+
+void MultiSizeBufferPool::Statistics::onChunkBecomeUsed(uint64_t chunkSize, bool chunkAllocatedFromHeap) {
+  // Comment: no overflow happens here due to subtraction, removed assertions after billions of runs
+  if (enableStatusReportChangesOnly_) {
+    reportFlag_ = true;
+  }
+  ++current_.numUsedChunks_;
+  ++overall_.numUsedChunks_;
+  if (!chunkAllocatedFromHeap) {
+    --current_.numUnusedChunks_;
+    current_.numUnusedBytes_ -= chunkSize;
+  }
+  current_.numUsedBytes_ += chunkSize;
+  overall_.numUsedBytes_ += chunkSize;
+}
+
+void MultiSizeBufferPool::Statistics::onChunkBecomeUnused(uint64_t chunkSize, operationType opType) {
+  // Comment: no overflow happens here due to subtraction, removed assertions after billions of runs
+  if (enableStatusReportChangesOnly_) {
+    reportFlag_ = true;
+  }
+  if ((opType == operationType::PUSH) || (opType == operationType::DELETE)) {
+    --current_.numUsedChunks_;
+    current_.numUsedBytes_ -= chunkSize;
+  }
+  if ((opType == operationType::PUSH) || (opType == operationType::ALLOC)) {
+    ++current_.numUnusedChunks_;
+    current_.numUnusedBytes_ += chunkSize;
+  }
+}
+
+void MultiSizeBufferPool::Statistics::onChunkAllocated(uint64_t chunkSize) {
+  // Comment: no overflow happens here due to subtraction, removed assertions after billions of runs
+  if (enableStatusReportChangesOnly_) {
+    reportFlag_ = true;
+  }
+  ++current_.numAllocatedChunks_;
+  current_.numAllocatedBytes_ += chunkSize;
+  if (current_.numAllocatedBytes_ > overall_.maxNumAllocatedBytes_) {
+    overall_.maxNumAllocatedBytes_.store(current_.numAllocatedBytes_);
+  }
+  current_.numNonAllocatedBytes_ -= chunkSize;
+  --current_.numNonAllocatedChunks_;
+  if (current_.numAllocatedChunks_ > overall_.maxNumAllocatedChunks_) {
+    overall_.maxNumAllocatedChunks_.store(current_.numAllocatedChunks_);
+  }
+
+  overall_.numAllocatedBytes_ += chunkSize;
+  ++overall_.numAllocatedChunks_;
+}
+
+void MultiSizeBufferPool::Statistics::onChunkDeleted(uint64_t chunkSize) {
+  // Comment: no overflow happens here due to subtraction, removed assertions after billions of runs
+  if (enableStatusReportChangesOnly_) {
+    reportFlag_ = true;
+  }
+  --current_.numAllocatedChunks_;
+  current_.numAllocatedBytes_ -= chunkSize;
+  current_.numNonAllocatedBytes_ += chunkSize;
+  ++current_.numNonAllocatedChunks_;
+
+  overall_.numDeletedBytes_ += chunkSize;
+  ++overall_.numDeletedChunks_;
+}
+
+void MultiSizeBufferPool::Statistics::onInit(uint32_t numMaxBuffers, uint32_t chunkSize) {
+  ConcordAssertNE(chunkSize, 0);
+  current_.numNonAllocatedBytes_ += numMaxBuffers * chunkSize;
+  current_.numNonAllocatedChunks_ += numMaxBuffers;
+}
+
+void MultiSizeBufferPool::Statistics::setLimits(uint64_t maxAllocatedBytes) {
+  if (maxAllocatedBytes == 0) return;
+  if (maxAllocatedBytes < current_.numNonAllocatedBytes_) {
+    current_.numNonAllocatedBytes_ = maxAllocatedBytes;
+  }
+}
+
+}  // namespace concordUtil

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -60,9 +60,9 @@ add_executable(simple_memory_pool_test simple_memory_pool_test.cpp)
 add_test(simple_memory_pool_test simple_memory_pool_test)
 target_link_libraries(simple_memory_pool_test GTest::Main util)
 
-add_executable(RawMemoryPool_test RawMemoryPool_test.cpp)
-add_test(RawMemoryPool_test RawMemoryPool_test)
-target_link_libraries(RawMemoryPool_test GTest::Main util)
+add_executable(MultiSizeBufferPool_test MultiSizeBufferPool_test.cpp)
+add_test(MultiSizeBufferPool_test MultiSizeBufferPool_test)
+target_link_libraries(MultiSizeBufferPool_test GTest::Main util)
 
 add_executable(synchronized_value_test synchronized_value_test.cpp)
 add_test(synchronized_value_test synchronized_value_test)

--- a/util/test/CMakeLists.txt
+++ b/util/test/CMakeLists.txt
@@ -64,6 +64,10 @@ add_executable(MultiSizeBufferPool_test MultiSizeBufferPool_test.cpp)
 add_test(MultiSizeBufferPool_test MultiSizeBufferPool_test)
 target_link_libraries(MultiSizeBufferPool_test GTest::Main util)
 
+add_executable(RawMemoryPool_test RawMemoryPool_test.cpp)
+add_test(RawMemoryPool_test RawMemoryPool_test)
+target_link_libraries(RawMemoryPool_test GTest::Main util)
+
 add_executable(synchronized_value_test synchronized_value_test.cpp)
 add_test(synchronized_value_test synchronized_value_test)
 target_link_libraries(synchronized_value_test GTest::Main util)

--- a/util/test/MultiSizeBufferPool_test.cpp
+++ b/util/test/MultiSizeBufferPool_test.cpp
@@ -1,0 +1,744 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <cstring>
+#include <memory>
+#include <vector>
+#include <future>
+#include <thread>
+#include <chrono>
+
+#include "gtest/gtest.h"
+
+#include "MultiSizeBufferPool.hpp"
+namespace concordUtil::test {
+
+using namespace std;
+using namespace concordUtil;
+using namespace std::chrono_literals;
+
+#define ASSERT_NFF ASSERT_NO_FATAL_FAILURE
+
+// valid subpool configurations
+static const MultiSizeBufferPool::SubpoolConfig subpool_config0{300, 4, 6};
+static const MultiSizeBufferPool::SubpoolConfig subpool_config1{800, 3, 5};
+static const MultiSizeBufferPool::SubpoolConfig subpool_config2{1034, 2, 4};
+static const MultiSizeBufferPool::SubpoolConfig subpool_config3{2048, 1, 5};
+
+// invalid subpool configurations
+static const MultiSizeBufferPool::SubpoolConfig subpool_config100{0, 4, 6};    // bufferSize == 0
+static const MultiSizeBufferPool::SubpoolConfig subpool_config101{300, 6, 4};  // numInitialBuffers > numMaxBuffers
+static const MultiSizeBufferPool::SubpoolConfig subpool_config102{
+    300, 0, 0};  // numInitialBuffers == numMaxBuffers == 0
+
+// pool config
+static const concordUtil::MultiSizeBufferPool::Config pool_config0{// maxAllocatedBytes
+                                                                   10ULL * (1 << 30),
+                                                                   // purgeEvaluationFrequency
+                                                                   0,
+                                                                   // statusReportFrequency
+                                                                   60,
+                                                                   // histogramsReportFrequency
+                                                                   300,
+                                                                   // metricsReportFrequency
+                                                                   5,
+                                                                   // enableStatusReportChangesOnly
+                                                                   false,
+                                                                   // subpoolSelectorEvaluationNumRetriesMinThreshold
+                                                                   3,
+                                                                   // subpoolSelectorEvaluationNumRetriesMaxThreshold
+                                                                   10};
+
+class MultiSizeBufferPoolTestFixture : public ::testing::Test {
+ public:
+ protected:
+  void SetUp() override{};
+  void TearDown() override {
+    if (release_all_buffers_on_teardown && pool_) pushAllBuffers();
+  };
+  void init(const MultiSizeBufferPool::SubpoolsConfig& subpools_config,
+            MultiSizeBufferPool::Config pool_config,
+            std::unique_ptr<MultiSizeBufferPool::ISubpoolSelector>&& subpool_selector = nullptr,
+            std::unique_ptr<MultiSizeBufferPool::IPurger>&& purger = nullptr) {
+    logging::Logger::getInstance("concord.memory.pool").setLogLevel(log4cplus::ERROR_LOG_LEVEL);
+    subpools_config_ = std::make_unique<MultiSizeBufferPool::SubpoolsConfig>(subpools_config);
+    pool_config_ = std::make_unique<MultiSizeBufferPool::Config>(pool_config);
+
+    std::string pool_name = std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + "_pool";
+    pool_ = std::make_unique<MultiSizeBufferPool>(
+        pool_name, timers_, *subpools_config_, *pool_config_, std::move(subpool_selector), std::move(purger));
+    resetAllocatedBuffers();
+  }
+
+  void doPeriodic() { pool_->doPeriodic(); }
+  // requested_buffer_size == 0 then getBufferBySubpoolSelector, else call getBufferByMinBufferSize
+  void popBufferAndValidate(uint32_t requested_buffer_size = 0,
+                            uint32_t expected_buffer_size = 0,
+                            bool expectSuccess = true) {
+    // we rely on the fact that pool will throw if bufferSize is invalid
+    auto [buffer, actual_buffer_size] = (requested_buffer_size == 0)
+                                            ? pool_->getBufferBySubpoolSelector()
+                                            : pool_->getBufferByMinBufferSize(requested_buffer_size);
+    if (expectSuccess) {
+      ASSERT_TRUE(buffer);
+      ASSERT_TRUE(MultiSizeBufferPool::validateBuffer(buffer).first);
+      ASSERT_EQ(actual_buffer_size, MultiSizeBufferPool::getBufferSize(buffer));
+      if (expected_buffer_size > 0) {
+        ASSERT_EQ(actual_buffer_size, expected_buffer_size);
+      }
+      {
+        std::lock_guard g(allocated_buffers_mutex_);
+        auto iter = allocated_buffers_.find(actual_buffer_size);
+        ASSERT_TRUE(iter != allocated_buffers_.end());
+        auto set_iter = iter->second;
+        ASSERT_TRUE(set_iter.find(buffer) == set_iter.end());
+        auto result = allocated_buffers_[actual_buffer_size].insert(buffer);
+        ASSERT_TRUE(result.second);
+      }
+    } else {
+      ASSERT_TRUE(!buffer);
+    }
+  }
+
+  void pushAllBuffers() {
+    std::lock_guard g(allocated_buffers_mutex_);
+    for (auto const& [_, sub_buffers] : allocated_buffers_) {
+      UNUSED(_);
+      for (const auto& buffer : sub_buffers) {
+        pool_->returnBuffer(buffer);
+      }
+    }
+    allocated_buffers_.clear();
+  }
+
+  // if bufferSizeHint != 0, delete from this subpool.
+  void pushArbitraryBuffer(uint32_t bufferSizeHint = 0) {
+    std::lock_guard g(allocated_buffers_mutex_);
+    char* buffer_to_erase{};
+    ASSERT_TRUE(!allocated_buffers_.empty());
+    auto erase_first_buffer_in_buffers = [this, &buffer_to_erase](Buffers& buffers) {
+      buffer_to_erase = *buffers.begin();
+      pool_->returnBuffer(buffer_to_erase);
+      buffers.erase(buffer_to_erase);
+    };
+    if (bufferSizeHint != 0) {
+      auto iter = allocated_buffers_.find(bufferSizeHint);
+      ASSERT_TRUE(iter != allocated_buffers_.end());
+      ASSERT_FALSE(iter->second.empty());
+      erase_first_buffer_in_buffers(iter->second);
+    } else {
+      // bufferSizeHint==0: Just choose 1st non-empty pool
+      for (auto& [_, sub_buffers] : allocated_buffers_) {
+        UNUSED(_);
+        if (!sub_buffers.empty()) {
+          erase_first_buffer_in_buffers(sub_buffers);
+          break;
+        }
+      }
+    }
+    ASSERT_TRUE(buffer_to_erase);
+  }
+
+  void pushSpecificBuffer(char* buffer_to_erase) {
+    std::lock_guard g(allocated_buffers_mutex_);
+    ASSERT_TRUE(buffer_to_erase);
+    auto bufferSize = MultiSizeBufferPool::getBufferSize(buffer_to_erase);
+    pool_->returnBuffer(buffer_to_erase);
+    auto iter = allocated_buffers_.find(bufferSize);
+    ASSERT_TRUE(iter != allocated_buffers_.end());
+    ASSERT_FALSE(iter->second.empty());
+    ASSERT_EQ(iter->second.erase(buffer_to_erase), 1);
+  }
+
+  void stopPool() {
+    for (auto& spIter : pool_->subpools_) {
+      auto& sp = spIter.second;
+      sp->stopFlag_ = true;
+      sp->waitForAvailChunkCond_.notify_all();
+    }
+  }
+
+  MultiSizeBufferPool::ChunkHeader* getBufferHeader(char* buffer) {
+    char* chunk = MultiSizeBufferPool::bufferToChunk(buffer);
+    return reinterpret_cast<MultiSizeBufferPool::ChunkHeader*>(chunk);
+  }
+
+  MultiSizeBufferPool::ChunkTrailer* getBufferTrailer(char* buffer) {
+    char* chunk = MultiSizeBufferPool::bufferToChunk(buffer);
+    auto chunkHeader = reinterpret_cast<MultiSizeBufferPool::ChunkHeader*>(chunk);
+    return MultiSizeBufferPool::getChunkTrailer(chunk,
+                                                chunkHeader->bufferSize_ + MultiSizeBufferPool::chunkMetadataSize());
+  }
+
+  void resetAllocatedBuffers() {
+    std::lock_guard g(allocated_buffers_mutex_);
+    allocated_buffers_.clear();
+    for (const auto& subpool_config : *subpools_config_) {
+      allocated_buffers_.emplace(subpool_config.bufferSize, std::set<char*>());
+    }
+  }
+
+  static uint32_t getChunkMetadataSize() { return MultiSizeBufferPool::chunkMetadataSize(); }
+  const MultiSizeBufferPool::SubPool& getSubPool(uint32_t bufferSize) const { return pool_->getSubPool(bufferSize); }
+  const MultiSizeBufferPool::Statistics& getPoolStats() const { return pool_->stats_; }
+  const MultiSizeBufferPool::Statistics& getSubPoolStats(const MultiSizeBufferPool::SubPool& sp) const {
+    return sp.stats_;
+  }
+
+  // True when all chunks are allocated from heap up to maximum allowed in subpool config, and none are available
+  bool isPoolEmpty() const {
+    for (const auto& [_, subpool] : pool_->subpools_) {
+      UNUSED(_);
+      if (!isSubPoolEmpty(*subpool)) return false;
+    }
+    return true;
+  }
+  bool isSubPoolEmpty(uint32_t bufferSize) const {
+    const auto& sp = pool_->getSubPool(bufferSize);
+    return isSubPoolEmpty(sp);
+  }
+  bool isSubPoolEmpty(const MultiSizeBufferPool::SubPool& sp) const {
+    return (sp.stats_.current_.numUnusedChunks_ == 0);
+  }
+
+  std::unique_ptr<MultiSizeBufferPool::SubpoolsConfig> subpools_config_;
+  std::unique_ptr<MultiSizeBufferPool::Config> pool_config_;
+  std::unique_ptr<MultiSizeBufferPool> pool_;
+  Timers timers_;
+  using Buffers = std::set<char*>;
+  std::map<uint32_t, Buffers> allocated_buffers_;
+  std::mutex allocated_buffers_mutex_;
+  bool release_all_buffers_on_teardown{true};
+  MultiSizeBufferPool::Statistics stats_{true};
+};
+
+TEST_F(MultiSizeBufferPoolTestFixture, Test_Invalid_Input) {
+  // Throw on empty subpools config
+  ASSERT_THROW(init({}, pool_config0), std::invalid_argument);
+
+  // Throw on non ascending subpools config buffer size
+  ASSERT_THROW(init({{subpool_config0, subpool_config1, subpool_config1}}, pool_config0), std::invalid_argument);
+  ASSERT_THROW(init({{subpool_config0, subpool_config2, subpool_config1}}, pool_config0), std::invalid_argument);
+
+  // Throw when bufferSize == 0
+  ASSERT_THROW(init({{subpool_config100}}, pool_config0), std::invalid_argument);
+
+  // Throw when numInitialBuffers > numMaxBuffers
+  ASSERT_THROW(init({{subpool_config101}}, pool_config0), std::invalid_argument);
+
+  // Throw when numInitialBuffers == numMaxBuffers == 0
+  ASSERT_THROW(init({{subpool_config102}}, pool_config0), std::invalid_argument);
+}
+
+// Test enforcement of maxAllocatedBytes
+TEST_F(MultiSizeBufferPoolTestFixture, Test_maxAllocatedBytes) {
+  // This is dirty, but done in a test
+  auto modifiedConfig = pool_config0;
+  auto chunkMetadataSize = getChunkMetadataSize();
+  decltype(modifiedConfig.maxAllocatedBytes) maxAllocatedBytes =
+      (subpool_config0.bufferSize + chunkMetadataSize) + (subpool_config1.bufferSize + chunkMetadataSize);
+  memcpy((void*)&modifiedConfig.maxAllocatedBytes, (void*)&maxAllocatedBytes, sizeof(maxAllocatedBytes));
+  // Make sure that when creating the pool, if initial subpools allocation exceeds maxAllocatedBytes. pool throws.
+  ASSERT_THROW(init({{subpool_config0, subpool_config1}}, modifiedConfig), std::invalid_argument);
+
+  // Now we start with valid initial allocation. Each subpool allows to allocate more chunks than we need, but the
+  // maxAllocatedBytes should block us from allocating more
+
+  // allow no more than what is allowed initially
+  decltype(modifiedConfig.maxAllocatedBytes) maxAllocatedBytes1 =
+      (subpool_config2.bufferSize + chunkMetadataSize) * subpool_config2.numInitialBuffers +
+      (subpool_config3.bufferSize + chunkMetadataSize) * subpool_config3.numInitialBuffers;
+  memcpy((void*)&modifiedConfig.maxAllocatedBytes, (void*)&maxAllocatedBytes1, sizeof(maxAllocatedBytes1));
+  ASSERT_NFF(init({{subpool_config2, subpool_config3}}, modifiedConfig));
+
+  // Get all chunks (use the smaller buffer)
+  const auto& stats = getPoolStats();
+  ASSERT_EQ(stats.current_.numUsedChunks_, 0);
+  for (size_t i{}; i < (subpool_config3.numInitialBuffers + subpool_config2.numInitialBuffers); ++i) {
+    ASSERT_NFF(popBufferAndValidate());
+  }
+
+  // should block - run 2 workers on both pools
+  ASSERT_EQ(stats.current_.numUsedChunks_, 3);
+  auto worker_allocator_future3 =
+      std::async(std::launch::async, [this]() { ASSERT_NFF(popBufferAndValidate(subpool_config3.bufferSize)); });
+  auto worker_allocator_future2 =
+      std::async(std::launch::async, [this]() { ASSERT_NFF(popBufferAndValidate(subpool_config2.bufferSize)); });
+  std::this_thread::sleep_for(100ms);
+  ASSERT_TRUE(worker_allocator_future3.valid());
+  ASSERT_TRUE(worker_allocator_future2.valid());
+  ASSERT_EQ(stats.current_.numUsedChunks_, 3);
+
+  // push one buffer
+  ASSERT_NFF(pushArbitraryBuffer(subpool_config3.bufferSize));
+  worker_allocator_future3.wait();
+  ASSERT_EQ(stats.current_.numUsedChunks_, 3);
+
+  // push another buffer
+  ASSERT_NFF(pushArbitraryBuffer(subpool_config2.bufferSize));
+  worker_allocator_future2.wait();
+  ASSERT_EQ(stats.current_.numUsedChunks_, 3);
+  worker_allocator_future2.get();
+  worker_allocator_future3.get();
+  ASSERT_FALSE(worker_allocator_future3.valid());
+  ASSERT_FALSE(worker_allocator_future2.valid());
+}
+
+// Create and destroy pool
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_Create_Destroy) {
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2}}, pool_config0));
+}
+
+// Test MultiSizeBufferPool::getBufferBySubpoolSelector by allocating a single allocation from each subpool_config
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_getBufferBySubpoolSelector_single_buffer_per_subpool) {
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2}}, pool_config0));
+
+  // Allocate
+  for (const auto& subpool_config : *subpools_config_) {
+    ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+  }
+}
+
+// Validate buffer magic protection on header and trailer
+TEST_F(MultiSizeBufferPoolTestFixture, validate_magic_protection) {
+  // initialize, allocate single buffer
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2}}, pool_config0));
+  ASSERT_NFF(popBufferAndValidate((*subpools_config_)[0].bufferSize));
+  ASSERT_EQ(allocated_buffers_[(*subpools_config_)[0].bufferSize].size(), 1);  // one buffer is allocated
+
+  // Get the header and corrupt it
+  auto* header{getBufferHeader(*allocated_buffers_.begin()->second.begin())};
+  auto magicField = header->magicField_;
+  memset(header, 0, sizeof(header->magicField_));
+
+  // push it back - we expect an exception
+  ASSERT_THROW(pushArbitraryBuffer(), std::invalid_argument);
+
+  // copy back so that test can end without more exceptions
+  memcpy(header, &magicField, sizeof(magicField));
+
+  // now get the trailer and corrupt it
+  auto* trailer{getBufferTrailer(*allocated_buffers_.begin()->second.begin())};
+  magicField = trailer->magicField_;
+  memset(trailer, 0, sizeof(trailer->magicField_));
+
+  // push it back - we expect an exception
+  ASSERT_THROW(pushArbitraryBuffer(), std::invalid_argument);
+
+  // copy back so that test can end without more exceptions
+  memcpy(trailer, &magicField, sizeof(trailer->magicField_));
+}
+
+// Test MultiSizeBufferPool::getBufferBySubpoolSelector by allocating numInitialBuffers from each subpool_config
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_getBufferBySubpoolSelector_numInitialBuffers_buffers_per_subpool) {
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2}}, pool_config0));
+
+  // Allocate
+  for (const auto& subpool_config : *subpools_config_) {
+    for (size_t i{}; i < subpool_config.numInitialBuffers; ++i) {
+      ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    }
+  }
+}
+
+// Test MultiSizeBufferPool::getBufferBySubpoolSelector by allocating numMaxBuffers from each subpool_config
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_getBufferBySubpoolSelector_numMaxBuffers_buffers_per_subpool) {
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2}}, pool_config0));
+
+  // Allocate
+  for (const auto& subpool_config : *subpools_config_) {
+    for (size_t i{}; i < subpool_config.numMaxBuffers; ++i) {
+      ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    }
+  }
+}
+
+// Test MultiSizeBufferPool::getBufferBySubpoolSelector by allocating numMaxBuffers from a single subpool_config, then
+// trying to allocate one more to trigger a wait
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_getBufferBySubpoolSelector_above_numMaxBuffers_buffers_single_subpool) {
+  ASSERT_NFF(init({{subpool_config0}}, pool_config0));
+
+  // Allocate all buffers from pool
+  for (const auto& subpool_config : *subpools_config_) {
+    for (size_t i{}; i < subpool_config.numMaxBuffers; ++i) {
+      ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    }
+  }
+
+  // Pool has no more resources, allocating one more time triggers a wait. To do it on a unittest we must
+  // run in a worker thread
+  auto worker_allocator_future =
+      std::async(std::launch::async, [this]() { ASSERT_NFF(popBufferAndValidate((*subpools_config_)[0].bufferSize)); });
+  ASSERT_TRUE(worker_allocator_future.valid());
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[0].bufferSize));
+  ASSERT_TRUE(isPoolEmpty());
+  ASSERT_EQ(allocated_buffers_[(*subpools_config_)[0].bufferSize].size(), (*subpools_config_)[0].numMaxBuffers);
+
+  // release one buffer and wait for worker thread to allocate successfully
+  ASSERT_NFF(pushArbitraryBuffer());
+  worker_allocator_future.wait();
+}
+
+// Test MultiSizeBufferPool::getBufferBySubpoolSelector by allocating numMaxBuffers from a first subpool_config, then
+// trying to allocate one more to get from the larger subpool
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_getBufferBySubpoolSelector_get_from_next_subpool) {
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2}}, pool_config0));
+
+  // Allocate  buffers from sub pool 0
+  for (size_t i{}; i < (*subpools_config_)[0].numMaxBuffers; ++i) {
+    ASSERT_NFF(popBufferAndValidate((*subpools_config_)[0].bufferSize));
+  }
+
+  // subpool has no more resources, so it should allocate one more from the next subpool
+  ASSERT_NFF(popBufferAndValidate((*subpools_config_)[0].bufferSize, (*subpools_config_)[1].bufferSize));
+}
+
+// Test MultiSizeBufferPool::getBufferBySubpoolSelector by allocating numMaxBuffers on all subpools, then trying to
+// allocate a buffer on the smallest sized pool. Thead will wait for a buffer, then we release a buffer on that subpool
+// and see that allocation from the smallest pool succeed.
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_getBufferBySubpoolSelector_Check_all_subpools_and_wait_for_original) {
+  ASSERT_NFF(init({{subpool_config0, subpool_config1, subpool_config2, subpool_config3}}, pool_config0));
+
+  // Allocate all buffers on all subpools
+  for (const auto& subpool_config : (*subpools_config_)) {
+    for (size_t i{}; i < subpool_config.numMaxBuffers; ++i) {
+      ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    }
+  }
+  // pool should be empty
+  ASSERT_TRUE(isPoolEmpty());
+
+  // Pool has no more resources, allocating one more time triggers a wait. To do it on a unittest we must
+  // run in a worker thread
+  auto worker_allocator_future =
+      std::async(std::launch::async, [this]() { ASSERT_NFF(popBufferAndValidate((*subpools_config_)[0].bufferSize)); });
+  ASSERT_TRUE(worker_allocator_future.valid());
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[0].bufferSize));
+
+  // release one buffer from the minimal pool and wait for worker thread to allocate successfully
+  ASSERT_TRUE(isPoolEmpty());
+  ASSERT_NFF(pushArbitraryBuffer((*subpools_config_)[0].bufferSize));
+  worker_allocator_future.wait();
+
+  // Pool should be still empty
+  ASSERT_TRUE(isPoolEmpty());
+}
+
+// Test pool when creating a pool an external subpool_config selector. Here we will implement a maximum buffer size
+// selector.
+TEST_F(MultiSizeBufferPoolTestFixture, test_external_subpool_selector) {
+  class MaximalSizeSubpoolSelector : public MultiSizeBufferPool::ISubpoolSelector {
+   public:
+    MaximalSizeSubpoolSelector(const MultiSizeBufferPool::SubpoolsConfig& subpools_config)
+        : MultiSizeBufferPool::ISubpoolSelector(subpools_config) {}
+    const MultiSizeBufferPool::SubpoolConfig& selectSubpool() const override { return config_.back(); }
+    std::string_view name() const override { return "MaximalSizeSubpoolSelector"; }
+    void reportBufferUsage(uint32_t subpoolSize, uint32_t actualRequiredSize) override{};
+  };
+
+  // pool with 3 subpools config, pass the custom selector
+  MultiSizeBufferPool::SubpoolsConfig subpools_config{{subpool_config0, subpool_config1, subpool_config2}};
+  ASSERT_NFF(init(subpools_config, pool_config0, std::make_unique<MaximalSizeSubpoolSelector>(subpools_config)));
+
+  // allocate all buffers with max subpool_config selector
+  for (size_t i{}; i < (*subpools_config_)[2].numMaxBuffers; ++i) {
+    ASSERT_NFF(popBufferAndValidate(0, (*subpools_config_)[2].bufferSize, true));
+  }
+
+  // allocate 1 buffer by minimal size from other subpools config
+  for (const auto& subpool_config : (*subpools_config_)) {
+    if ((*subpools_config_)[2].bufferSize == subpool_config.bufferSize) continue;
+    ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize, subpool_config.bufferSize, true));
+  }
+
+  // Try to allocate one more buffer by subpool_config selector. This should cause wait on worker thread.
+  auto worker_allocator_future = std::async(
+      std::launch::async, [this]() { ASSERT_NFF(popBufferAndValidate(0, (*subpools_config_)[2].bufferSize)); });
+  ASSERT_TRUE(worker_allocator_future.valid());
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[2].bufferSize));
+
+  // release the buffer
+  ASSERT_NFF(pushArbitraryBuffer((*subpools_config_)[2].bufferSize));
+  worker_allocator_future.wait();
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[2].bufferSize));
+}
+
+class MultiSizeBufferPoolParametrizedTestFixture1
+    : public MultiSizeBufferPoolTestFixture,
+      public testing::WithParamInterface<MultiSizeBufferPool::SubpoolsConfig> {};
+
+TEST_P(MultiSizeBufferPoolParametrizedTestFixture1, validate_statistics_parametrized) {
+  auto subpools_config = GetParam();
+  auto chunkMetadataSize = getChunkMetadataSize();
+  ASSERT_NFF(init(subpools_config, pool_config0));
+
+  auto& o = stats_.overall_;  // local overall stats marked as o
+  auto& c = stats_.current_;  // local current stats marked as o
+
+  // validate initial number of chunks
+  for (const auto& subpool_config : subpools_config) {
+    const auto& sp = getSubPool(subpool_config.bufferSize);
+    const auto& spStats = getSubPoolStats(sp);
+    const auto& current_stats = spStats.current_;
+    ASSERT_EQ(current_stats.numAllocatedChunks_, subpool_config.numInitialBuffers);
+    ASSERT_EQ(current_stats.numNonAllocatedChunks_, subpool_config.numMaxBuffers - subpool_config.numInitialBuffers);
+    ASSERT_EQ(current_stats.numUsedChunks_, 0);
+    ASSERT_EQ(current_stats.numUnusedChunks_, current_stats.numAllocatedChunks_);
+    c.numAllocatedChunks_ += current_stats.numAllocatedChunks_;
+    c.numNonAllocatedChunks_ += current_stats.numNonAllocatedChunks_;
+    c.numUsedChunks_ += current_stats.numUsedChunks_;
+    c.numUnusedChunks_ += current_stats.numUnusedChunks_;
+    c.numAllocatedBytes_ += current_stats.numAllocatedChunks_ * (chunkMetadataSize + subpool_config.bufferSize);
+  }
+  o.numAllocatedBytes_.store(c.numAllocatedBytes_);
+  o.numAllocatedChunks_.store(c.numAllocatedChunks_);
+
+  // validate initial pool statistics vs subpools
+  const auto& target_pool_stats = getPoolStats();
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedChunks_, c.numAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numNonAllocatedChunks_, c.numNonAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numUsedChunks_, c.numUsedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numUnusedChunks_, c.numUnusedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedBytes_, c.numAllocatedBytes_);
+
+  // validate overalls
+  ASSERT_EQ(o.numAllocatedBytes_, target_pool_stats.overall_.numAllocatedBytes_);
+  ASSERT_EQ(o.numAllocatedChunks_, target_pool_stats.overall_.numAllocatedChunks_);
+  ASSERT_EQ(o.numDeletedBytes_, target_pool_stats.overall_.numDeletedBytes_);
+  ASSERT_EQ(o.numUsedBytes_, target_pool_stats.overall_.numUsedBytes_);
+  ASSERT_EQ(o.numDeletedChunks_, target_pool_stats.overall_.numDeletedChunks_);
+  ASSERT_EQ(o.numUsedChunks_, target_pool_stats.overall_.numUsedChunks_);
+
+  // Allocated maximum chunks from each subpool and validate again.
+  // None of the single allocations should trigger an allocation from heap
+  c.numAllocatedChunks_ = 0;
+  c.numNonAllocatedChunks_ = 0;
+  c.numUnusedChunks_ = 0;
+  c.numAllocatedBytes_ = 0;
+  c.numAllocatedChunks_ = 0;
+  for (const auto& subpool_config : subpools_config) {
+    const auto& sp = getSubPool(subpool_config.bufferSize);
+    const auto& spStats = getSubPoolStats(sp);
+    const auto& current_stats = spStats.current_;
+    for (size_t i{}; i < subpool_config.numMaxBuffers; ++i) {
+      ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    }
+    ASSERT_EQ(current_stats.numAllocatedChunks_, subpool_config.numMaxBuffers);
+    ASSERT_EQ(current_stats.numNonAllocatedChunks_, 0);
+    ASSERT_EQ(current_stats.numUsedChunks_, subpool_config.numMaxBuffers);
+    ASSERT_EQ(current_stats.numUnusedChunks_, 0);
+    c.numAllocatedChunks_ += subpool_config.numMaxBuffers;
+    c.numUsedChunks_ += subpool_config.numMaxBuffers;
+    c.numAllocatedBytes_ += subpool_config.numMaxBuffers * (subpool_config.bufferSize + chunkMetadataSize);
+  }
+  o.numAllocatedBytes_.store(target_pool_stats.current_.numAllocatedBytes_);
+  o.numAllocatedChunks_.store(target_pool_stats.current_.numAllocatedChunks_);
+  o.numUsedBytes_.store(target_pool_stats.current_.numUsedBytes_);
+  o.numUsedChunks_.store(target_pool_stats.current_.numUsedChunks_);
+
+  // validate initial pool statistics vs subpools
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedChunks_, c.numAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numNonAllocatedChunks_, c.numNonAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numUsedChunks_, c.numUsedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numUnusedChunks_, c.numUnusedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedBytes_, c.numAllocatedBytes_);
+
+  // validate numUsedBytes
+  for (const auto& [bufferSize, buffers] : allocated_buffers_) {
+    c.numUsedBytes_ += buffers.size() * (bufferSize + chunkMetadataSize);
+  }
+  ASSERT_EQ(target_pool_stats.current_.numUsedBytes_, c.numUsedBytes_);
+
+  // return all buffers and validate again
+  for (auto const& [_, sub_buffers] : allocated_buffers_) {
+    UNUSED(_);
+    for (const auto& buffer : sub_buffers) {
+      pool_->returnBuffer(buffer);
+      --c.numUsedChunks_;
+      ++c.numUnusedChunks_;
+    }
+  }
+  resetAllocatedBuffers();
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedChunks_, c.numAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numNonAllocatedChunks_, c.numNonAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numUsedChunks_, c.numUsedChunks_);
+  ASSERT_EQ(target_pool_stats.current_.numUnusedChunks_, c.numUnusedChunks_);
+
+  // allocate 1 buffer from each subpool, then check overall statistics
+  for (const auto& subpool_config : subpools_config) {
+    ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    o.numUsedBytes_ += subpool_config.bufferSize + chunkMetadataSize;
+    ++o.numUsedChunks_;
+  }
+  ASSERT_EQ(target_pool_stats.overall_.numAllocatedBytes_, o.numAllocatedBytes_);
+  ASSERT_EQ(target_pool_stats.overall_.numDeletedBytes_, o.numDeletedBytes_);
+  ASSERT_EQ(target_pool_stats.overall_.numUsedBytes_, o.numUsedBytes_);
+  ASSERT_EQ(target_pool_stats.overall_.numAllocatedChunks_, o.numAllocatedChunks_);
+  ASSERT_EQ(target_pool_stats.overall_.numDeletedChunks_, o.numDeletedChunks_);
+  ASSERT_EQ(target_pool_stats.overall_.numUsedChunks_, o.numUsedChunks_);
+
+  // check report on failure: report that client actually needed x2 of buffer size and validate counter goes up
+  ASSERT_EQ(target_pool_stats.overall_.numBufferUsageFailed_, 0);
+  for (size_t i{}; i < 3; ++i) {
+    auto buffer = *allocated_buffers_.begin()->second.begin();
+    auto header = getBufferHeader(buffer);
+    ASSERT_NFF(pool_->reportBufferUsage(*allocated_buffers_.begin()->second.begin(), header->bufferSize_ * 2));
+  }
+  ASSERT_EQ(target_pool_stats.overall_.numBufferUsageFailed_, 3);
+}
+
+INSTANTIATE_TEST_CASE_P(validate_statistics_parametrized,
+                        MultiSizeBufferPoolParametrizedTestFixture1,
+                        ::testing::Values(MultiSizeBufferPool::SubpoolsConfig{{300, 3, 3}},
+                                          MultiSizeBufferPool::SubpoolsConfig{{300, 1, 3}},
+                                          MultiSizeBufferPool::SubpoolsConfig{{300, 2, 6}, {400, 4, 6}}), );
+
+// with a single subpool, take all buffers and then wait with numMaxBuffers threads. See that every time a single
+// buffer is returned, 1 waiting thread is freed and taking the returned buffer.
+TEST_F(MultiSizeBufferPoolTestFixture, test_multithreading1) {
+  ASSERT_NFF(init({{subpool_config0}}, pool_config0));
+
+  // allocate all buffers
+  for (size_t i{}; i < (*subpools_config_)[0].numMaxBuffers; ++i) {
+    ASSERT_NFF(popBufferAndValidate(0, (*subpools_config_)[0].bufferSize, true));
+  }
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[0].bufferSize));
+  ASSERT_TRUE(isPoolEmpty());
+
+  std::vector<std::future<void>> workers_futures;
+  std::atomic_size_t counter{};
+  // Try to pop, worker threads should get "stuck" on an infinite wait
+  for (size_t i{}; i < (*subpools_config_)[0].numMaxBuffers; ++i) {
+    auto f = std::async(std::launch::async, [&, this]() {
+      ASSERT_NFF(popBufferAndValidate(0, (*subpools_config_)[0].bufferSize, true));
+      ++counter;
+    });
+    ASSERT_TRUE(f.valid());
+    workers_futures.push_back(std::move(f));
+  }
+
+  // Wait some for worker threads to reach infinite wait, then start releasing buffers
+  std::this_thread::sleep_for(100ms);
+  ASSERT_EQ(counter, 0);
+  for (size_t i{}; i < (*subpools_config_)[0].numMaxBuffers; ++i) {
+    ASSERT_NFF(pushArbitraryBuffer());
+  }
+  // wait for all to finish
+  for (const auto& f : workers_futures) {
+    f.wait();
+  }
+  ASSERT_EQ(counter, (*subpools_config_)[0].numMaxBuffers);
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[0].bufferSize));
+  ASSERT_TRUE(isPoolEmpty());
+}
+
+// Similar to test_multithreading1,but check that all threads go out when pool is destroyed
+TEST_F(MultiSizeBufferPoolTestFixture, test_multithreading2) {
+  ASSERT_NFF(init({{subpool_config0}}, pool_config0));
+
+  // allocate all buffers
+  for (size_t i{}; i < (*subpools_config_)[0].numMaxBuffers; ++i) {
+    ASSERT_NFF(popBufferAndValidate(0, (*subpools_config_)[0].bufferSize, true));
+  }
+  ASSERT_TRUE(isSubPoolEmpty((*subpools_config_)[0].bufferSize));
+  ASSERT_TRUE(isPoolEmpty());
+
+  std::vector<std::future<void>> workers_futures;
+  std::atomic_size_t counter{};
+  // Try to pop, worker threads should get blocked, but eventually get a buffer when another thread frees one
+  for (size_t i{}; i < (*subpools_config_)[0].numMaxBuffers; ++i) {
+    auto f = std::async(std::launch::async, [&, this]() {
+      auto [buffer, actual_buffer_size] = pool_->getBufferBySubpoolSelector();
+      (void)actual_buffer_size;
+      ASSERT_TRUE(buffer);
+      ++counter;
+    });
+    ASSERT_TRUE(f.valid());
+    workers_futures.push_back(std::move(f));
+  }
+
+  // Wait some for worker threads to reach infinite wait, then push back all chunks to see that they are all out and
+  // pull is not empty
+  ASSERT_TRUE(isPoolEmpty());
+  ASSERT_NFF(pushAllBuffers());
+  for (const auto& f : workers_futures) {
+    f.wait();
+  }
+  std::this_thread::sleep_for(100ms);
+  ASSERT_EQ(counter, (*subpools_config_)[0].numMaxBuffers);
+  ASSERT_TRUE(isPoolEmpty());
+}
+
+// Test external purger passed on constructor
+TEST_F(MultiSizeBufferPoolTestFixture, Subpool_test_external_purger) {
+  class BrutalPoolPurger : public MultiSizeBufferPool::IPurger {
+   public:
+    std::string_view name() const override { return "BrutalPoolPurger"; }
+    virtual void evaluate(MultiSizeBufferPool& pool) override {
+      const auto& subpoolsBufferSizes = pool.getSubpoolsBufferSizes();
+      for (const auto& buffersize : subpoolsBufferSizes) pool.setPurgeState(buffersize, true, 0);
+    }
+  };
+
+  auto modifiedConfig = pool_config0;
+  decltype(modifiedConfig.purgeEvaluationFrequency) purgeEvaluationFrequency = 1;  // every second evaluate
+  memcpy((void*)&modifiedConfig.purgeEvaluationFrequency,
+         (void*)&purgeEvaluationFrequency,
+         sizeof(purgeEvaluationFrequency));
+
+  // pool with 3 subpools config, pass the custom selector
+  MultiSizeBufferPool::SubpoolsConfig subpools_config{{subpool_config0, subpool_config1, subpool_config2}};
+  ASSERT_NFF(init(subpools_config, modifiedConfig, nullptr, std::make_unique<BrutalPoolPurger>()));
+
+  // Allocate all buffers on all subpools
+  ASSERT_FALSE(isPoolEmpty());
+  for (const auto& subpool_config : (*subpools_config_)) {
+    for (size_t i{}; i < subpool_config.numMaxBuffers; ++i) {
+      ASSERT_NFF(popBufferAndValidate(subpool_config.bufferSize));
+    }
+  }
+
+  // trigger purger, then return all buffers. Pool should deallocate and become empty.
+  // Check statistics as well
+  ASSERT_NFF(doPeriodic());
+  ASSERT_NFF(pushAllBuffers());
+  ASSERT_TRUE(isPoolEmpty());
+
+  auto chunkMetadataSize = getChunkMetadataSize();
+  auto totalBytes = subpool_config0.numMaxBuffers * (subpool_config0.bufferSize + chunkMetadataSize) +
+                    subpool_config1.numMaxBuffers * (subpool_config1.bufferSize + chunkMetadataSize) +
+                    subpool_config2.numMaxBuffers * (subpool_config2.bufferSize + chunkMetadataSize);
+  auto totalChunks = subpool_config0.numMaxBuffers + subpool_config1.numMaxBuffers + subpool_config2.numMaxBuffers;
+  const auto& target_pool_stats = getPoolStats();
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedBytes_, 0);
+  ASSERT_EQ(target_pool_stats.current_.numNonAllocatedBytes_, totalBytes);
+  ASSERT_EQ(target_pool_stats.current_.numUsedBytes_, 0);
+  ASSERT_EQ(target_pool_stats.current_.numUnusedBytes_, 0);
+  ASSERT_EQ(target_pool_stats.current_.numAllocatedChunks_, 0);
+  ASSERT_EQ(target_pool_stats.current_.numNonAllocatedChunks_, totalChunks);
+  ASSERT_EQ(target_pool_stats.current_.numUsedChunks_, 0);
+  ASSERT_EQ(target_pool_stats.current_.numUnusedChunks_, 0);
+  ASSERT_EQ(target_pool_stats.overall_.numDeletedBytes_, totalBytes);
+  ASSERT_EQ(target_pool_stats.overall_.numDeletedChunks_, totalChunks);
+}
+
+}  // namespace concordUtil::test
+
+int main(int argc, char** argv) {
+  srand(time(NULL));
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style =
+      "threadsafe";  // mitigate the risks of testing in a possibly multithreaded environment
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
* **Problem Overview** *
1)
Introducing new Multi size buffer Pool for the pre-processor. Can be used as a utility. This pool allowes to save memory by choosing the right expected buffer and retrying in a rare case of failure. Most results in our system areless than 64K (99% of cases), so this is the 1st choice.
For more details - see MultiSizeBufferPool.hpp header.

2)
In addition, support for RawMemoryPool is kept: it is possible to choose which pool to use, or choose not to use any pool with the new parameter preProcessorMemoryPoolMode.

3) Fix il formed performance handler API. isRegisteredComponent doesn't make sense to have - since this is a time-of-check time-of-use issue (we are a multithreaded system). so I removed this API. The functions to register/unregister components should be  best effort. Nothing bad happens if I try to register/unregister the same component multiple times. so what? Tons of standard library APIs are defined like this. Example: set::insert, or unique_ptr::reset and the list is very long. No need to crash on this.


* **Testing Done**  
Added unuttests in MultiSizeBufferPool_test.cpp
Did leak checks.
Did Maestro LRT runs chess_plus and Freetrade.
 
no auto-bump