### PR TITLE
Clientservice and replica handling for primary-only logic for Eth Filter APIs

### DIFF
--- a/bftengine/include/bftengine/Replica.hpp
+++ b/bftengine/include/bftengine/Replica.hpp
@@ -54,7 +54,8 @@ enum MsgFlag : uint64_t {
   INTERNAL_FLAG = 0x40,
   PUBLISH_ON_CHAIN_OBJECT_FLAG = 0x80,
   CLIENTS_PUB_KEYS_FLAG = 0x100,
-  DB_CHECKPOINT_FLAG = 0x200
+  DB_CHECKPOINT_FLAG = 0x200,
+  PRIMARY_ONLY_FLAG = 0x401
 };
 
 // The IControlHandler is a group of methods that enables the userRequestHandler to perform infrastructure

--- a/bftengine/include/bftengine/SimpleClient.hpp
+++ b/bftengine/include/bftengine/SimpleClient.hpp
@@ -40,7 +40,7 @@ struct SimpleClientParams {
 };
 
 // Possible values for 'flags' parameter
-enum ClientMsgFlag : uint8_t {
+enum ClientMsgFlag : uint64_t {
   EMPTY_FLAGS_REQ = 0x0,
   READ_ONLY_REQ = 0x1,
   PRE_PROCESS_REQ = 0x2,
@@ -49,6 +49,7 @@ enum ClientMsgFlag : uint8_t {
   EMPTY_CLIENT_REQ = 0x10,
   RECONFIG_FLAG_REQ = 0x20,
   RECONFIG_READ_ONLY_REQ = 0x21,  // Same as READ_ONLY_REQ | RECONFIG_FLAG_REQ
+  PRIMARY_ONLY_REQ = 0x401,
 };
 
 // Call back for request - at this point we know for sure that a client is handling the request, so we can assure that

--- a/bftengine/src/bftengine/ReplicaImp.cpp
+++ b/bftengine/src/bftengine/ReplicaImp.cpp
@@ -4687,6 +4687,14 @@ void ReplicaImp::executeReadOnlyRequest(concordUtils::SpanWrapper &parent_span, 
   ClientReplyMsg reply(currentPrimary(), request->requestSeqNum(), config_.getreplicaId());
   uint16_t clientId = request->clientProxyId();
   int status = 0;
+
+  // Send dummy reply to clients if this is not primary replica, as primary replica will only process the request
+  if (request->isPrimaryOnly() && !isCurrentPrimary()) {
+    LOG_DEBUG(GL, "PrimaryOnly & ReadOnly request received and node not current primary, sending dummy reply back.");
+    send(&reply, clientId);
+    return;
+  }
+
   bftEngine::IRequestsHandler::ExecutionRequestsQueue accumulatedRequests;
   accumulatedRequests.push_back(bftEngine::IRequestsHandler::ExecutionRequest{clientId,
                                                                               static_cast<uint64_t>(lastExecutedSeqNum),

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.cpp
@@ -95,6 +95,8 @@ ClientRequestMsg::ClientRequestMsg(ClientRequestMsgHeader* body)
 
 bool ClientRequestMsg::isReadOnly() const { return (msgBody()->flags & READ_ONLY_REQ) != 0; }
 
+bool ClientRequestMsg::isPrimaryOnly() const { return (msgBody()->flags & PRIMARY_ONLY_REQ) == PRIMARY_ONLY_REQ; }
+
 bool ClientRequestMsg::shouldValidateAsync() const {
   // Reconfiguration messages are validated in their own handler, so we should not do its validation in an asynchronous
   // manner, as that will lead to overhead. Similarly, key exchanges should happen rarely, and thus we should validate

--- a/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
+++ b/bftengine/src/bftengine/messages/ClientRequestMsg.hpp
@@ -55,6 +55,8 @@ class ClientRequestMsg : public MessageBase {
 
   bool isReadOnly() const;
 
+  bool isPrimaryOnly() const;
+
   uint64_t flags() const { return msgBody()->flags; }
 
   uint32_t result() const { return msgBody()->result; }

--- a/client/bftclient/include/bftclient/base_types.h
+++ b/client/bftclient/include/bftclient/base_types.h
@@ -36,12 +36,13 @@ struct ClientId {
   bool operator<(const ClientId& other) const { return val < other.val; }
 };
 
-enum Flags : uint8_t {
+enum Flags : uint64_t {
   EMPTY_FLAGS_REQ = 0x0,
   READ_ONLY_REQ = 0x1,
   PRE_PROCESS_REQ = 0x2,
   KEY_EXCHANGE_REQ = 0x8,
-  RECONFIG_FLAG = 0x20
+  RECONFIG_FLAG = 0x20,
+  PRIMARY_ONLY_REQ = 0x401
 };
 
 struct ReplicaSpecificInfo {

--- a/client/bftclient/include/bftclient/config.h
+++ b/client/bftclient/include/bftclient/config.h
@@ -82,6 +82,7 @@ struct RequestConfig {
   std::string span_context = "";
   bool key_exchange = false;
   bool reconfiguration = false;
+  bool primary_only = false;
 };
 
 // The configuration for a single write request.

--- a/client/bftclient/src/bft_client.cpp
+++ b/client/bftclient/src/bft_client.cpp
@@ -78,7 +78,7 @@ Client::Client(SharedCommPtr comm, const ClientConfig& config, std::shared_ptr<c
 }
 
 Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool read_only, uint16_t client_id) {
-  uint8_t flags = read_only ? READ_ONLY_REQ : EMPTY_FLAGS_REQ;
+  uint64_t flags = read_only ? READ_ONLY_REQ : EMPTY_FLAGS_REQ;
   size_t expected_sig_len = 0;
   bool write_req_with_pre_exec = !read_only && config.pre_execute;
 
@@ -92,6 +92,11 @@ Msg Client::createClientMsg(const RequestConfig& config, Msg&& request, bool rea
   if (config.reconfiguration) {
     flags |= RECONFIG_FLAG;
   }
+
+  if (config.primary_only) {
+    flags |= PRIMARY_ONLY_REQ;
+  }
+
   auto header_size = sizeof(ClientRequestMsgHeader);
   auto msg_size = header_size + request.size() + config.correlation_id.size() + config.span_context.size();
   if (transaction_signer_) {
@@ -318,10 +323,24 @@ void Client::wait(SeqNumToReplyMap& replies) {
       auto request = reply_certificates_.find(reply.metadata.seq_num);
       if (request == reply_certificates_.end()) continue;
       if (pending_requests_.size() > 0 && replies.size() == pending_requests_.size()) return;
-      if (auto match = request->second.onReply(std::move(reply))) {
-        primary_ = request->second.getPrimary();
-        replies.insert(std::make_pair(request->first, match->reply));
-        reply_certificates_.erase(request->first);
+
+      if (request->second.isPrimaryOnly()) {
+        // isPrimaryOnly flag set case - we process reply from Primary Node
+        //  and ignore all other replies from non-Primary nodes
+        if (reply.metadata.primary.value().val == reply.rsi.from.val) {
+          LOG_DEBUG(logger_, "Reply received with isPrimaryOnly flag from Primary node");
+          primary_ = reply.metadata.primary;
+          std::map<ReplicaId, Msg> trsi = {{reply.rsi.from, reply.rsi.data}};
+          replies.insert(std::make_pair(request->first, Reply{reply.metadata.result, reply.data, trsi}));
+          reply_certificates_.erase(request->first);
+        }
+      } else {
+        // Generic case
+        if (auto match = request->second.onReply(std::move(reply))) {
+          primary_ = request->second.getPrimary();
+          replies.insert(std::make_pair(request->first, match->reply));
+          reply_certificates_.erase(request->first);
+        }
       }
     }
   }
@@ -362,6 +381,11 @@ MatchConfig Client::readConfigToMatchConfig(const ReadConfig& read_config) {
   } else {
     mc.quorum = quorum_converter_.toMofN(std::get<MofN>(read_config.quorum));
   }
+
+  if (read_config.request.primary_only) {
+    mc.is_primary_only = read_config.request.primary_only;
+  }
+
   return mc;
 }
 

--- a/client/bftclient/src/matcher.h
+++ b/client/bftclient/src/matcher.h
@@ -27,6 +27,7 @@ struct MatchConfig {
   MofN quorum;
   uint64_t sequence_number;
   bool include_primary_ = true;  // by default part of the match is the current primary
+  bool is_primary_only = false;  // set only if the request is primary-only request
 };
 
 // The parts of data that must match in a reply for quorum to be reached
@@ -71,6 +72,8 @@ class Matcher {
     if (!config_.include_primary_) return std::nullopt;
     return primary_;
   }
+
+  bool isPrimaryOnly() { return config_.is_primary_only; }
 
  private:
   // Check the validity of a reply

--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -98,6 +98,7 @@ void RequestServiceCallData::sendToConcordClient() {
   req_config.max_reply_size = client_->getMaxReplyBufferSize();
   req_config.timeout = timeout;
   req_config.correlation_id = request_.correlation_id();
+  req_config.primary_only = request_.primary_only();
 
   auto callback = [this, req_config, is_any_request_type](concord::client::concordclient::SendResult&& send_result) {
     grpc::Status status;

--- a/client/proto/request/v1/request.proto
+++ b/client/proto/request/v1/request.proto
@@ -65,6 +65,13 @@ message Request {
   // `correlation_id` to a sequence number which can be used to track the request
   // in log messages in the blockchain network.
   optional string correlation_id = 5;
+
+  // Optional flag to mark the request as primary-only.
+  // A primary-only request is a read-only request intended to be served by 
+  // primary validator node only and
+  // this request is ignored by other non-primary validator nodes.
+  // Concord Client acknowledges replies from primary node only.
+  optional bool primary_only = 7;
 }
 
 message Response {


### PR DESCRIPTION
* **Problem Overview**  

This handling involves introducing PRIMARY_ONLY flag and setting it when we receive request from ethrpc and propagate this flag appropriately to Concord where it can, send replies from primary node only and do not process request on any other node. We tag the corresponding match config with same flag in reply certificates so that we don't participate in reply consensus as reply is served only from primary node.

The use case for this approach is to support ETH Filter APIs (eth_newFilter, eth_getFilterLogs, eth_uninstallFilter etc). These APIs are designed to be read requests which are intended to served by primary node only and not served by any other non-primary nodes.

