### PR TITLE
Clientservice and replica handling for primary-only logic for Eth Filter APIs

### DIFF
--- a/bftengine/include/bftengine/ClientMsgs.hpp
+++ b/bftengine/include/bftengine/ClientMsgs.hpp
@@ -62,6 +62,7 @@ struct ClientReplyMsgHeader {
   // information. The offset of the replica specific information from the start of the reply message
   // is `replyLength - replicaSpecificInfoLength`.
   uint32_t replicaSpecificInfoLength = 0;
+  bool isPrimaryOnly = false;
 };
 
 #pragma pack(pop)

--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -54,7 +54,8 @@ enum MsgFlag : uint64_t {
   INTERNAL_FLAG = 0x40,
   PUBLISH_ON_CHAIN_OBJECT_FLAG = 0x80,
   CLIENTS_PUB_KEYS_FLAG = 0x100,
-  DB_CHECKPOINT_FLAG = 0x200
+  DB_CHECKPOINT_FLAG = 0x200,
+  PRIMARY_ONLY_FLAG = 0x401
 };
 
 // The IControlHandler is a group of methods that enables the userRequestHandler to perform infrastructure

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -40,7 +40,7 @@ struct SimpleClientParams {
 };
 
 // Possible values for 'flags' parameter
-enum ClientMsgFlag : uint8_t {
+enum ClientMsgFlag : uint64_t {
   EMPTY_FLAGS_REQ = 0x0,
   READ_ONLY_REQ = 0x1,
   PRE_PROCESS_REQ = 0x2,
@@ -49,6 +49,7 @@ enum ClientMsgFlag : uint8_t {
   EMPTY_CLIENT_REQ = 0x10,
   RECONFIG_FLAG_REQ = 0x20,
   RECONFIG_READ_ONLY_REQ = 0x21,  // Same as READ_ONLY_REQ | RECONFIG_FLAG_REQ
+  PRIMARY_ONLY_REQ = 0x401,
 };
 
 // Call back for request - at this point we know for sure that a client is handling the request, so we can assure that

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4740,7 +4740,6 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
                                                     actualReplyLength,
                                                     actualReplicaSpecificInfoLength,
                                                     status));
-
   // TODO(GG): TBD - how do we want to support empty replies? (actualReplyLength==0)
   if (!status) {
     if (actualReplyLength > 0) {

--- a/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientReplyMsg.hpp
@@ -25,7 +25,7 @@ class ClientReplyMsg : public MessageBase {
   static_assert(sizeof(ClientReplyMsgHeader::reqSeqNum) == sizeof(ReqId), "");
   static_assert(sizeof(ClientReplyMsgHeader::currentPrimaryId) == sizeof(ReplicaId), "");
   static_assert(sizeof(ClientReplyMsgHeader::result) == sizeof(uint32_t), "");
-  static_assert(sizeof(ClientReplyMsgHeader) == 28, "ClientReplyMsgHeader is 28B");
+  static_assert(sizeof(ClientReplyMsgHeader) == 29, "ClientReplyMsgHeader is 29B");
 
  public:
   ClientReplyMsg(ReplicaId primaryId, ReqId reqSeqNum, ReplicaId replicaId);

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -95,6 +95,8 @@ ClientRequestMsg::ClientRequestMsg(ClientRequestMsgHeader* body)
 
 bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY_REQ) != 0; }
 
+bool ClientRequestMsg::isPrimaryOnly() const { return (msgBody()->flags & PRIMARY_ONLY_REQ) == PRIMARY_ONLY_REQ; }
+
 bool ClientRequestMsg::shouldValidateAsync() const {
   // Reconfiguration messages are validated in their own handler, so we should not do its validation in an asynchronous
   // manner, as that will lead to overhead. Similarly, key exchanges should happen rarely, and thus we should validate

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -55,6 +55,8 @@ class ClientRequestMsg : public MessageBase {
 
   bool isReadOnly() const;
 
+  bool isPrimaryOnly() const;
+
   uint64_t flags() const { return msgBody()->flags; }
 
   uint32_t result() const { return msgBody()->result; }

--- a/client/bftclient/include/bftclient/base_types.h
+++ b/client/bftclient/include/bftclient/base_types.h
@@ -36,12 +36,13 @@ struct ClientId {
   bool operator<(const ClientId& other) const { return val < other.val; }
 };
 
-enum Flags : uint8_t {
+enum Flags : uint64_t {
   EMPTY_FLAGS_REQ = 0x0,
   READ_ONLY_REQ = 0x1,
   PRE_PROCESS_REQ = 0x2,
   KEY_EXCHANGE_REQ = 0x8,
-  RECONFIG_FLAG = 0x20
+  RECONFIG_FLAG = 0x20,
+  PRIMARY_ONLY_REQ = 0x401
 };
 
 struct ReplicaSpecificInfo {

--- a/client/bftclient/include/bftclient/config.h
+++ b/client/bftclient/include/bftclient/config.h
@@ -82,6 +82,7 @@ struct RequestConfig {
   std::string span_context = "";
   bool key_exchange = false;
   bool reconfiguration = false;
+  bool primary_only = false;
 };
 
 // The configuration for a single write request.

--- a/client/bftclient/src/msg_receiver.cpp
+++ b/client/bftclient/src/msg_receiver.cpp
@@ -83,6 +83,7 @@ void MsgReceiver::onNewMessage(bft::communication::NodeNum source,
   reply.metadata = metadata;
   reply.rsi = std::move(rsi);
   reply.data = Msg(start_of_body, start_of_rsi);
+  reply.isPrimaryOnly = header->isPrimaryOnly;
 
   queue_.push(std::move(reply));
 }

--- a/client/bftclient/src/msg_receiver.h
+++ b/client/bftclient/src/msg_receiver.h
@@ -46,6 +46,7 @@ struct UnmatchedReply {
   ReplyMetadata metadata;
   Msg data;
   ReplicaSpecificInfo rsi;
+  bool isPrimaryOnly;
 };
 
 // A thread-safe queue that allows the ASIO thread to push newly received messages and the client

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -480,6 +480,9 @@ void SingleRequestProcessingJob::execute() {
       read_config_.request.max_reply_size = max_reply_size_;
     }
     read_config_.request.reconfiguration = flags_ & RECONFIG_FLAG_REQ;
+    if ((flags_ & PRIMARY_ONLY_REQ) == PRIMARY_ONLY_REQ) {
+      read_config_.request.primary_only = true;
+    }
     res = processing_client_->SendRequest(read_config_, std::move(request_));
   } else {
     write_config_.request.timeout = timeout_ms_;

--- a/client/client_pool/src/concord_client_pool.cpp
+++ b/client/client_pool/src/concord_client_pool.cpp
@@ -235,8 +235,15 @@ SubmitResult ConcordClientPool::SendRequest(const bft::client::ReadConfig &confi
     callback(bftEngine::SendResult{static_cast<uint32_t>(OperationResult::INVALID_REQUEST)});
     return SubmitResult::Overloaded;
   }
-  auto request_flag =
-      config.request.reconfiguration ? ClientMsgFlag::RECONFIG_READ_ONLY_REQ : ClientMsgFlag::READ_ONLY_REQ;
+
+  bftEngine::ClientMsgFlag request_flag;
+
+  if (config.request.primary_only) {
+    request_flag = ClientMsgFlag::PRIMARY_ONLY_REQ;
+  } else {
+    request_flag =
+        config.request.reconfiguration ? ClientMsgFlag::RECONFIG_READ_ONLY_REQ : ClientMsgFlag::READ_ONLY_REQ;
+  }
   return SendRequest(std::forward<std::vector<uint8_t>>(request),
                      request_flag,
                      config.request.timeout,

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -97,6 +97,7 @@ void RequestServiceCallData::sendToConcordClient() {
   req_config.pre_execute = request_.pre_execute();
   req_config.timeout = timeout;
   req_config.correlation_id = request_.correlation_id();
+  req_config.primary_only = request_.primary_only();
 
   auto callback = [this, req_config, is_any_request_type](concord::client::concordclient::SendResult&& send_result) {
     grpc::Status status;

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -130,6 +130,7 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
 void ConcordClient::send(const bft::client::ReadConfig& config,
                          bft::client::Msg&& msg,
                          const std::function<void(SendResult&&)>& callback) {
+  LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
   client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
 }
 

--- a/client/concordclient/src/concord_client.cpp
+++ b/client/concordclient/src/concord_client.cpp
@@ -130,7 +130,6 @@ ConcordClientPoolConfig ConcordClient::createClientPoolStruct(const ConcordClien
 void ConcordClient::send(const bft::client::ReadConfig& config,
                          bft::client::Msg&& msg,
                          const std::function<void(SendResult&&)>& callback) {
-  LOG_INFO(logger_, "Log message until config is used f=" << config_.topology.f_val);
   client_pool_->SendRequest(config, std::forward<bft::client::Msg>(msg), callback);
 }
 

--- a/client/proto/request/v1/request.proto
+++ b/client/proto/request/v1/request.proto
@@ -65,6 +65,12 @@ message Request {
   // `correlation_id` to a sequence number which can be used to track the request
   // in log messages in the blockchain network.
   optional string correlation_id = 5;
+
+  // Optional flag to mark the request as primary-only.
+  // A primary-only request is a read-only request intended to be served by 
+  // primary node only and this request is ignored by other non-primary nodes.
+  // Concord Client acknowledges replies from primary node only.
+  optional bool primary_only = 7;
 }
 
 message Response {


### PR DESCRIPTION

* **Problem Overview**  
 This handling involves introducing PRIMARY_ONLY flag and setting it when we receive request from ethrpc and propagate this flag appropriately to Concord where it can, send replies from primary node only and do not process request on any other node. Replies are tagged with same flag so that we don't participate in reply consensus as reply is served only from primary node. 
