### PR TITLE
Add signature field to response proto object

### DIFF
--- a/client/clientservice/src/request_service.cpp
+++ b/client/clientservice/src/request_service.cpp
@@ -181,7 +181,17 @@ void RequestServiceCallData::sendToConcordClient() {
     } else {
       this->response_.set_raw_response(std::move(data));
     }
-
+    if (!reply.rsi.empty()) {
+      for (const auto& [id, sig] : reply.rsi) {
+        if (sig.empty()) {
+          continue;
+        }
+        auto obj = this->response_.add_signatures();
+        obj->set_id(id.val);
+        obj->set_signature(std::string(sig.begin(), sig.end()));
+        LOG_TRACE(logger, "received rsi:" << id.val << " " << std::string(sig.begin(), sig.end()));
+      }
+    }
     metrics_.num_completed_requests++;
     updateAggregator();
     this->populateResult(grpc::Status::OK);

--- a/client/proto/request/v1/request.proto
+++ b/client/proto/request/v1/request.proto
@@ -74,12 +74,18 @@ message Request {
   optional bool primary_only = 7;
 }
 
+message Signature {
+  int32 id = 1;
+  bytes signature = 2;
+}
+
 message Response {
   // Application data returned by the execution engine.
   oneof application_response {
     bytes raw_response = 1;
     google.protobuf.Any typed_response = 6;
-  } 
+  }
+  repeated Signature signatures = 7;
 }
 
 //Error messages corresponding to the error returned by request service. 


### PR DESCRIPTION
* **Problem Overview**  
  We need a new signatures field in the response so that any user can verify that the response is valid.
  Currently this is done only for ethereum requests.
  This change collects the signatures from the RSI field and stores them in the new signatures field.
  Whoever made the request will handle the signatures as needed.
* **Testing Done**  
  Tested with signing ethereum requests and then verifying them on the user side
