### PR TITLE
Added initial changes to support multiple Merkle trees in the storage.

### DIFF
--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -199,9 +199,9 @@ Msg NibblePath 5001 {
 
 Msg BatchedInternalNodeKey 5002 {
     # The version of this key is the *tree* version, not block version
+    string address
     uint64 version
     NibblePath path
-    string address
 }
 
 Msg LeafChild 5003 {

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -201,6 +201,7 @@ Msg BatchedInternalNodeKey 5002 {
     # The version of this key is the *tree* version, not block version
     uint64 version
     NibblePath path
+    string address
 }
 
 Msg LeafChild 5003 {

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -199,7 +199,7 @@ Msg NibblePath 5001 {
 
 Msg BatchedInternalNodeKey 5002 {
     # The version of this key is the *tree* version, not block version
-    string address
+    string custom_prefix
     uint64 version
     NibblePath path
 }

--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -202,7 +202,7 @@ class BlockMerkleCategory {
     Reader(const storage::rocksdb::NativeClient& db) : db_{db} {}
 
     // Return the latest root node in the system.
-    sparse_merkle::BatchedInternalNode get_latest_root(std::string address = "") const override;
+    sparse_merkle::BatchedInternalNode get_latest_root(std::string custom_prefix = "") const override;
 
     // Retrieve a BatchedInternalNode given an InternalNodeKey.
     //

--- a/kvbc/include/categorization/block_merkle_category.h
+++ b/kvbc/include/categorization/block_merkle_category.h
@@ -202,7 +202,7 @@ class BlockMerkleCategory {
     Reader(const storage::rocksdb::NativeClient& db) : db_{db} {}
 
     // Return the latest root node in the system.
-    sparse_merkle::BatchedInternalNode get_latest_root() const override;
+    sparse_merkle::BatchedInternalNode get_latest_root(std::string address = "") const override;
 
     // Retrieve a BatchedInternalNode given an InternalNodeKey.
     //

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -219,7 +219,7 @@ class DBAdapter : public IDbAdapter {
     Reader(const DBAdapter &adapter) : adapter_{adapter} {}
 
     // Return the latest root node in the system.
-    sparse_merkle::BatchedInternalNode get_latest_root() const override;
+    sparse_merkle::BatchedInternalNode get_latest_root(std::string address = "") const override;
 
     // Retrieve a BatchedInternalNode given an InternalNodeKey.
     //

--- a/kvbc/include/merkle_tree_db_adapter.h
+++ b/kvbc/include/merkle_tree_db_adapter.h
@@ -219,7 +219,7 @@ class DBAdapter : public IDbAdapter {
     Reader(const DBAdapter &adapter) : adapter_{adapter} {}
 
     // Return the latest root node in the system.
-    sparse_merkle::BatchedInternalNode get_latest_root(std::string address = "") const override;
+    sparse_merkle::BatchedInternalNode get_latest_root(std::string custom_prefix = "") const override;
 
     // Retrieve a BatchedInternalNode given an InternalNodeKey.
     //

--- a/kvbc/include/sparse_merkle/base_types.h
+++ b/kvbc/include/sparse_merkle/base_types.h
@@ -53,6 +53,57 @@ class Version {
   Type value_ = 0;
 };
 
+// A type safe address wrapper
+class Address {
+ public:
+  using Type = std::string;
+  using SIZE_PREFIX_TYPE = std::uint8_t;
+  static constexpr auto SIZE_IN_BYTES = 20 * sizeof(std::uint8_t);
+  static constexpr auto SIZE_PREFIX_BYTES = sizeof(std::uint8_t);
+  static constexpr auto TOTAL_SIZE = SIZE_PREFIX_BYTES + SIZE_IN_BYTES;
+
+ public:
+  Address() = default;
+  Address(size_t size) {
+    ConcordAssert(size <= SIZE_IN_BYTES);
+    addr_.assign('\0', size);
+  }
+  Address(const Type& val) : addr_(val) { ConcordAssert(val.size() <= SIZE_IN_BYTES); }
+  Address(Type&& val) : addr_(std::move(val)) { ConcordAssert(val.size() <= SIZE_IN_BYTES); }
+
+  void set(std::uint8_t pos, char c) {
+    ConcordAssert(pos < addr_.size());
+    addr_[pos] = c;
+  }
+  char get(std::uint8_t pos) const {
+    ConcordAssert(pos < addr_.size());
+    return addr_[pos];
+  }
+  bool operator==(const Address& other) const { return addr_ == other.addr_; }
+  bool operator!=(const Address& other) const { return addr_ != other.addr_; }
+  bool operator<(const Address& other) const { return addr_ < other.addr_; }
+
+  const Type& value() const { return addr_; }
+  size_t size() const { return addr_.size(); }
+
+ protected:
+  Type addr_;
+};
+
+class PaddedAddress : public Address {
+ public:
+  template <class T>
+  PaddedAddress(T&& arg) : Address(std::forward<T>(arg)) {}
+  char get(std::uint8_t pos) const {
+    ConcordAssert(pos < SIZE_IN_BYTES);
+    if (pos < addr_.size()) {
+      return addr_[pos];
+    } else {
+      return '\0';
+    }
+  }
+};
+
 // A nibble is 4 bits, stored in the lower bits of a byte.
 class Nibble {
  public:

--- a/kvbc/include/sparse_merkle/base_types.h
+++ b/kvbc/include/sparse_merkle/base_types.h
@@ -243,7 +243,7 @@ class NibblePath {
   NibblePath() : num_nibbles_(0) {}
   NibblePath(size_t num_nibbles, const std::vector<uint8_t>& path) : num_nibbles_(num_nibbles), path_(path) {
     ConcordAssert(num_nibbles < Hash::MAX_NIBBLES);
-    ConcordAssert(path.size() == (num_nibbles % 2 ? (num_nibbles + 1) / 2 : num_nibbles / 2));
+    ConcordAssert(path.size() == pathLengthInBytes(num_nibbles));
   }
 
   bool operator==(const NibblePath& other) const { return num_nibbles_ == other.num_nibbles_ && path_ == other.path_; }
@@ -261,6 +261,11 @@ class NibblePath {
       return true;
     }
     return false;
+  }
+
+  // Return the count of elements (bytes) in path_
+  static size_t pathLengthInBytes(size_t num_nibbles) {
+    return (num_nibbles % 2 ? (num_nibbles + 1) / 2 : num_nibbles / 2);
   }
 
   // Return the length of the path_ in nibbles

--- a/kvbc/include/sparse_merkle/base_types.h
+++ b/kvbc/include/sparse_merkle/base_types.h
@@ -53,8 +53,8 @@ class Version {
   Type value_ = 0;
 };
 
-// A type safe address wrapper
-class Address {
+// A type safe custom prefix wrapper
+class CustomPrefix {
  public:
   using Type = std::string;
   using SIZE_PREFIX_TYPE = std::uint8_t;
@@ -63,41 +63,41 @@ class Address {
   static constexpr auto TOTAL_SIZE = SIZE_PREFIX_BYTES + SIZE_IN_BYTES;
 
  public:
-  Address() = default;
-  Address(size_t size) {
+  CustomPrefix() = default;
+  CustomPrefix(size_t size) {
     ConcordAssert(size <= SIZE_IN_BYTES);
-    addr_.assign('\0', size);
+    prefix_.assign('\0', size);
   }
-  Address(const Type& val) : addr_(val) { ConcordAssert(val.size() <= SIZE_IN_BYTES); }
-  Address(Type&& val) : addr_(std::move(val)) { ConcordAssert(val.size() <= SIZE_IN_BYTES); }
+  CustomPrefix(const Type& val) : prefix_(val) { ConcordAssert(val.size() <= SIZE_IN_BYTES); }
+  CustomPrefix(Type&& val) : prefix_(std::move(val)) { ConcordAssert(val.size() <= SIZE_IN_BYTES); }
 
   void set(std::uint8_t pos, char c) {
-    ConcordAssert(pos < addr_.size());
-    addr_[pos] = c;
+    ConcordAssert(pos < prefix_.size());
+    prefix_[pos] = c;
   }
   char get(std::uint8_t pos) const {
-    ConcordAssert(pos < addr_.size());
-    return addr_[pos];
+    ConcordAssert(pos < prefix_.size());
+    return prefix_[pos];
   }
-  bool operator==(const Address& other) const { return addr_ == other.addr_; }
-  bool operator!=(const Address& other) const { return addr_ != other.addr_; }
-  bool operator<(const Address& other) const { return addr_ < other.addr_; }
+  bool operator==(const CustomPrefix& other) const { return prefix_ == other.prefix_; }
+  bool operator!=(const CustomPrefix& other) const { return prefix_ != other.prefix_; }
+  bool operator<(const CustomPrefix& other) const { return prefix_ < other.prefix_; }
 
-  const Type& value() const { return addr_; }
-  size_t size() const { return addr_.size(); }
+  const Type& value() const { return prefix_; }
+  size_t size() const { return prefix_.size(); }
 
  protected:
-  Type addr_;
+  Type prefix_;
 };
 
-class PaddedAddress : public Address {
+class PaddedCustomPrefix : public CustomPrefix {
  public:
   template <class T>
-  PaddedAddress(T&& arg) : Address(std::forward<T>(arg)) {}
+  PaddedCustomPrefix(T&& arg) : CustomPrefix(std::forward<T>(arg)) {}
   char get(std::uint8_t pos) const {
     ConcordAssert(pos < SIZE_IN_BYTES);
-    if (pos < addr_.size()) {
-      return addr_[pos];
+    if (pos < prefix_.size()) {
+      return prefix_[pos];
     } else {
       return '\0';
     }

--- a/kvbc/include/sparse_merkle/db_reader.h
+++ b/kvbc/include/sparse_merkle/db_reader.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace concord {
 namespace kvbc {
 namespace sparse_merkle {
@@ -28,7 +30,7 @@ class IDBReader {
   virtual ~IDBReader() = default;
 
   // Return the latest root node in the system
-  virtual BatchedInternalNode get_latest_root() const = 0;
+  virtual BatchedInternalNode get_latest_root(std::string address = "") const = 0;
 
   // Retrieve a BatchedInternalNode given an InternalNodeKey.
   //

--- a/kvbc/include/sparse_merkle/db_reader.h
+++ b/kvbc/include/sparse_merkle/db_reader.h
@@ -30,7 +30,7 @@ class IDBReader {
   virtual ~IDBReader() = default;
 
   // Return the latest root node in the system
-  virtual BatchedInternalNode get_latest_root(std::string address = "") const = 0;
+  virtual BatchedInternalNode get_latest_root(std::string custom_prefix = "") const = 0;
 
   // Retrieve a BatchedInternalNode given an InternalNodeKey.
   //

--- a/kvbc/include/sparse_merkle/internal_node.h
+++ b/kvbc/include/sparse_merkle/internal_node.h
@@ -387,8 +387,8 @@ class BatchedInternalNode {
                                      Version version,
                                      Nibble child_key,
                                      size_t prefix_bits_in_common,
-                                     LeafChild child1,
-                                     LeafChild child2);
+                                     const LeafChild& child1,
+                                     const LeafChild& child2);
 
   // Remove the LeafChild at the given index. Updates of children should be set
   // to new_version.

--- a/kvbc/include/sparse_merkle/keys.h
+++ b/kvbc/include/sparse_merkle/keys.h
@@ -25,13 +25,13 @@ namespace sparse_merkle {
 class InternalNodeKey {
  public:
   template <class T>
-  InternalNodeKey(Version version, const NibblePath& path, T&& address)
-      : version_(version), path_(path), address_(std::forward<T>(address)) {}
+  InternalNodeKey(T&& address, Version version, const NibblePath& path)
+      : address_(std::forward<T>(address)), version_(version), path_(path) {}
 
   // Return the root of a sparse merkle tree at a given version.
   template <class T>
-  static InternalNodeKey root(Version version, T&& address) {
-    return InternalNodeKey(version, NibblePath(), std::forward<T>(address));
+  static InternalNodeKey root(T&& address, Version version) {
+    return InternalNodeKey(std::forward<T>(address), version, NibblePath());
   }
 
   bool operator==(const InternalNodeKey& other) const { return version_ == other.version_ && path_ == other.path_; }
@@ -62,9 +62,9 @@ class InternalNodeKey {
   NibblePath& path() { return path_; }
 
  private:
+  std::string address_;
   Version version_;
   NibblePath path_;
-  std::string address_;
 };
 
 // The key for a leaf node of a sparse merkle tree.

--- a/kvbc/include/sparse_merkle/keys.h
+++ b/kvbc/include/sparse_merkle/keys.h
@@ -34,35 +34,37 @@ class InternalNodeKey {
     return InternalNodeKey(std::forward<T>(address), version, NibblePath());
   }
 
-  bool operator==(const InternalNodeKey& other) const { return version_ == other.version_ && path_ == other.path_; }
+  bool operator==(const InternalNodeKey& other) const {
+    return address_ == other.address_ && version_ == other.version_ && path_ == other.path_;
+  }
 
-  // Compare by version then by path
+  // Compare by address, version and then by path
   bool operator<(const InternalNodeKey& other) const {
-    if (version_ == other.version_ && path_ == other.path_) {
+    if (address_ != other.address_) {
       return address_ < other.address_;
     }
-    if (version_ == other.version_) {
-      return path_ < other.path_;
+    if (version_ != other.version_) {
+      return version_ < other.version_;
     }
-    return version_ < other.version_;
+    return path_ < other.path_;
   }
 
   std::string toString() const {
     if (path_.empty()) {
-      return std::string("<ROOT>") + "-" + version_.toString();
+      return address_.value() + std::string("-<ROOT>") + "-" + version_.toString();
     }
-    return path_.toString() + "-" + version_.toString();
+    return address_.value() + "-" + path_.toString() + "-" + version_.toString();
   }
 
   Version version() const { return version_; }
 
-  const std::string& address() const { return address_; }
+  const Address& address() const { return address_; }
 
   const NibblePath& path() const { return path_; }
   NibblePath& path() { return path_; }
 
  private:
-  std::string address_;
+  Address address_;
   Version version_;
   NibblePath path_;
 };
@@ -74,28 +76,37 @@ class InternalNodeKey {
 // merkle tree.
 class LeafKey {
  public:
-  static constexpr auto SIZE_IN_BYTES = Hash::SIZE_IN_BYTES + Version::SIZE_IN_BYTES;
+  static constexpr auto SIZE_IN_BYTES = PaddedAddress::TOTAL_SIZE + Hash::SIZE_IN_BYTES + Version::SIZE_IN_BYTES;
 
  public:
-  LeafKey(Hash key, Version version) : key_(key), version_(version) {}
+  template <class T>
+  LeafKey(Hash key, Version version, T&& address) : key_(key), version_(version), address_(std::forward<T>(address)) {}
+  LeafKey(Hash key, Version version) : key_(key), version_(version), address_("") {}
 
-  bool operator==(const LeafKey& other) const { return key_ == other.key_ && version_ == other.version_; }
+  bool operator==(const LeafKey& other) const {
+    return address_ == other.address_ && key_ == other.key_ && version_ == other.version_;
+  }
   bool operator!=(const LeafKey& other) const { return !(*this == other); }
 
-  // Compare by key_ then version_
+  // Compare by addres, key_ and then version_
   bool operator<(const LeafKey& other) const {
-    if (key_ < other.key_) {
-      return true;
+    if (address_ != other.address_) {
+      return address_ < other.address_;
     }
-    return key_ == other.key_ && version_ < other.version_;
+    if (key_ != other.key_) {
+      return key_ < other.key_;
+    }
+    return version_ < other.version_;
   }
 
-  std::string toString() const { return key_.toString() + "-" + version_.toString(); }
+  std::string toString() const { return key_.toString() + "-" + version_.toString() + "-" + address_.value(); }
 
   Nibble getNibble(const size_t n) const {
     ConcordAssert(n < Hash::MAX_NIBBLES);
     return key_.getNibble(n);
   }
+
+  const PaddedAddress& address() const { return address_; }
 
   Version version() const { return version_; }
 
@@ -104,6 +115,7 @@ class LeafKey {
  private:
   Hash key_;
   Version version_;
+  PaddedAddress address_;
 };
 
 std::ostream& operator<<(std::ostream& os, const LeafKey&);

--- a/kvbc/include/sparse_merkle/keys.h
+++ b/kvbc/include/sparse_merkle/keys.h
@@ -25,23 +25,23 @@ namespace sparse_merkle {
 class InternalNodeKey {
  public:
   template <class T>
-  InternalNodeKey(T&& address, Version version, const NibblePath& path)
-      : address_(std::forward<T>(address)), version_(version), path_(path) {}
+  InternalNodeKey(T&& custom_prefix, Version version, const NibblePath& path)
+      : custom_prefix_(std::forward<T>(custom_prefix)), version_(version), path_(path) {}
 
   // Return the root of a sparse merkle tree at a given version.
   template <class T>
-  static InternalNodeKey root(T&& address, Version version) {
-    return InternalNodeKey(std::forward<T>(address), version, NibblePath());
+  static InternalNodeKey root(T&& custom_prefix, Version version) {
+    return InternalNodeKey(std::forward<T>(custom_prefix), version, NibblePath());
   }
 
   bool operator==(const InternalNodeKey& other) const {
-    return address_ == other.address_ && version_ == other.version_ && path_ == other.path_;
+    return custom_prefix_ == other.custom_prefix_ && version_ == other.version_ && path_ == other.path_;
   }
 
   // Compare by address, version and then by path
   bool operator<(const InternalNodeKey& other) const {
-    if (address_ != other.address_) {
-      return address_ < other.address_;
+    if (custom_prefix_ != other.custom_prefix_) {
+      return custom_prefix_ < other.custom_prefix_;
     }
     if (version_ != other.version_) {
       return version_ < other.version_;
@@ -51,20 +51,20 @@ class InternalNodeKey {
 
   std::string toString() const {
     if (path_.empty()) {
-      return address_.value() + std::string("-<ROOT>") + "-" + version_.toString();
+      return custom_prefix_.value() + std::string("-<ROOT>") + "-" + version_.toString();
     }
-    return address_.value() + "-" + path_.toString() + "-" + version_.toString();
+    return custom_prefix_.value() + "-" + path_.toString() + "-" + version_.toString();
   }
 
   Version version() const { return version_; }
 
-  const Address& address() const { return address_; }
+  const CustomPrefix& customPrefix() const { return custom_prefix_; }
 
   const NibblePath& path() const { return path_; }
   NibblePath& path() { return path_; }
 
  private:
-  Address address_;
+  CustomPrefix custom_prefix_;
   Version version_;
   NibblePath path_;
 };
@@ -76,22 +76,22 @@ class InternalNodeKey {
 // merkle tree.
 class LeafKey {
  public:
-  static constexpr auto SIZE_IN_BYTES = PaddedAddress::TOTAL_SIZE + Hash::SIZE_IN_BYTES + Version::SIZE_IN_BYTES;
+  static constexpr auto SIZE_IN_BYTES = PaddedCustomPrefix::TOTAL_SIZE + Hash::SIZE_IN_BYTES + Version::SIZE_IN_BYTES;
 
  public:
   template <class T>
-  LeafKey(Hash key, Version version, T&& address) : key_(key), version_(version), address_(std::forward<T>(address)) {}
-  LeafKey(Hash key, Version version) : key_(key), version_(version), address_("") {}
+  LeafKey(Hash key, Version version, T&& address) : key_(key), version_(version), prefix_(std::forward<T>(address)) {}
+  LeafKey(Hash key, Version version) : key_(key), version_(version), prefix_("") {}
 
   bool operator==(const LeafKey& other) const {
-    return address_ == other.address_ && key_ == other.key_ && version_ == other.version_;
+    return prefix_ == other.prefix_ && key_ == other.key_ && version_ == other.version_;
   }
   bool operator!=(const LeafKey& other) const { return !(*this == other); }
 
-  // Compare by addres, key_ and then version_
+  // Compare by prefix_, key_ and then version_
   bool operator<(const LeafKey& other) const {
-    if (address_ != other.address_) {
-      return address_ < other.address_;
+    if (prefix_ != other.prefix_) {
+      return prefix_ < other.prefix_;
     }
     if (key_ != other.key_) {
       return key_ < other.key_;
@@ -99,14 +99,14 @@ class LeafKey {
     return version_ < other.version_;
   }
 
-  std::string toString() const { return key_.toString() + "-" + version_.toString() + "-" + address_.value(); }
+  std::string toString() const { return key_.toString() + "-" + version_.toString() + "-" + prefix_.value(); }
 
   Nibble getNibble(const size_t n) const {
     ConcordAssert(n < Hash::MAX_NIBBLES);
     return key_.getNibble(n);
   }
 
-  const PaddedAddress& address() const { return address_; }
+  const PaddedCustomPrefix& customPrefix() const { return prefix_; }
 
   Version version() const { return version_; }
 
@@ -115,7 +115,7 @@ class LeafKey {
  private:
   Hash key_;
   Version version_;
-  PaddedAddress address_;
+  PaddedCustomPrefix prefix_;
 };
 
 std::ostream& operator<<(std::ostream& os, const LeafKey&);

--- a/kvbc/include/sparse_merkle/tree.h
+++ b/kvbc/include/sparse_merkle/tree.h
@@ -43,11 +43,15 @@ namespace sparse_merkle {
 class Tree {
  public:
   Tree() = default;
-  explicit Tree(std::shared_ptr<IDBReader> db_reader) : db_reader_(db_reader) { reset(); }
+  explicit Tree(std::shared_ptr<IDBReader> db_reader, std::string address = "")
+      : db_reader_(db_reader), address_(address) {
+    reset();
+  }
 
   const Hash& get_root_hash() const { return root_.hash(); }
   Version get_version() const { return root_.version(); }
   bool empty() const { return root_.numChildren() == 0; }
+  std::string toString() { return root_.toString(); }
 
   // Add or update key-value pairs given in `updates`, and remove keys in
   // `deleted_keys`.
@@ -74,7 +78,7 @@ class Tree {
   //
   // This is necessary to do before updates, as we only allow updating the
   // latest tree.
-  void reset() { root_ = db_reader_->get_latest_root(); }
+  void reset() { root_ = db_reader_->get_latest_root(address_); }
 
   UpdateBatch update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
                           const concord::kvbc::KeysVector& deleted_keys,
@@ -82,6 +86,7 @@ class Tree {
 
   std::shared_ptr<IDBReader> db_reader_;
   BatchedInternalNode root_;
+  std::string address_;
 };
 
 }  // namespace sparse_merkle

--- a/kvbc/include/sparse_merkle/tree.h
+++ b/kvbc/include/sparse_merkle/tree.h
@@ -43,8 +43,8 @@ namespace sparse_merkle {
 class Tree {
  public:
   Tree() = default;
-  explicit Tree(std::shared_ptr<IDBReader> db_reader, std::string address = "")
-      : db_reader_(db_reader), address_(address) {
+  explicit Tree(std::shared_ptr<IDBReader> db_reader, std::string custom_prefix = "")
+      : db_reader_(db_reader), custom_prefix_(custom_prefix) {
     reset();
   }
 
@@ -78,7 +78,7 @@ class Tree {
   //
   // This is necessary to do before updates, as we only allow updating the
   // latest tree.
-  void reset() { root_ = db_reader_->get_latest_root(address_); }
+  void reset() { root_ = db_reader_->get_latest_root(custom_prefix_); }
 
   UpdateBatch update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
                           const concord::kvbc::KeysVector& deleted_keys,
@@ -86,7 +86,7 @@ class Tree {
 
   std::shared_ptr<IDBReader> db_reader_;
   BatchedInternalNode root_;
-  std::string address_;
+  std::string custom_prefix_;
 };
 
 }  // namespace sparse_merkle

--- a/kvbc/include/sparse_merkle/update_cache.h
+++ b/kvbc/include/sparse_merkle/update_cache.h
@@ -34,8 +34,8 @@ namespace detail {
 // A new instance of this structure is created during every update call.
 class UpdateCache {
  public:
-  UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader, std::string address)
-      : version_(root.version() + 1), db_reader_(db_reader), original_root_(root), address_(address) {}
+  UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader, std::string custom_prefix)
+      : version_(root.version() + 1), db_reader_(db_reader), original_root_(root), custom_prefix_(custom_prefix) {}
 
   const StaleNodeIndexes& stale() const { return stale_; }
   const auto& internalNodes() const { return internal_nodes_; }
@@ -74,7 +74,7 @@ class UpdateCache {
   // These nodes are mutable and are all being updated to a single version.
   // Therefore we key them by their NibblePath alone, without a version.
   std::map<InternalNodeKey, BatchedInternalNode> internal_nodes_;
-  std::string address_;
+  std::string custom_prefix_;
 };
 
 }  // namespace detail

--- a/kvbc/include/sparse_merkle/update_cache.h
+++ b/kvbc/include/sparse_merkle/update_cache.h
@@ -34,8 +34,8 @@ namespace detail {
 // A new instance of this structure is created during every update call.
 class UpdateCache {
  public:
-  UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader)
-      : version_(root.version() + 1), db_reader_(db_reader), original_root_(root) {}
+  UpdateCache(const BatchedInternalNode& root, const std::shared_ptr<IDBReader>& db_reader, std::string address)
+      : version_(root.version() + 1), db_reader_(db_reader), original_root_(root), address_(address) {}
 
   const StaleNodeIndexes& stale() const { return stale_; }
   const auto& internalNodes() const { return internal_nodes_; }
@@ -55,8 +55,8 @@ class UpdateCache {
 
   void putStale(const std::optional<LeafKey>& key);
   void putStale(const InternalNodeKey& key);
-  void put(const NibblePath& path, const BatchedInternalNode& node);
-  void remove(const NibblePath& path);
+  void put(const InternalNodeKey& key, const BatchedInternalNode& node);
+  void remove(const InternalNodeKey& key);
 
  private:
   // The version of the tree after this update is complete.
@@ -73,7 +73,8 @@ class UpdateCache {
   //
   // These nodes are mutable and are all being updated to a single version.
   // Therefore we key them by their NibblePath alone, without a version.
-  std::map<NibblePath, BatchedInternalNode> internal_nodes_;
+  std::map<InternalNodeKey, BatchedInternalNode> internal_nodes_;
+  std::string address_;
 };
 
 }  // namespace detail

--- a/kvbc/include/sparse_merkle/walker.h
+++ b/kvbc/include/sparse_merkle/walker.h
@@ -56,6 +56,8 @@ class Walker {
 
   void insertEmptyRootAtCurrentVersion();
 
+  const std::string& address() const { return address_; }
+
  private:
   void ascend();
   std::pair<Nibble, Hash> pop();

--- a/kvbc/include/sparse_merkle/walker.h
+++ b/kvbc/include/sparse_merkle/walker.h
@@ -28,7 +28,8 @@ typedef std::stack<BatchedInternalNode, std::vector<BatchedInternalNode>> NodeSt
 // A class for ascending and descending the tree. This is used for updates.
 class Walker {
  public:
-  Walker(UpdateCache& cache, std::string address) : cache_(cache), current_node_(cache.getRoot()), address_(address) {
+  Walker(UpdateCache& cache, std::string custom_prefix)
+      : cache_(cache), current_node_(cache.getRoot()), custom_prefix_(custom_prefix) {
     // Save the version of the root node, in case we only update the root node.
     stale_version_ = current_node_.version();
   }
@@ -56,7 +57,7 @@ class Walker {
 
   void insertEmptyRootAtCurrentVersion();
 
-  const std::string& address() const { return address_; }
+  const std::string& customPrefix() const { return custom_prefix_; }
 
  private:
   void ascend();
@@ -76,7 +77,7 @@ class Walker {
   NodeStack stack_;
   BatchedInternalNode current_node_;
   NibblePath nibble_path_;
-  std::string address_;
+  std::string custom_prefix_;
 };
 
 }  // namespace detail

--- a/kvbc/include/sparse_merkle/walker.h
+++ b/kvbc/include/sparse_merkle/walker.h
@@ -28,7 +28,7 @@ typedef std::stack<BatchedInternalNode, std::vector<BatchedInternalNode>> NodeSt
 // A class for ascending and descending the tree. This is used for updates.
 class Walker {
  public:
-  Walker(UpdateCache& cache) : cache_(cache), current_node_(cache.getRoot()) {
+  Walker(UpdateCache& cache, std::string address) : cache_(cache), current_node_(cache.getRoot()), address_(address) {
     // Save the version of the root node, in case we only update the root node.
     stale_version_ = current_node_.version();
   }
@@ -74,6 +74,7 @@ class Walker {
   NodeStack stack_;
   BatchedInternalNode current_node_;
   NibblePath nibble_path_;
+  std::string address_;
 };
 
 }  // namespace detail

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -76,12 +76,12 @@ BatchedInternalNodeKey toBatchedInternalNodeKey(const sparse_merkle::InternalNod
 
 BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().move_data()};
-  return BatchedInternalNodeKey{key.version().value(), std::move(path)};
+  return BatchedInternalNodeKey{key.version().value(), std::move(path), key.address()};
 }
 
-std::vector<uint8_t> rootKey(uint64_t version) {
+std::vector<uint8_t> rootKey(uint64_t version, std::string address = "") {
   auto v = sparse_merkle::Version(version);
-  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(v)));
+  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(v, address)));
 }
 
 // A key used in tree_.update()
@@ -775,8 +775,8 @@ uint64_t BlockMerkleCategory::getLatestTreeVersion() const {
   return 0;
 }
 
-sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_latest_root() const {
-  if (auto latest_root_key = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0))) {
+sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_latest_root(std::string address) const {
+  if (auto latest_root_key = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0, address))) {
     if (auto serialized = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, *latest_root_key)) {
       return deserializeBatchedInternalNode(*serialized);
     }

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -71,12 +71,12 @@ VersionedKey leafKeyToVersionedKey(const sparse_merkle::LeafKey& leaf_key) {
 // favor of the one immediately below it.
 BatchedInternalNodeKey toBatchedInternalNodeKey(const sparse_merkle::InternalNodeKey& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().data()};
-  return BatchedInternalNodeKey{key.address(), key.version().value(), std::move(path)};
+  return BatchedInternalNodeKey{key.address().value(), key.version().value(), std::move(path)};
 }
 
 BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().move_data()};
-  return BatchedInternalNodeKey{key.address(), key.version().value(), std::move(path)};
+  return BatchedInternalNodeKey{key.address().value(), key.version().value(), std::move(path)};
 }
 
 std::vector<uint8_t> rootKey(uint64_t version, const std::string& address = "") {

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -71,17 +71,17 @@ VersionedKey leafKeyToVersionedKey(const sparse_merkle::LeafKey& leaf_key) {
 // favor of the one immediately below it.
 BatchedInternalNodeKey toBatchedInternalNodeKey(const sparse_merkle::InternalNodeKey& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().data()};
-  return BatchedInternalNodeKey{key.version().value(), std::move(path)};
+  return BatchedInternalNodeKey{key.address(), key.version().value(), std::move(path)};
 }
 
 BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().move_data()};
-  return BatchedInternalNodeKey{key.version().value(), std::move(path), key.address()};
+  return BatchedInternalNodeKey{key.address(), key.version().value(), std::move(path)};
 }
 
 std::vector<uint8_t> rootKey(uint64_t version, const std::string& address = "") {
   auto v = sparse_merkle::Version(version);
-  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(v, address)));
+  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(address, v)));
 }
 
 // A key used in tree_.update()

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -79,7 +79,7 @@ BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&&
   return BatchedInternalNodeKey{key.version().value(), std::move(path), key.address()};
 }
 
-std::vector<uint8_t> rootKey(uint64_t version, std::string address = "") {
+std::vector<uint8_t> rootKey(uint64_t version, const std::string& address = "") {
   auto v = sparse_merkle::Version(version);
   return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(v, address)));
 }

--- a/kvbc/src/categorization/block_merkle_category.cpp
+++ b/kvbc/src/categorization/block_merkle_category.cpp
@@ -71,17 +71,17 @@ VersionedKey leafKeyToVersionedKey(const sparse_merkle::LeafKey& leaf_key) {
 // favor of the one immediately below it.
 BatchedInternalNodeKey toBatchedInternalNodeKey(const sparse_merkle::InternalNodeKey& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().data()};
-  return BatchedInternalNodeKey{key.address().value(), key.version().value(), std::move(path)};
+  return BatchedInternalNodeKey{key.customPrefix().value(), key.version().value(), std::move(path)};
 }
 
 BatchedInternalNodeKey toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey&& key) {
   auto path = NibblePath{static_cast<uint8_t>(key.path().length()), key.path().move_data()};
-  return BatchedInternalNodeKey{key.address().value(), key.version().value(), std::move(path)};
+  return BatchedInternalNodeKey{key.customPrefix().value(), key.version().value(), std::move(path)};
 }
 
-std::vector<uint8_t> rootKey(uint64_t version, const std::string& address = "") {
+std::vector<uint8_t> rootKey(uint64_t version, const std::string& custom_prefix = "") {
   auto v = sparse_merkle::Version(version);
-  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(address, v)));
+  return serialize(toBatchedInternalNodeKey(sparse_merkle::InternalNodeKey::root(custom_prefix, v)));
 }
 
 // A key used in tree_.update()
@@ -775,8 +775,8 @@ uint64_t BlockMerkleCategory::getLatestTreeVersion() const {
   return 0;
 }
 
-sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_latest_root(std::string address) const {
-  if (auto latest_root_key = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0, address))) {
+sparse_merkle::BatchedInternalNode BlockMerkleCategory::Reader::get_latest_root(std::string custom_prefix) const {
+  if (auto latest_root_key = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, rootKey(0, custom_prefix))) {
     if (auto serialized = db_.get(BLOCK_MERKLE_INTERNAL_NODES_CF, *latest_root_key)) {
       return deserializeBatchedInternalNode(*serialized);
     }

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -446,7 +446,7 @@ std::pair<sparse_merkle::UpdateBatch, sparse_merkle::detail::UpdateCache> DBAdap
   return smTree_.update_with_cache(updates, KeysVector{std::cbegin(deletes), std::cend(deletes)});
 }
 
-BatchedInternalNode DBAdapter::Reader::get_latest_root() const {
+BatchedInternalNode DBAdapter::Reader::get_latest_root(std::string address) const {
   const auto lastBlock = adapter_.getLastReachableBlockId();
   if (lastBlock == 0) {
     return BatchedInternalNode{};
@@ -462,7 +462,7 @@ BatchedInternalNode DBAdapter::Reader::get_latest_root() const {
     return BatchedInternalNode{};
   }
 
-  return get_internal(InternalNodeKey::root(stateRootVersion));
+  return get_internal(InternalNodeKey::root(stateRootVersion, address));
 }
 
 BatchedInternalNode DBAdapter::Reader::get_internal(const InternalNodeKey &key) const {
@@ -708,7 +708,7 @@ KeysVector DBAdapter::internalProvableKeysForVersion(const Version &version) con
   // Rely on the fact that root internal keys always precede non-root ones - due to lexicographical ordering and root
   // internal keys having empty nibble paths. See InternalNodeKey serialization code.
   return keysForVersion(db_,
-                        DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version)),
+                        DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version, "")),
                         version,
                         EKeySubtype::Internal,
                         [](const Key &key) { return DBKeyManipulator::extractVersionFromInternalKey(key); });

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -462,7 +462,7 @@ BatchedInternalNode DBAdapter::Reader::get_latest_root(std::string address) cons
     return BatchedInternalNode{};
   }
 
-  return get_internal(InternalNodeKey::root(stateRootVersion, address));
+  return get_internal(InternalNodeKey::root(address, stateRootVersion));
 }
 
 BatchedInternalNode DBAdapter::Reader::get_internal(const InternalNodeKey &key) const {
@@ -708,7 +708,7 @@ KeysVector DBAdapter::internalProvableKeysForVersion(const Version &version) con
   // Rely on the fact that root internal keys always precede non-root ones - due to lexicographical ordering and root
   // internal keys having empty nibble paths. See InternalNodeKey serialization code.
   return keysForVersion(db_,
-                        DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version, "")),
+                        DBKeyManipulator::genInternalDbKey(InternalNodeKey::root("", version)),
                         version,
                         EKeySubtype::Internal,
                         [](const Key &key) { return DBKeyManipulator::extractVersionFromInternalKey(key); });

--- a/kvbc/src/merkle_tree_db_adapter.cpp
+++ b/kvbc/src/merkle_tree_db_adapter.cpp
@@ -446,7 +446,7 @@ std::pair<sparse_merkle::UpdateBatch, sparse_merkle::detail::UpdateCache> DBAdap
   return smTree_.update_with_cache(updates, KeysVector{std::cbegin(deletes), std::cend(deletes)});
 }
 
-BatchedInternalNode DBAdapter::Reader::get_latest_root(std::string address) const {
+BatchedInternalNode DBAdapter::Reader::get_latest_root(std::string custom_prefix) const {
   const auto lastBlock = adapter_.getLastReachableBlockId();
   if (lastBlock == 0) {
     return BatchedInternalNode{};
@@ -462,7 +462,7 @@ BatchedInternalNode DBAdapter::Reader::get_latest_root(std::string address) cons
     return BatchedInternalNode{};
   }
 
-  return get_internal(InternalNodeKey::root(address, stateRootVersion));
+  return get_internal(InternalNodeKey::root(custom_prefix, stateRootVersion));
 }
 
 BatchedInternalNode DBAdapter::Reader::get_internal(const InternalNodeKey &key) const {

--- a/kvbc/src/sparse_merkle/internal_node.cpp
+++ b/kvbc/src/sparse_merkle/internal_node.cpp
@@ -173,8 +173,12 @@ size_t BatchedInternalNode::insertInternalChildren(size_t index,
   return index;
 }
 
-BatchedInternalNode::InsertResult BatchedInternalNode::insertTwoLeafChildren(
-    size_t index, Version version, Nibble child_key, size_t prefix_bits_in_common, LeafChild child1, LeafChild child2) {
+BatchedInternalNode::InsertResult BatchedInternalNode::insertTwoLeafChildren(size_t index,
+                                                                             Version version,
+                                                                             Nibble child_key,
+                                                                             size_t prefix_bits_in_common,
+                                                                             const LeafChild& child1,
+                                                                             const LeafChild& child2) {
   size_t child1_index = 0;
   size_t child2_index = 0;
   // prefix_bits_in_common start from MSB. At most there can be 3 bits in common

--- a/kvbc/src/sparse_merkle/keys.cpp
+++ b/kvbc/src/sparse_merkle/keys.cpp
@@ -15,7 +15,7 @@
 namespace concord::kvbc::sparse_merkle {
 
 std::ostream& operator<<(std::ostream& os, const LeafKey& key) {
-  os << key.address().value() << "-" << key.hash() << "-" << key.version();
+  os << key.hash() << "-" << key.version() << "-" << key.customPrefix().value();
   return os;
 }
 

--- a/kvbc/src/sparse_merkle/keys.cpp
+++ b/kvbc/src/sparse_merkle/keys.cpp
@@ -15,7 +15,7 @@
 namespace concord::kvbc::sparse_merkle {
 
 std::ostream& operator<<(std::ostream& os, const LeafKey& key) {
-  os << key.hash() << "-" << key.version();
+  os << key.address().value() << "-" << key.hash() << "-" << key.version();
   return os;
 }
 

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -101,7 +101,7 @@ void remove(Walker& walker, const Hash& key_hash) {
 
     if (auto rv = std::get_if<BatchedInternalNode::RemoveComplete>(&result)) {
       histograms.remove_depth->record(walker.depth());
-      auto stale = LeafKey(key_hash, rv->version);
+      auto stale = LeafKey(key_hash, rv->version, walker.address());
       return walker.ascendToRoot(stale);
     }
 
@@ -111,7 +111,7 @@ void remove(Walker& walker, const Hash& key_hash) {
     }
 
     if (auto rv = std::get_if<BatchedInternalNode::RemoveBatchedInternalNode>(&result)) {
-      walker.markStale(LeafKey(key_hash, rv->removed_version));
+      walker.markStale(LeafKey(key_hash, rv->removed_version, walker.address()));
       return removeBatchedInternalNode(walker, rv->promoted);
     }
 
@@ -169,7 +169,7 @@ UpdateBatch Tree::update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
       leaf_hash = hasher.hash(val.data(), val.length());
     }
     LeafNode leaf_node{val};
-    LeafKey leaf_key{hasher.hash(key.data(), key.length()), version};
+    LeafKey leaf_key{hasher.hash(key.data(), key.length()), version, address_};
     LeafChild child{leaf_hash, leaf_key};
     Walker walker(cache, address_);
     insert(walker, child);

--- a/kvbc/src/sparse_merkle/tree.cpp
+++ b/kvbc/src/sparse_merkle/tree.cpp
@@ -101,7 +101,7 @@ void remove(Walker& walker, const Hash& key_hash) {
 
     if (auto rv = std::get_if<BatchedInternalNode::RemoveComplete>(&result)) {
       histograms.remove_depth->record(walker.depth());
-      auto stale = LeafKey(key_hash, rv->version, walker.address());
+      auto stale = LeafKey(key_hash, rv->version, walker.customPrefix());
       return walker.ascendToRoot(stale);
     }
 
@@ -111,7 +111,7 @@ void remove(Walker& walker, const Hash& key_hash) {
     }
 
     if (auto rv = std::get_if<BatchedInternalNode::RemoveBatchedInternalNode>(&result)) {
-      walker.markStale(LeafKey(key_hash, rv->removed_version, walker.address()));
+      walker.markStale(LeafKey(key_hash, rv->removed_version, walker.customPrefix()));
       return removeBatchedInternalNode(walker, rv->promoted);
     }
 
@@ -133,14 +133,14 @@ UpdateBatch Tree::update(const concord::kvbc::SetOfKeyValuePairs& updates,
   histograms.num_deleted_keys->record(deleted_keys.size());
   TimeRecorder scoped_timer(*histograms.update);
   reset();
-  UpdateCache cache(root_, db_reader_, address_);
+  UpdateCache cache(root_, db_reader_, custom_prefix_);
   return update_impl(updates, deleted_keys, cache);
 }
 
 std::pair<UpdateBatch, UpdateCache> Tree::update_with_cache(const concord::kvbc::SetOfKeyValuePairs& updates,
                                                             const concord::kvbc::KeysVector& deleted_keys) {
   reset();
-  UpdateCache cache(root_, db_reader_, address_);
+  UpdateCache cache(root_, db_reader_, custom_prefix_);
   auto batch = update_impl(updates, deleted_keys, cache);
   return std::make_pair(batch, cache);
 }
@@ -155,7 +155,7 @@ UpdateBatch Tree::update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
   // Deletes come before inserts because it makes more semantic sense. A user can delete a key and then write a new
   // version, but it makes no sense to add a new version and then delete a key.
   for (auto& key : deleted_keys) {
-    Walker walker(cache, address_);
+    Walker walker(cache, custom_prefix_);
     auto key_hash = hasher.hash(key.data(), key.length());
     sparse_merkle::remove(walker, key_hash);
   }
@@ -169,9 +169,9 @@ UpdateBatch Tree::update_impl(const concord::kvbc::SetOfKeyValuePairs& updates,
       leaf_hash = hasher.hash(val.data(), val.length());
     }
     LeafNode leaf_node{val};
-    LeafKey leaf_key{hasher.hash(key.data(), key.length()), version, address_};
+    LeafKey leaf_key{hasher.hash(key.data(), key.length()), version, custom_prefix_};
     LeafChild child{leaf_hash, leaf_key};
-    Walker walker(cache, address_);
+    Walker walker(cache, custom_prefix_);
     insert(walker, child);
     batch.leaf_nodes.emplace_back(leaf_key, leaf_node);
   }

--- a/kvbc/src/sparse_merkle/update_cache.cpp
+++ b/kvbc/src/sparse_merkle/update_cache.cpp
@@ -15,7 +15,7 @@
 namespace concord::kvbc::sparse_merkle::detail {
 
 BatchedInternalNode UpdateCache::getInternalNode(const InternalNodeKey& key) {
-  auto it = internal_nodes_.find(key.path());
+  auto it = internal_nodes_.find(key);
   if (it != internal_nodes_.end()) {
     return it->second;
   }
@@ -29,17 +29,17 @@ void UpdateCache::putStale(const std::optional<LeafKey>& key) {
 }
 
 const BatchedInternalNode& UpdateCache::getRoot() {
-  auto it = internal_nodes_.find(NibblePath());
+  auto it = internal_nodes_.find({version_, NibblePath(), address_});
   if (it != internal_nodes_.end()) {
     return it->second;
   }
   return original_root_;
 }
 
-void UpdateCache::put(const NibblePath& path, const BatchedInternalNode& node) { internal_nodes_[path] = node; }
+void UpdateCache::put(const InternalNodeKey& key, const BatchedInternalNode& node) { internal_nodes_[key] = node; }
 
 void UpdateCache::putStale(const InternalNodeKey& key) { stale_.internal_keys.insert(key); }
 
-void UpdateCache::remove(const NibblePath& path) { internal_nodes_.erase(path); }
+void UpdateCache::remove(const InternalNodeKey& key) { internal_nodes_.erase(key); }
 
 }  // namespace concord::kvbc::sparse_merkle::detail

--- a/kvbc/src/sparse_merkle/update_cache.cpp
+++ b/kvbc/src/sparse_merkle/update_cache.cpp
@@ -29,7 +29,7 @@ void UpdateCache::putStale(const std::optional<LeafKey>& key) {
 }
 
 const BatchedInternalNode& UpdateCache::getRoot() {
-  auto it = internal_nodes_.find({address_, version_, NibblePath()});
+  auto it = internal_nodes_.find({custom_prefix_, version_, NibblePath()});
   if (it != internal_nodes_.end()) {
     return it->second;
   }

--- a/kvbc/src/sparse_merkle/update_cache.cpp
+++ b/kvbc/src/sparse_merkle/update_cache.cpp
@@ -29,7 +29,7 @@ void UpdateCache::putStale(const std::optional<LeafKey>& key) {
 }
 
 const BatchedInternalNode& UpdateCache::getRoot() {
-  auto it = internal_nodes_.find({version_, NibblePath(), address_});
+  auto it = internal_nodes_.find({address_, version_, NibblePath()});
   if (it != internal_nodes_.end()) {
     return it->second;
   }

--- a/kvbc/src/sparse_merkle/walker.cpp
+++ b/kvbc/src/sparse_merkle/walker.cpp
@@ -36,7 +36,7 @@ void Walker::descend(const Hash& key, Version next_version) {
   stack_.push(current_node_);
   Nibble next_nibble = key.getNibble(depth());
   nibble_path_.append(next_nibble);
-  InternalNodeKey next_internal_key{address_, next_version, nibble_path_};
+  InternalNodeKey next_internal_key{custom_prefix_, next_version, nibble_path_};
   current_node_ = cache_.getInternalNode(next_internal_key);
   stale_version_ = current_node_.version();
 }
@@ -68,7 +68,7 @@ void Walker::ascend() {
 
 std::optional<Nibble> Walker::removeCurrentNode() {
   markCurrentNodeStale();
-  cache_.remove({address_, stale_version_, nibble_path_});
+  cache_.remove({custom_prefix_, stale_version_, nibble_path_});
   if (!atRoot()) {
     return pop().first;
   }
@@ -78,7 +78,7 @@ std::optional<Nibble> Walker::removeCurrentNode() {
 void Walker::insertEmptyRootAtCurrentVersion() {
   auto children = BatchedInternalNode::Children{};
   children[0] = InternalChild{PLACEHOLDER_HASH, cache_.version()};
-  cache_.put({address_, cache_.version(), NibblePath{}}, BatchedInternalNode{children});
+  cache_.put({custom_prefix_, cache_.version(), NibblePath{}}, BatchedInternalNode{children});
 }
 
 std::pair<Nibble, Hash> Walker::pop() {
@@ -97,10 +97,10 @@ void Walker::markCurrentNodeStale() {
   // Don't mark the initial root stale, and don't mark an already cached node
   // stale.
   if (stale_version_ != Version(0) && stale_version_ != version()) {
-    cache_.putStale(InternalNodeKey(address_, stale_version_, nibble_path_));
+    cache_.putStale(InternalNodeKey(custom_prefix_, stale_version_, nibble_path_));
   }
 }
 
-void Walker::cacheCurrentNode() { cache_.put({address_, cache_.version(), nibble_path_}, current_node_); }
+void Walker::cacheCurrentNode() { cache_.put({custom_prefix_, cache_.version(), nibble_path_}, current_node_); }
 
 }  // namespace concord::kvbc::sparse_merkle::detail

--- a/kvbc/src/sparse_merkle/walker.cpp
+++ b/kvbc/src/sparse_merkle/walker.cpp
@@ -36,7 +36,7 @@ void Walker::descend(const Hash& key, Version next_version) {
   stack_.push(current_node_);
   Nibble next_nibble = key.getNibble(depth());
   nibble_path_.append(next_nibble);
-  InternalNodeKey next_internal_key{next_version, nibble_path_, address_};
+  InternalNodeKey next_internal_key{address_, next_version, nibble_path_};
   current_node_ = cache_.getInternalNode(next_internal_key);
   stale_version_ = current_node_.version();
 }
@@ -68,7 +68,7 @@ void Walker::ascend() {
 
 std::optional<Nibble> Walker::removeCurrentNode() {
   markCurrentNodeStale();
-  cache_.remove({stale_version_, nibble_path_, address_});
+  cache_.remove({address_, stale_version_, nibble_path_});
   if (!atRoot()) {
     return pop().first;
   }
@@ -78,7 +78,7 @@ std::optional<Nibble> Walker::removeCurrentNode() {
 void Walker::insertEmptyRootAtCurrentVersion() {
   auto children = BatchedInternalNode::Children{};
   children[0] = InternalChild{PLACEHOLDER_HASH, cache_.version()};
-  cache_.put({cache_.version(), NibblePath{}, address_}, BatchedInternalNode{children});
+  cache_.put({address_, cache_.version(), NibblePath{}}, BatchedInternalNode{children});
 }
 
 std::pair<Nibble, Hash> Walker::pop() {
@@ -97,10 +97,10 @@ void Walker::markCurrentNodeStale() {
   // Don't mark the initial root stale, and don't mark an already cached node
   // stale.
   if (stale_version_ != Version(0) && stale_version_ != version()) {
-    cache_.putStale(InternalNodeKey(stale_version_, nibble_path_, address_));
+    cache_.putStale(InternalNodeKey(address_, stale_version_, nibble_path_));
   }
 }
 
-void Walker::cacheCurrentNode() { cache_.put({cache_.version(), nibble_path_, address_}, current_node_); }
+void Walker::cacheCurrentNode() { cache_.put({address_, cache_.version(), nibble_path_}, current_node_); }
 
 }  // namespace concord::kvbc::sparse_merkle::detail

--- a/kvbc/test/sparse_merkle/test_db.h
+++ b/kvbc/test/sparse_merkle/test_db.h
@@ -24,7 +24,7 @@ class TestDB : public IDBReader {
  public:
   void put(const LeafKey& key, const LeafNode& val) { leaf_nodes_[key] = val; }
   void put(const InternalNodeKey& key, const BatchedInternalNode& val) {
-    assert(internal_nodes_.find(key) == internal_nodes_.end());
+    ConcordAssert(internal_nodes_.find(key) == internal_nodes_.end());
 
     internal_nodes_[key] = val;
     if (latest_version_[key.address()] < key.version()) {

--- a/kvbc/test/sparse_merkle/test_db.h
+++ b/kvbc/test/sparse_merkle/test_db.h
@@ -15,32 +15,35 @@
 #include "sparse_merkle/keys.h"
 #include "sparse_merkle/db_reader.h"
 #include "sparse_merkle/internal_node.h"
+#include "kvbc/include/categorization/details.h"
 
 using namespace std;
 using namespace concord::kvbc::sparse_merkle;
 
-class TestDB : public concord::kvbc::sparse_merkle::IDBReader {
+class TestDB : public IDBReader {
  public:
   void put(const LeafKey& key, const LeafNode& val) { leaf_nodes_[key] = val; }
   void put(const InternalNodeKey& key, const BatchedInternalNode& val) {
+    assert(internal_nodes_.find(key) == internal_nodes_.end());
+
     internal_nodes_[key] = val;
-    if (latest_version_ < key.version()) {
-      latest_version_ = key.version();
+    if (latest_version_[key.address()] < key.version()) {
+      latest_version_[key.address()] = key.version();
     }
   }
 
-  BatchedInternalNode get_latest_root() const override {
-    if (latest_version_ == 0) {
+  BatchedInternalNode get_latest_root(std::string address = "") const override {
+    if (latest_version_.find(address) == latest_version_.end()) {
       return BatchedInternalNode();
     }
-    auto root_key = InternalNodeKey::root(latest_version_);
+    auto root_key = InternalNodeKey::root(latest_version_.at(address), address);
     return internal_nodes_.at(root_key);
   }
 
   BatchedInternalNode get_internal(const InternalNodeKey& key) const override { return internal_nodes_.at(key); }
 
  private:
-  Version latest_version_ = 0;
+  map<std::string, Version> latest_version_;
   map<LeafKey, LeafNode> leaf_nodes_;
   map<InternalNodeKey, BatchedInternalNode> internal_nodes_;
 };

--- a/kvbc/test/sparse_merkle/test_db.h
+++ b/kvbc/test/sparse_merkle/test_db.h
@@ -27,8 +27,8 @@ class TestDB : public IDBReader {
     ConcordAssert(internal_nodes_.find(key) == internal_nodes_.end());
 
     internal_nodes_[key] = val;
-    if (latest_version_[key.address()] < key.version()) {
-      latest_version_[key.address()] = key.version();
+    if (latest_version_[key.address().value()] < key.version()) {
+      latest_version_[key.address().value()] = key.version();
     }
   }
 

--- a/kvbc/test/sparse_merkle/test_db.h
+++ b/kvbc/test/sparse_merkle/test_db.h
@@ -36,7 +36,7 @@ class TestDB : public IDBReader {
     if (latest_version_.find(address) == latest_version_.end()) {
       return BatchedInternalNode();
     }
-    auto root_key = InternalNodeKey::root(latest_version_.at(address), address);
+    auto root_key = InternalNodeKey::root(address, latest_version_.at(address));
     return internal_nodes_.at(root_key);
   }
 

--- a/kvbc/test/sparse_merkle/test_db.h
+++ b/kvbc/test/sparse_merkle/test_db.h
@@ -27,16 +27,16 @@ class TestDB : public IDBReader {
     ConcordAssert(internal_nodes_.find(key) == internal_nodes_.end());
 
     internal_nodes_[key] = val;
-    if (latest_version_[key.address().value()] < key.version()) {
-      latest_version_[key.address().value()] = key.version();
+    if (latest_version_[key.customPrefix().value()] < key.version()) {
+      latest_version_[key.customPrefix().value()] = key.version();
     }
   }
 
-  BatchedInternalNode get_latest_root(std::string address = "") const override {
-    if (latest_version_.find(address) == latest_version_.end()) {
+  BatchedInternalNode get_latest_root(std::string custom_prefix = "") const override {
+    if (latest_version_.find(custom_prefix) == latest_version_.end()) {
       return BatchedInternalNode();
     }
-    auto root_key = InternalNodeKey::root(address, latest_version_.at(address));
+    auto root_key = InternalNodeKey::root(custom_prefix, latest_version_.at(custom_prefix));
     return internal_nodes_.at(root_key);
   }
 

--- a/kvbc/test/sparse_merkle/tree_test.cpp
+++ b/kvbc/test/sparse_merkle/tree_test.cpp
@@ -274,7 +274,7 @@ TEST(tree_tests, insert_single_leaf_node) {
   // Only a single node was created. It's key is made up of an empty nibble
   // path, since there are no collisions requring going deeper into the tree.
   auto& root = batch.internal_nodes.at(0);
-  ASSERT_EQ(InternalNodeKey(1, NibblePath(), ""), root.first);
+  ASSERT_EQ(InternalNodeKey("", 1, NibblePath()), root.first);
 
   // There should be a root and a single leaf
   ASSERT_EQ(2, root.second.numChildren());

--- a/kvbc/test/sparse_merkle/tree_test.cpp
+++ b/kvbc/test/sparse_merkle/tree_test.cpp
@@ -274,7 +274,7 @@ TEST(tree_tests, insert_single_leaf_node) {
   // Only a single node was created. It's key is made up of an empty nibble
   // path, since there are no collisions requring going deeper into the tree.
   auto& root = batch.internal_nodes.at(0);
-  ASSERT_EQ(InternalNodeKey(1, NibblePath()), root.first);
+  ASSERT_EQ(InternalNodeKey(1, NibblePath(), ""), root.first);
 
   // There should be a root and a single leaf
   ASSERT_EQ(2, root.second.numChildren());

--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -113,7 +113,7 @@ bool hasProvableStaleIndexKeysSince(const std::shared_ptr<IDBClient> &db, const 
 
 bool hasInternalKeysForVersion(const std::shared_ptr<IDBClient> &db, const Version &version) {
   auto iter = db->getIteratorGuard();
-  const auto key = iter->seekAtLeast(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version, ""))).first;
+  const auto key = iter->seekAtLeast(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root("", version))).first;
   if (!key.empty() && DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key &&
       DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Internal &&
       DBKeyManipulator::extractVersionFromInternalKey(key) == version) {

--- a/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/db_adapter_unit_test.cpp
@@ -113,7 +113,7 @@ bool hasProvableStaleIndexKeysSince(const std::shared_ptr<IDBClient> &db, const 
 
 bool hasInternalKeysForVersion(const std::shared_ptr<IDBClient> &db, const Version &version) {
   auto iter = db->getIteratorGuard();
-  const auto key = iter->seekAtLeast(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version))).first;
+  const auto key = iter->seekAtLeast(DBKeyManipulator::genInternalDbKey(InternalNodeKey::root(version, ""))).first;
   if (!key.empty() && DBKeyManipulator::getDBKeyType(key) == EDBKeyType::Key &&
       DBKeyManipulator::getKeySubtype(key) == EKeySubtype::Internal &&
       DBKeyManipulator::extractVersionFromInternalKey(key) == version) {

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -294,12 +294,13 @@ TEST(key_manipulator, stale_db_key_internal) {
   // second byte of the nibble path is 0x34 (by appending 0x03 and 0x04)
   path.append(0x03);
   path.append(0x04);
-  const auto internalKey = InternalNodeKey{defaultVersion, path, ""};
+  std::string address = "abcdefg123";
+  const auto internalKey = InternalNodeKey{defaultVersion, path, address};
   const auto key = DBKeyManipulator::genStaleDbKey(internalKey, defaultVersion);
   const auto expected =
       toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::ProvableStale) +
                serializeIntegral(defaultBlockId) + DBKeyManipulator::genInternalDbKey(internalKey).toString());
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2 + 1);
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2 + 1 + address.size());
   ASSERT_TRUE(key == expected);
 }
 

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -182,7 +182,7 @@ TEST(key_manipulator, internal_key_even) {
   // second byte of the nibble path is 0x34 (by appending 0x03 and 0x04)
   path.append(0x03);
   path.append(0x04);
-  const auto internalKey = InternalNodeKey{defaultVersion, path};
+  const auto internalKey = InternalNodeKey{defaultVersion, path, ""};
   const auto key = DBKeyManipulator::genInternalDbKey(internalKey);
   // Expect that two bytes of nibbles have been written.
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
@@ -201,7 +201,7 @@ TEST(key_manipulator, internal_key_odd) {
   path.append(0x02);
   // second byte of the nibble path is 0x30 (by appending 0x03)
   path.append(0x03);
-  const auto internalKey = InternalNodeKey{defaultVersion, path};
+  const auto internalKey = InternalNodeKey{defaultVersion, path, ""};
   const auto key = DBKeyManipulator::genInternalDbKey(internalKey);
   // Expect that two bytes of nibbles have been written.
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
@@ -292,7 +292,7 @@ TEST(key_manipulator, stale_db_key_internal) {
   // second byte of the nibble path is 0x34 (by appending 0x03 and 0x04)
   path.append(0x03);
   path.append(0x04);
-  const auto internalKey = InternalNodeKey{defaultVersion, path};
+  const auto internalKey = InternalNodeKey{defaultVersion, path, ""};
   const auto key = DBKeyManipulator::genStaleDbKey(internalKey, defaultVersion);
   const auto expected =
       toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::ProvableStale) +

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -155,9 +155,9 @@ TEST(key_manipulator, extract_key_from_non_provable_stale_key) {
 TEST(key_manipulator, data_key_leaf) {
   const auto leafKey = LeafKey{defaultHash, defaultVersion};
   const auto key = DBKeyManipulator::genDataDbKey(leafKey);
-  std::string emptyAddress(concord::kvbc::sparse_merkle::PaddedAddress::TOTAL_SIZE, '\0');
+  std::string emptyCustomPrefix(concord::kvbc::sparse_merkle::PaddedCustomPrefix::TOTAL_SIZE, '\0');
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Leaf) + defaultHashStrBuf +
-                                 serializeIntegral(leafKey.version().value()) + emptyAddress);
+                                 serializeIntegral(leafKey.version().value()) + emptyCustomPrefix);
   ASSERT_EQ(key.length(), 1 + 1 + 32 + 8 + 21);
   ASSERT_TRUE(key == expected);
 }
@@ -167,9 +167,9 @@ TEST(key_manipulator, data_key_leaf) {
 TEST(key_manipulator, data_key_sliver) {
   const auto version = 42ul;
   const auto key = DBKeyManipulator::genDataDbKey(defaultSliver, version);
-  std::string emptyAddress(concord::kvbc::sparse_merkle::PaddedAddress::TOTAL_SIZE, '\0');
+  std::string emptyCustomPrefix(concord::kvbc::sparse_merkle::PaddedCustomPrefix::TOTAL_SIZE, '\0');
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Leaf) + defaultHashStrBuf +
-                                 serializeIntegral(version) + emptyAddress);
+                                 serializeIntegral(version) + emptyCustomPrefix);
   ASSERT_EQ(key.length(), 1 + 1 + 32 + 8 + 21);
   ASSERT_TRUE(key == expected);
 }
@@ -204,17 +204,17 @@ TEST(key_manipulator, internal_key_odd) {
   path.append(0x02);
   // second byte of the nibble path is 0x30 (by appending 0x03)
   path.append(0x03);
-  std::string address = "test";
-  const auto internalKey = InternalNodeKey{address, defaultVersion, path};
+  std::string custom_prefix = "test";
+  const auto internalKey = InternalNodeKey{custom_prefix, defaultVersion, path};
   const auto key = DBKeyManipulator::genInternalDbKey(internalKey);
   // Expect that two bytes of nibbles have been written.
-  const auto expected =
-      toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
-               serializeIntegral(std::uint8_t{0x4}) + serializeIntegral(address[0]) + serializeIntegral(address[1]) +
-               serializeIntegral(address[2]) + serializeIntegral(address[3]) +
-               serializeIntegral(internalKey.version().value()) + serializeIntegral(std::uint8_t{3}) +
-               serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x30}));
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2 + 1 + address.size());
+  const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
+                                 serializeIntegral(std::uint8_t{0x4}) + serializeIntegral(custom_prefix[0]) +
+                                 serializeIntegral(custom_prefix[1]) + serializeIntegral(custom_prefix[2]) +
+                                 serializeIntegral(custom_prefix[3]) +
+                                 serializeIntegral(internalKey.version().value()) + serializeIntegral(std::uint8_t{3}) +
+                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x30}));
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2 + 1 + custom_prefix.size());
   ASSERT_TRUE(key == expected);
 }
 
@@ -299,13 +299,13 @@ TEST(key_manipulator, stale_db_key_internal) {
   // second byte of the nibble path is 0x34 (by appending 0x03 and 0x04)
   path.append(0x03);
   path.append(0x04);
-  std::string address = "abcdefg123";
-  const auto internalKey = InternalNodeKey{address, defaultVersion, path};
+  std::string custom_prefix = "abcdefg123";
+  const auto internalKey = InternalNodeKey{custom_prefix, defaultVersion, path};
   const auto key = DBKeyManipulator::genStaleDbKey(internalKey, defaultVersion);
   const auto expected =
       toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::ProvableStale) +
                serializeIntegral(defaultBlockId) + DBKeyManipulator::genInternalDbKey(internalKey).toString());
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2 + 1 + address.size());
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2 + 1 + custom_prefix.size());
   ASSERT_TRUE(key == expected);
 }
 

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -187,8 +187,9 @@ TEST(key_manipulator, internal_key_even) {
   // Expect that two bytes of nibbles have been written.
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
                                  serializeIntegral(internalKey.version().value()) + serializeIntegral(std::uint8_t{4}) +
-                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x34}));
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2);
+                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x34}) +
+                                 serializeIntegral(std::uint8_t{0x0}));
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2 + 1);
   ASSERT_TRUE(key == expected);
 }
 
@@ -206,8 +207,9 @@ TEST(key_manipulator, internal_key_odd) {
   // Expect that two bytes of nibbles have been written.
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Internal) +
                                  serializeIntegral(internalKey.version().value()) + serializeIntegral(std::uint8_t{3}) +
-                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x30}));
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2);
+                                 serializeIntegral(std::uint8_t{0x12}) + serializeIntegral(std::uint8_t{0x30}) +
+                                 serializeIntegral(std::uint8_t{0x0}));
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 2 + 1);
   ASSERT_TRUE(key == expected);
 }
 
@@ -297,7 +299,7 @@ TEST(key_manipulator, stale_db_key_internal) {
   const auto expected =
       toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::ProvableStale) +
                serializeIntegral(defaultBlockId) + DBKeyManipulator::genInternalDbKey(internalKey).toString());
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2);
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 8 + 1 + 2 + 1);
   ASSERT_TRUE(key == expected);
 }
 

--- a/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/serialization_unit_test.cpp
@@ -155,9 +155,10 @@ TEST(key_manipulator, extract_key_from_non_provable_stale_key) {
 TEST(key_manipulator, data_key_leaf) {
   const auto leafKey = LeafKey{defaultHash, defaultVersion};
   const auto key = DBKeyManipulator::genDataDbKey(leafKey);
+  std::string emptyAddress(concord::kvbc::sparse_merkle::PaddedAddress::TOTAL_SIZE, '\0');
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Leaf) + defaultHashStrBuf +
-                                 serializeIntegral(leafKey.version().value()));
-  ASSERT_EQ(key.length(), 1 + 1 + 32 + 8);
+                                 serializeIntegral(leafKey.version().value()) + emptyAddress);
+  ASSERT_EQ(key.length(), 1 + 1 + 32 + 8 + 21);
   ASSERT_TRUE(key == expected);
 }
 
@@ -166,9 +167,10 @@ TEST(key_manipulator, data_key_leaf) {
 TEST(key_manipulator, data_key_sliver) {
   const auto version = 42ul;
   const auto key = DBKeyManipulator::genDataDbKey(defaultSliver, version);
+  std::string emptyAddress(concord::kvbc::sparse_merkle::PaddedAddress::TOTAL_SIZE, '\0');
   const auto expected = toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::Leaf) + defaultHashStrBuf +
-                                 serializeIntegral(version));
-  ASSERT_EQ(key.length(), 1 + 1 + 32 + 8);
+                                 serializeIntegral(version) + emptyAddress);
+  ASSERT_EQ(key.length(), 1 + 1 + 32 + 8 + 21);
   ASSERT_TRUE(key == expected);
 }
 
@@ -316,7 +318,7 @@ TEST(key_manipulator, stale_db_key_leaf) {
   const auto expected =
       toSliver(serializeEnum(EDBKeyType::Key) + serializeEnum(EKeySubtype::ProvableStale) +
                serializeIntegral(defaultBlockId) + DBKeyManipulator::genDataDbKey(leafKey).toString());
-  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 32 + 8);
+  ASSERT_EQ(key.length(), 1 + 1 + 8 + 1 + 1 + 32 + 8 + 21);
   ASSERT_TRUE(key == expected);
 }
 


### PR DESCRIPTION
Added assertion to check for collisions + fix.
Added the address field to the InternalNodeKey's serialization.

* **Problem Overview**  
 Initial work to support multiple Merkle trees in storage. This will be needed when we build a MPT per account and a global MPT where the keys will be the account addresses and the values will be the account storage Merkle roots.
* **Testing Done**  
  All unit tests pass + added a non empty address in unit test
  serialization_unit_test/stale_db_key_internal for better
  code coverage. 
Ran locally 200 times the property based test **sparse_merkle_storage_db_adapter_property_test**
