### PR TITLE
Wallet service fixes

### DIFF
--- a/utt/privacy-wallet-service/CMakeLists.txt
+++ b/utt/privacy-wallet-service/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(privacy-wallet-service PUBLIC
 )
 
 add_library(privacy-wallet-service-lib ${privacy-wallet-service-src})
+
 target_link_libraries(privacy-wallet-service-lib PUBLIC
   privacy-wallet-service-proto utt_client_api privacy_wallet_lib nlohmann_json::nlohmann_json stdc++fs
 )

--- a/utt/privacy-wallet-service/include/Wallet.hpp
+++ b/utt/privacy-wallet-service/include/Wallet.hpp
@@ -18,7 +18,6 @@
 #include <tuple>
 #include <optional>
 #include <grpcpp/grpcpp.h>
-#include "wallet-api.grpc.pb.h"  // Generated from privacy-wallet-library/proto/api
 #include <utt-client-api/ClientApi.hpp>
 #include <utt-common-api/CommonApi.hpp>
 namespace utt::walletservice {
@@ -47,6 +46,7 @@ class Wallet {
   uint64_t getBalance() const;
   uint64_t getBudget() const;
   bool isRegistered() const;
+  std::vector<utt::client::CoinDescriptor> getCoinsDescriptors() const;
 
  private:
   std::string userId_;

--- a/utt/privacy-wallet-service/proto/CMakeLists.txt
+++ b/utt/privacy-wallet-service/proto/CMakeLists.txt
@@ -13,3 +13,9 @@ grpc_generate_cpp(GRPC_SRCS GRPC_HDRS ${CMAKE_CURRENT_BINARY_DIR}
 add_library(privacy-wallet-service-proto STATIC ${PROTO_SRCS} ${GRPC_SRCS})
 target_link_libraries(privacy-wallet-service-proto PRIVATE protobuf::libprotobuf gRPC::grpc++)
 target_include_directories(privacy-wallet-service-proto PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-Wsign-conversion HAVE_SIGN_CONVERSION)
+if (HAVE_SIGN_CONVERSION)
+    target_compile_options(privacy-wallet-service-proto PRIVATE -Wno-sign-conversion)
+endif (HAVE_SIGN_CONVERSION)

--- a/utt/privacy-wallet-service/proto/api/v1/wallet-api.proto
+++ b/utt/privacy-wallet-service/proto/api/v1/wallet-api.proto
@@ -98,6 +98,7 @@ message GetStateResponse {
     uint64 budget = 1[jstype = JS_STRING];
     uint64 balance = 2[jstype = JS_STRING];
     string user_id = 3;
+    map<string, uint64> coins = 4;
 }
 
 message PrivacyWalletRequest {

--- a/utt/privacy-wallet-service/src/PrivacyService.cpp
+++ b/utt/privacy-wallet-service/src/PrivacyService.cpp
@@ -360,6 +360,9 @@ std::pair<utt::Transaction, utt::TxOutputSigs> PrivacyWalletServiceImpl::buildCl
   state_resp->set_budget(wallet_->getBudget());
   state_resp->set_balance(wallet_->getBalance());
   state_resp->set_user_id(wallet_->getUserId());
+  for (const auto& coin : wallet_->getCoinsDescriptors()) {
+    (*(state_resp->mutable_coins()))[coin.nullifier_] = coin.value_;
+  }
   return grpc::Status::OK;
 }
 }  // namespace utt::walletservice

--- a/utt/privacy-wallet-service/src/Wallet.cpp
+++ b/utt/privacy-wallet-service/src/Wallet.cpp
@@ -91,4 +91,6 @@ uint64_t Wallet::getBalance() const { return user_->getBalance(); }
 uint64_t Wallet::getBudget() const { return user_->getPrivacyBudget(); }
 
 bool Wallet::isRegistered() const { return registered_; }
+
+std::vector<utt::client::CoinDescriptor> Wallet::getCoinsDescriptors() const { return user_->getCoinsDescriptors(); }
 }  // namespace utt::walletservice

--- a/utt/privacy-wallet-service/tests/grpc-service/grpc-server-test.cpp
+++ b/utt/privacy-wallet-service/tests/grpc-service/grpc-server-test.cpp
@@ -24,7 +24,6 @@ namespace fs = std::experimental::filesystem;
 
 #include "testUtils/testUtils.hpp"
 #include "gtest/gtest.h"
-#include "wallet-api.grpc.pb.h"  // Generated from privacy-wallet-library/proto/api
 
 #include <grpcpp/channel.h>
 #include <grpcpp/create_channel.h>
@@ -296,6 +295,10 @@ TEST_F(test_privacy_wallet_grpc_service, test_get_state) {
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(response.get_state_response().balance(), 1000);
   ASSERT_EQ(response.get_state_response().budget(), 1000);
+  ASSERT_EQ(response.get_state_response().coins_size(), 1);
+  for (const auto& [_, val] : response.get_state_response().coins()) {
+    ASSERT_EQ(val, 1000);
+  }
 }
 
 TEST_F(test_privacy_wallet_grpc_service, test_mint_cycle) {

--- a/utt/utt-client-api/include/utt-client-api/PickCoins.hpp
+++ b/utt/utt-client-api/include/utt-client-api/PickCoins.hpp
@@ -14,8 +14,9 @@
 #pragma once
 
 #include <vector>
+#include <unordered_map>
 #include <cstdint>
-
+#include <string>
 namespace libutt::api {
 class Coin;
 }  // namespace libutt::api
@@ -26,6 +27,7 @@ namespace utt::client {
 /// @param coins The available coins to pick from
 /// @param amount The target amount
 /// @return Up to two coins that satisfy the amount (preferring exact matches) or need to be merged
-std::vector<size_t> PickCoinsPreferExactMatch(const std::vector<libutt::api::Coin>& coins, uint64_t targetAmount);
+std::vector<std::string> PickCoinsPreferExactMatch(const std::unordered_map<std::string, libutt::api::Coin>& coins,
+                                                   uint64_t targetAmount);
 
 }  // namespace utt::client

--- a/utt/utt-client-api/include/utt-client-api/User.hpp
+++ b/utt/utt-client-api/include/utt-client-api/User.hpp
@@ -30,6 +30,11 @@ struct TxResult {
   bool isFinal_ = true;
 };
 
+struct CoinDescriptor {
+  std::string nullifier_;
+  uint64_t value_;
+};
+
 class User {
  public:
   User();  // Default empty user object
@@ -107,6 +112,7 @@ class User {
   /// to transfer the desired amount.
   TxResult transfer(const std::string& userId, const std::string& pk, uint64_t amount) const;
 
+  std::vector<CoinDescriptor> getCoinsDescriptors() const;
   void debugOutput() const;
 
  private:

--- a/utt/utt-client-api/src/User.cpp
+++ b/utt/utt-client-api/src/User.cpp
@@ -562,6 +562,14 @@ TxResult User::transfer(const std::string& userId, const std::string& destPK, ui
   }
 }
 
+std::vector<CoinDescriptor> User::getCoinsDescriptors() const {
+  std::vector<CoinDescriptor> ret;
+  for (const auto& [nullifier, coin] : pImpl_->coins_) {
+    ret.push_back({nullifier, coin.getVal()});
+  }
+  return ret;
+}
+
 void User::debugOutput() const {
   std::cout << "------ USER DEBUG OUTPUT START -------------\n";
   if (!pImpl_->client_) {


### PR DESCRIPTION
* **Problem Overview**  
  This PR fixes the following:
1. It saves the coins in a map instead of a list, such that a coin cannot be stored twice
2. Add functionality to get the coins identifier & values from the wallet service
* **Testing Done**  
  uinttests
