### PR TITLE
Removing the badge for codecoverage from landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(gcc)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28gcc%29")
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Release%20build%20(clang)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Release+build+%28clang%29")
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(clang)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28clang%29")
-[![codecoverage](https://github.com/vmware/concord-bft/actions/workflows/codecoverage.yml/badge.svg)](https://github.com/vmware/concord-bft/actions/workflows/codecoverage.yml)
 
 <!-- ![Concored-bft Logo](TBD) -->
 


### PR DESCRIPTION
* **Problem Overview**  
Code coverage calculation is an internal process, and it's not been very stable recently. @cjn please restore the badge when the job has been stabilized.

* **Testing Done**  
N/A - just documentation
