### PR TITLE
Added a new error log which can caught by log parser in case of actual failures during preprocessing

### DIFF
--- a/bftengine/src/preprocessor/PreProcessor.cpp
+++ b/bftengine/src/preprocessor/PreProcessor.cpp
@@ -1911,23 +1911,25 @@ OperationResult PreProcessor::launchReqPreProcessing(const string &batchCid,
     if (preProcessResult == OperationResult::SUCCESS) {
       break;
     }
-    LOG_ERROR(logger(),
-              "Pre-execution failed" << KVLOG(clientId,
-                                              reqSeqNum,
-                                              batchCid,
-                                              reqCid,
-                                              reqOffsetInBatch,
-                                              (uint32_t)preProcessResult,
-                                              resultLen,
-                                              request.outActualReplySize,
-                                              request.outRequiredReplySize,
-                                              maxReplySize,
-                                              resultBufferEntry.get().buffer,
-                                              request.maxReplySize,
-                                              request.requestSize));
+    LOG_WARN(logger(),
+             "Pre-execution failed" << KVLOG(clientId,
+                                             reqSeqNum,
+                                             batchCid,
+                                             reqCid,
+                                             reqOffsetInBatch,
+                                             (uint32_t)preProcessResult,
+                                             resultLen,
+                                             request.outActualReplySize,
+                                             request.outRequiredReplySize,
+                                             maxReplySize,
+                                             resultBufferEntry.get().buffer,
+                                             request.maxReplySize,
+                                             request.requestSize));
     if ((memoryPoolMode_ != PreProcessorMemoryPoolMode::MULTI_SIZE_BUFFER_POOL) ||
         (OperationResult::EXEC_DATA_TOO_LARGE != preProcessResult)) {
       // do not retry pre-execute if not using a memory pool OR if error is not due to response buffer size
+      LOG_ERROR(logger(),
+                "Will not retry pre-execute:" << KVLOG(clientId, reqSeqNum, batchCid, (uint32_t)preProcessResult));
       break;
     }
 


### PR DESCRIPTION

* **Problem Overview**  
Due to recent memory optimisation changes, it has been observed that during preprocessing the request, we write preprocessing failure error log if the engine response is greater than optimised buffer length. Here the actual response threshold size is bigger than engine response. After which, we increase the limit of optimised buffer size and retry the preprocessing of the request. During the second time the request gets processed successfully without error logs. Due to this behaviour, our log parser which is integrated in our end to end product testing will check for error logs in the container logs after the executions of end to end tests. Since we write the error logs during first time, log parser was catching these error logs and fail the entire end to end test case at the end. To prevent this, as part of the fix i have moved the first occurring logs to warning and added a new error log to capture the actual preprocessing failure.

