### PR TITLE
Fix key exchange crash with f+1 replicas down

### DIFF
--- a/bftengine/include/bftengine/KeyExchangeManager.hpp
+++ b/bftengine/include/bftengine/KeyExchangeManager.hpp
@@ -219,6 +219,8 @@ class KeyExchangeManager {
   IClientPublicKeyStore* clientPublicKeyStore_{nullptr};
   bool publishedMasterKey = false;
   std::mutex startup_mutex_;
+  // map to store seqNum and its candidate key
+  std::map<SeqNum, PrivateKeys::KeyData> seq_candidate_map_;
 
   struct Metrics {
     std::chrono::seconds lastMetricsDumpTime;


### PR DESCRIPTION
* **Problem Overview**  
  Replica crashes with assert 
  2023-01-27T09:53:52,064,+0000|FATAL|1|concord.bft|message-processing||17|0|slow|KeyExchangeManager.cpp:104| Assert: expression 'private_keys_.key_data().generated.pub == kemsg.pubkey' is false in function onKeyExchange (/concord/submodules/concord-bft/bftengine/src/bftengine/KeyExchangeManager.cpp 104) | [SQ:998]

The source replica(where key-exchange is performed) generates candidate key for sequence numbers on receiving key-exchange command. As f+1 replicas are down, the multiple key-exchange commands are sent from operator, candidate key gets generated for multiple seq numbers but not executed. When other replicas are up, the flow reaches to onKeyExchange, the first sequence number gets executed and candidate keys are cleared. The next sequence number does not have candidate keys, causing the crash.

Fix:
Whenever new candidate keys are generated for a sequence number, we are storing seqnum->candidate key pair in map.
For each execution of sequence number, we are clearing it from the map. In this way we always have a candidate key for the sequence number.

* **Testing Done**  
  Manually tested on build 0.0.1.0.1662.
  Hermes CI passed.
  Verified by ST Team
