### PR TITLE
Install gmp library as utt dependency after it was removed from concord-crypto as relic library dependency

### DIFF
--- a/utt/dependencies.cmake
+++ b/utt/dependencies.cmake
@@ -10,6 +10,27 @@ ProcessorCount(NPROC)
 set(THIRDPARTY_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR})
 file(MAKE_DIRECTORY ${THIRDPARTY_INSTALL_DIR}/include)
 
+ExternalProject_Add(libgmp
+                    PREFIX libgmp
+                    URL "https://gmplib.org/download/gmp/gmp-6.1.2.tar.lz"
+                    CONFIGURE_COMMAND ./configure --with-pic 
+                                                  --enable-cxx 
+                                                  --disable-fat
+                                                  --disable-shared
+                                                  --build x86_64-linux-gnu 
+                                                  --prefix=${THIRDPARTY_INSTALL_DIR}
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -j${NPROC}
+                    BUILD_IN_SOURCE 1
+                    LOG_DOWNLOAD 1
+                    LOG_BUILD 1
+)
+
+set(GMP_INCLUDE_DIR ${THIRDPARTY_INSTALL_DIR}/include)
+set(GMP_LIBRARY   ${THIRDPARTY_INSTALL_DIR}/lib/libgmp.a )
+set(GMPXX_LIBRARY ${THIRDPARTY_INSTALL_DIR}/lib/libgmpxx.a )
+message(STATUS "GMP_INCLUDE_DIR ${GMP_INCLUDE_DIR}")
+message(STATUS "GMP_LIBRARY ${GMP_LIBRARY}")
+message(STATUS "GMPXX_LIBRARY ${GMPXX_LIBRARY}")
 
 ExternalProject_Add(libsodium
                     PREFIX libsodium
@@ -24,12 +45,15 @@ ExternalProject_Add(libsodium
 ExternalProject_Add(ntl
                     PREFIX ntl
                     URL "https://libntl.org/ntl-11.5.1.tar.gz"
-                    CONFIGURE_COMMAND cd src && ./configure NTL_THREADS=off PREFIX=${THIRDPARTY_INSTALL_DIR}
+                    CONFIGURE_COMMAND cd src && ./configure NTL_THREADS=off 
+                                                            PREFIX=${THIRDPARTY_INSTALL_DIR}
+                                                            GMP_PREFIX=${THIRDPARTY_INSTALL_DIR}
                     BUILD_IN_SOURCE 1
                     LOG_DOWNLOAD 1
                     LOG_BUILD 1
                     BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C src -j${NPROC}
                     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} -C src install
+                    DEPENDS libgmp
 )
 set(NTL_INCLUDE_DIR ${THIRDPARTY_INSTALL_DIR}/include)
 set(NTL_LIBRARY ${THIRDPARTY_INSTALL_DIR}/lib/libntl.a)
@@ -42,13 +66,17 @@ ExternalProject_Add(ate_pairing
                     GIT_REPOSITORY "https://github.com/herumi/ate-pairing.git"
                     GIT_TAG "530223d7502e95f6141be19addf1e24d27a14d50"
                     CONFIGURE_COMMAND ""
-                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} -C src -j${NPROC} DBG=on SUPPORT_SNARK=1 
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} VERBOSE=1 -C src -j${NPROC} DBG=on
+                                                                                    SUPPORT_SNARK=1 
+                                                                                    INC_DIR=-I${THIRDPARTY_INSTALL_DIR}/include\ -I../include
+                                                                                    LIB_DIR=${THIRDPARTY_INSTALL_DIR}/lib
                     BUILD_IN_SOURCE 1
                     LOG_DOWNLOAD 1
                     LOG_BUILD 1
                     INSTALL_COMMAND install -p -D -t ${THIRDPARTY_INSTALL_DIR}/include/ate-pairing/include 
                                                   include/bn.h include/zm.h include/zm2.h &&
                                     install -p -D -t ${THIRDPARTY_INSTALL_DIR}/lib lib/libzm.a
+                    DEPENDS libgmp
 )
 
 set(ZM_INCLUDE_DIR ${THIRDPARTY_INSTALL_DIR}/include)


### PR DESCRIPTION

Install gmp library as utt dependency after it was removed from concord-crypto as relic library dependency