### PR TITLE
Optimize digest calculation in pruning callback

### DIFF
--- a/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
+++ b/bftengine/include/bcstatetransfer/SimpleBCStateTransfer.hpp
@@ -38,7 +38,6 @@ namespace bftEngine {
 // can also handle a limited amount of arbitrary mutable state (which is
 // represented as a small set of fixed size pages).
 namespace bcst {
-
 // Each block is required to store the digest of the previous block (this digest
 // is used by the state transfer to safely transfer blocks among the replicas).
 // The application/storage layer is responsible to store the digests in the
@@ -99,6 +98,7 @@ class IAppState {
   virtual void getPrevDigestFromBlock(const char *blockData,
                                       const uint32_t blockSize,
                                       StateTransferDigest *outPrevBlockDigest) const = 0;
+  virtual std::future<std::optional<concord::crypto::BlockDigest>> getPrevDigestFromBlockAsync(uint64_t block_id) = 0;
 
   // Add a block
   // blockId   - the block number

--- a/bftengine/src/bcstatetransfer/RVBManager.hpp
+++ b/bftengine/src/bcstatetransfer/RVBManager.hpp
@@ -70,7 +70,7 @@ class RVBManager {
  public:
   // Init / Destroy functions
   RVBManager() = delete;
-  RVBManager(const Config& config, const IAppState* state_api, const std::shared_ptr<DataStore>& ds);
+  RVBManager(const Config& config, IAppState* const state_api, const std::shared_ptr<DataStore>& ds);
   void init(bool fetching);
 
   // Update the RVB data (up to last_checkpoint_desc.maBlockId) according to recent checkpoint  storage updates (added
@@ -151,7 +151,7 @@ class RVBManager {
 
   // config, storage and data store
   const Config& config_;
-  const IAppState* as_;
+  IAppState* const as_;
   const std::shared_ptr<DataStore>& ds_;
 
   // RVB data (during ST as destination)

--- a/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
+++ b/bftengine/src/simplestatetransfer/SimpleStateTran.cpp
@@ -31,7 +31,6 @@ namespace bftEngine {
 namespace SimpleInMemoryStateTransfer {
 
 namespace impl {
-
 logging::Logger STLogger = logging::getLogger("state-transfer");
 
 class SimpleStateTran : public ISimpleInMemoryStateTransfer {
@@ -127,6 +126,7 @@ class SimpleStateTran : public ISimpleInMemoryStateTransfer {
     void getPrevDigestFromBlock(const char* blockData,
                                 const uint32_t blockSize,
                                 bcst::StateTransferDigest* outPrevBlockDigest) const override;
+    std::future<std::optional<concord::crypto::BlockDigest>> getPrevDigestFromBlockAsync(uint64_t block_id) override;
 
     bool putBlock(const uint64_t blockId, const char* block, const uint32_t blockSize, bool lastBlock = true) override;
 
@@ -455,7 +455,7 @@ void SimpleStateTran::createCheckpointOfCurrentState(uint64_t checkpointNumber) 
   lastKnownCheckpoint = checkpointNumber;
 
   //  map from a metadata page to its set of updated app pages
-  std::map<uint32_t, std::set<uint32_t> > pagesMap;
+  std::map<uint32_t, std::set<uint32_t>> pagesMap;
 
   for (uint32_t appPage : updateAppPages_) {
     uint32_t mPage = findMetadataPageOfAppPage(appPage);
@@ -653,6 +653,12 @@ void SimpleStateTran::DummyBDState::getPrevDigestFromBlock(const char* blockData
                                                            const uint32_t blockSize,
                                                            bcst::StateTransferDigest* outPrevBlockDigest) const {
   ConcordAssert(false);
+}
+
+std::future<std::optional<concord::crypto::BlockDigest>> SimpleStateTran::DummyBDState::getPrevDigestFromBlockAsync(
+    uint64_t block_id) {
+  ConcordAssert(false);
+  return std::async([]() { return std::optional<concord::crypto::BlockDigest>{}; });
 }
 
 bool SimpleStateTran::DummyBDState::putBlock(const uint64_t blockId,

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -116,6 +116,8 @@ class Replica : public IReplica,
   void getPrevDigestFromBlock(const char *blockData,
                               const uint32_t blockSize,
                               bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override final;
+  std::future<std::optional<concord::crypto::BlockDigest>> getPrevDigestFromBlockAsync(BlockId block_id) override;
+
   bool putBlock(const uint64_t blockId,
                 const char *blockData,
                 const uint32_t blockSize,
@@ -260,6 +262,7 @@ class Replica : public IReplica,
   std::unique_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> creEngine_;
   std::shared_ptr<concord::client::reconfiguration::IStateClient> creClient_;
   concord::util::ThreadPool blocks_io_workers_pool;
+  concord::util::ThreadPool digests_workers_pool_{"digests-thread-pool", 4};
   struct Recorders {
     static constexpr uint64_t MAX_VALUE_MICROSECONDS = 2ULL * 1000ULL * 1000ULL;  // 2 seconds
     const std::string component_ = "iappstate";

--- a/kvbc/include/kvbc_adapter/categorization/app_state_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/categorization/app_state_adapter.hpp
@@ -52,6 +52,13 @@ class AppStateAdapter : public bftEngine::bcst::IAppState {
   void getPrevDigestFromBlock(const char *blockData,
                               const uint32_t blockSize,
                               bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override final;
+
+  std::future<std::optional<concord::crypto::BlockDigest>> getPrevDigestFromBlockAsync(
+      uint64_t block_id) override final {
+    ConcordAssert(false);
+    return std::async([]() { return std::optional<concord::crypto::BlockDigest>{}; });
+  }
+
   bool putBlock(const uint64_t blockId,
                 const char *blockData,
                 const uint32_t blockSize,

--- a/kvbc/include/kvbc_adapter/replica_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/replica_adapter.hpp
@@ -159,6 +159,11 @@ class ReplicaBlockchain : public IBlocksDeleter,
     return app_state_->getPrevDigestFromBlock(blockData, blockSize, outPrevBlockDigest);
   }
 
+  std::future<std::optional<concord::crypto::BlockDigest>> getPrevDigestFromBlockAsync(
+      uint64_t block_id) override final {
+    return app_state_->getPrevDigestFromBlockAsync(block_id);
+  }
+
   bool putBlock(const uint64_t blockId,
                 const char *blockData,
                 const uint32_t blockSize,

--- a/kvbc/include/kvbc_adapter/v4blockchain/app_state_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/v4blockchain/app_state_adapter.hpp
@@ -49,6 +49,12 @@ class AppStateAdapter : public bftEngine::bcst::IAppState {
                                       const uint32_t blockSize,
                                       bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override;
 
+  virtual std::future<std::optional<concord::crypto::BlockDigest>> getPrevDigestFromBlockAsync(
+      uint64_t block_id) override {
+    ConcordAssert(false);
+    return std::async([]() { return std::optional<concord::crypto::BlockDigest>{}; });
+  }
+
   virtual bool putBlock(const uint64_t blockId,
                         const char *blockData,
                         const uint32_t blockSize,

--- a/kvbc/include/v4blockchain/detail/blocks.h
+++ b/kvbc/include/v4blockchain/detail/blocks.h
@@ -71,6 +71,11 @@ class Block {
     return *reinterpret_cast<const concord::crypto::BlockDigest*>(buffer_.data() + sizeof(version_type));
   }
 
+  static const concord::crypto::BlockDigest& parentDigest(const std::string_view buffer) {
+    ConcordAssert(buffer.size() >= HEADER_SIZE);
+    return *reinterpret_cast<const concord::crypto::BlockDigest*>(buffer.data() + sizeof(version_type));
+  }
+
   void addDigest(const concord::crypto::BlockDigest& digest) {
     ConcordAssert(isValid_);
     ConcordAssert(buffer_.size() >= HEADER_SIZE);

--- a/kvbc/src/v4blockchain/detail/blockchain.cpp
+++ b/kvbc/src/v4blockchain/detail/blockchain.cpp
@@ -167,7 +167,7 @@ concord::crypto::BlockDigest Blockchain::calculateBlockDigest(concord::kvbc::Blo
 concord::crypto::BlockDigest Blockchain::getBlockParentDigest(concord::kvbc::BlockId id) const {
   auto block_str = getBlockData(id);
   ConcordAssert(block_str.has_value());
-  return v4blockchain::detail::Block{*block_str}.parentDigest();
+  return v4blockchain::detail::Block::parentDigest(*block_str);
 }
 
 std::optional<std::string> Blockchain::getBlockData(concord::kvbc::BlockId id) const {

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -355,6 +355,7 @@ std::optional<BlockId> KeyValueBlockchain::getLastStatetransferBlockId() const {
 std::optional<concord::crypto::BlockDigest> KeyValueBlockchain::parentDigest(BlockId block_id) const {
   const auto last_reachable_block = getLastReachableBlockId();
   if (block_id > last_reachable_block) {
+    LOG_DEBUG(V4_BLOCK_LOG, KVLOG(block_id, last_reachable_block));
     return std::optional<concord::crypto::BlockDigest>(state_transfer_chain_.getBlockParentDigest(block_id));
   }
   if (block_id < getGenesisBlockId()) {


### PR DESCRIPTION
<placeholder>
* **Problem Overview**  

Pruning can happen anytime resulting into removal of blocks from storage. RVBManager maintains Range Validation Tree (RVT) which it has to persist during every checkpoint by adding/removing set of Range Validation Block (RVB) nodes. Each such RVB node represents single block at interval (configurable through FRS).

Once pruning is done, digests for pruned blocks would be unavailable forever making it impossible for RVBManager to checkpoint RVT. To mitigate this RVBManager expects a callback whenever pruning is about to begin.

RVBManager was spending enormous time in this callback for calculating and storing digests of to-be-pruned blocks. Existing basic implementation was fetching and calculating digest one block at a time. This fix would parallelize the digest calculation by fetching blocks concurrently from the storage.

* **Testing Done**  
 Executed all tests locally.
