### PR TITLE
Fix gmp linker issues

### DIFF
--- a/utt/libutt/src/CMakeLists.txt
+++ b/utt/libutt/src/CMakeLists.txt
@@ -52,7 +52,7 @@ if(APPLE)
     )
 else()
     target_link_libraries(utt PUBLIC
-        ${NTL_LIBRARY} ${LIBFF_LIBRARY} pthread ${ZM_LIBRARY} gmp gmpxx xutils xassert stdc++fs OpenSSL::Crypto z
+    ${NTL_LIBRARY} ${LIBFF_LIBRARY} pthread ${ZM_LIBRARY} ${GMPXX_LIBRARY} ${GMP_LIBRARY} xutils xassert stdc++fs OpenSSL::Crypto z
     )
 endif()
 


### PR DESCRIPTION
Once we have the image with **make build-docker-images**, the make build build command failed due to linker issues. 
After Installing gmp library as utt dependency, there are below linker errors:
```
[ 51%] Linking CXX executable ../bin/test/TestCoin
/usr/bin/ld: cannot find -lgmp
/usr/bin/ld: cannot find -lgmpxx
clang: error: linker command failed with exit code 1 (use -v to see invocation)
utt/libutt/test/CMakeFiles/TestCoin.dir/build.make:108: recipe for target 'utt/libutt/bin/test/TestCoin' failed
make[2]: *** [utt/libutt/bin/test/TestCoin] Error 1
CMakeFiles/Makefile2:8481: recipe for target 'utt/libutt/test/CMakeFiles/TestCoin.dir/all' failed
make[1]: *** [utt/libutt/test/CMakeFiles/TestCoin.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

Updating utt cmakelist fixed the issues.

Testing:
Tested manually building docker-images