### PR TITLE
Recover the wallet service implicitly on startup

### DIFF
--- a/utt/include/config.hpp
+++ b/utt/include/config.hpp
@@ -37,8 +37,8 @@ class PublicConfig {
   PublicConfig(PublicConfig&& o);
   PublicConfig& operator=(PublicConfig&& o);
 
-  bool operator==(const PublicConfig& o);
-  bool operator!=(const PublicConfig& o);
+  bool operator==(const PublicConfig& o) const;
+  bool operator!=(const PublicConfig& o) const;
 
   std::string getCommitVerificationKey() const;
   std::string getRegistrationVerificationKey() const;

--- a/utt/libutt/src/api/config.cpp
+++ b/utt/libutt/src/api/config.cpp
@@ -34,12 +34,12 @@ PublicConfig::~PublicConfig() = default;
 PublicConfig::PublicConfig(PublicConfig&& o) = default;
 PublicConfig& PublicConfig::operator=(PublicConfig&& o) = default;
 
-bool PublicConfig::operator==(const PublicConfig& o) {
+bool PublicConfig::operator==(const PublicConfig& o) const {
   return pImpl_->params_ == o.pImpl_->params_ && pImpl_->commitVerificationKey_ == o.pImpl_->commitVerificationKey_ &&
          pImpl_->registrationVerificationKey_ == o.pImpl_->registrationVerificationKey_;
 }
 
-bool PublicConfig::operator!=(const PublicConfig& o) { return !operator==(o); }
+bool PublicConfig::operator!=(const PublicConfig& o) const { return !operator==(o); }
 
 std::string PublicConfig::getCommitVerificationKey() const {
   return libutt::serialize<libutt::RandSigPK>(pImpl_->commitVerificationKey_);

--- a/utt/privacy-wallet-lib/include/storage/FileBasedUserStorage.hpp
+++ b/utt/privacy-wallet-lib/include/storage/FileBasedUserStorage.hpp
@@ -32,12 +32,16 @@ class FileBasedUserStorage : public IStorage {
   void removeCoin(const libutt::api::Coin&) override;
   void startTransaction() override;
   void commit() override;
+  void setUserId(const std::string& user_id) override;
+  void setUttPublicConfig(const libutt::api::PublicConfig& utt_public_config) override;
 
   libutt::api::types::CurvePoint getClientSideSecret() override;
   libutt::api::types::CurvePoint getSystemSideSecret() override;
   libutt::api::types::Signature getRcmSignature() override;
   std::vector<libutt::api::Coin> getCoins() override;
   std::pair<std::string, std::string> getKeyPair() override;
+  std::string getUserId() override;
+  libutt::api::PublicConfig getUttPublicConfig() override;
 
  protected:
   std::string state_path_;

--- a/utt/privacy-wallet-lib/src/storage/FileBasedUserStorage.cpp
+++ b/utt/privacy-wallet-lib/src/storage/FileBasedUserStorage.cpp
@@ -117,6 +117,20 @@ void FileBasedUserStorage::setCoin(const libutt::api::Coin& c) {
   state_["coins"][bytesToHex(c.getNullifier())] = bytesToHex(libutt::api::serialize(c));
 }
 
+void FileBasedUserStorage::setUserId(const std::string& user_id) {
+  if (state_.contains("user_id") && getUserId() != user_id) {
+    throw std::runtime_error("user id is already set");
+  }
+  state_["user_id"] = user_id;
+}
+
+void FileBasedUserStorage::setUttPublicConfig(const libutt::api::PublicConfig& utt_public_config) {
+  if (state_.contains("utt_public_config") && getUttPublicConfig() != utt_public_config) {
+    throw std::runtime_error("utt public configuration is already set");
+  }
+  state_["utt_public_config"] = bytesToHex(libutt::api::serialize(utt_public_config));
+}
+
 void FileBasedUserStorage::removeCoin(const libutt::api::Coin& c) {
   state_["coins"].erase(bytesToHex(c.getNullifier()));
 }
@@ -160,4 +174,15 @@ std::pair<std::string, std::string> FileBasedUserStorage::getKeyPair() {
   auto pk = hexStringToBytes(state_["key_pair"]["pk"]);
   return {std::string(sk.begin(), sk.end()), std::string(pk.begin(), pk.end())};
 }
+
+std::string FileBasedUserStorage::getUserId() {
+  if (!state_.contains("user_id")) return std::string();
+  return state_["user_id"];
+}
+
+libutt::api::PublicConfig FileBasedUserStorage::getUttPublicConfig() {
+  if (!state_.contains("utt_public_config")) return libutt::api::PublicConfig();
+  return libutt::api::deserialize<libutt::api::PublicConfig>(hexStringToBytes(state_["utt_public_config"]));
+}
+
 }  // namespace utt::client

--- a/utt/privacy-wallet-lib/tests/storage/FileBasedStorageTests.cpp
+++ b/utt/privacy-wallet-lib/tests/storage/FileBasedStorageTests.cpp
@@ -40,7 +40,7 @@ class test_utt_storage : public libutt::api::testing::test_utt_instance {
   void restartStorage() { storage_ = std::make_unique<utt::client::FileBasedUserStorage>(storage_path); }
 
   std::string storage_path = "./test_storage";
-  std::unique_ptr<utt::client::IStorage> storage_;
+  std::unique_ptr<utt::client::FileBasedUserStorage> storage_;
 };
 TEST_F(test_utt_storage, test_isNewStorage) {
   ASSERT_TRUE(storage_->isNewStorage());
@@ -52,6 +52,60 @@ TEST_F(test_utt_storage, test_isNewStorage_negative) {
   ASSERT_TRUE(storage_->isNewStorage());
   storage_->setKeyPair({"private_key", "public_key"});
   ASSERT_TRUE(storage_->isNewStorage());
+}
+
+TEST_F(test_utt_storage, test_set_user_id) {
+  ASSERT_TRUE(storage_->isNewStorage());
+  {
+    IStorage::tx_guard g(*storage_);
+    storage_->setUserId("user_1");
+  }
+  restartStorage();
+  ASSERT_FALSE(storage_->isNewStorage());
+  ASSERT_EQ(storage_->getUserId(), "user_1");
+}
+
+TEST_F(test_utt_storage, test_get_empty_user_id) {
+  ASSERT_TRUE(storage_->isNewStorage());
+  ASSERT_EQ(storage_->getUserId(), "");
+}
+
+TEST_F(test_utt_storage, test_assert_on_resetting_client_id) {
+  ASSERT_TRUE(storage_->isNewStorage());
+  {
+    IStorage::tx_guard g(*storage_);
+    storage_->setUserId("user_1");
+  }
+  restartStorage();
+  ASSERT_NO_THROW(storage_->setUserId("user_1"));
+  ASSERT_ANY_THROW(storage_->setUserId("user_2"));
+}
+
+TEST_F(test_utt_storage, test_set_utt_public_config) {
+  ASSERT_TRUE(storage_->isNewStorage());
+  {
+    IStorage::tx_guard g(*storage_);
+    storage_->setUttPublicConfig(config->getPublicConfig());
+  }
+  restartStorage();
+  ASSERT_FALSE(storage_->isNewStorage());
+  ASSERT_EQ(storage_->getUttPublicConfig(), config->getPublicConfig());
+}
+
+TEST_F(test_utt_storage, test_get_empty_utt_public_config) {
+  ASSERT_TRUE(storage_->isNewStorage());
+  ASSERT_EQ(storage_->getUttPublicConfig(), libutt::api::PublicConfig());
+}
+
+TEST_F(test_utt_storage, test_assert_on_utt_public_config) {
+  ASSERT_TRUE(storage_->isNewStorage());
+  {
+    IStorage::tx_guard g(*storage_);
+    storage_->setUttPublicConfig(config->getPublicConfig());
+  }
+  restartStorage();
+  ASSERT_NO_THROW(storage_->setUttPublicConfig(config->getPublicConfig()));
+  ASSERT_ANY_THROW(storage_->setUttPublicConfig(libutt::api::PublicConfig()));
 }
 
 TEST_F(test_utt_storage, test_setKeyPair) {

--- a/utt/privacy-wallet-service/include/PrivacyService.hpp
+++ b/utt/privacy-wallet-service/include/PrivacyService.hpp
@@ -26,7 +26,7 @@ namespace utt::walletservice {
 //@TODO hide on its own file..
 class PrivacyWalletServiceImpl final : public vmware::concord::privacy::wallet::api::v1::PrivacyWalletService::Service {
  public:
-  PrivacyWalletServiceImpl() {}
+  PrivacyWalletServiceImpl();
   ::grpc::Status PrivacyWalletService(
       ::grpc::ServerContext* context,
       const ::vmware::concord::privacy::wallet::api::v1::PrivacyWalletRequest* request,

--- a/utt/privacy-wallet-service/include/Wallet.hpp
+++ b/utt/privacy-wallet-service/include/Wallet.hpp
@@ -47,8 +47,10 @@ class Wallet {
   uint64_t getBudget() const;
   bool isRegistered() const;
   std::vector<utt::client::CoinDescriptor> getCoinsDescriptors() const;
+  static std::unique_ptr<Wallet> recoverFromStorage(const std::string& storage_path);
 
  private:
+  Wallet() = default;
   std::string userId_;
   std::string private_key_;
   std::unique_ptr<utt::client::User> user_;

--- a/utt/privacy-wallet-service/src/PrivacyService.cpp
+++ b/utt/privacy-wallet-service/src/PrivacyService.cpp
@@ -20,6 +20,8 @@
 using namespace utt::client::utils::crypto;
 using namespace ::vmware::concord::privacy::wallet::api::v1;
 namespace utt::walletservice {
+const std::string PrivacyWalletServiceImpl::wallet_db_path = "wallet-db";
+
 PrivacyWalletService::PrivacyWalletService() : privacy_wallet_service_(std::make_unique<PrivacyWalletServiceImpl>()) {
   utt::client::Initialize();
 }
@@ -48,9 +50,12 @@ void PrivacyWalletService::Shutdown() {
     std::cout << "server shutdown complete.." << std::endl;
   }
 }
-
-const std::string PrivacyWalletServiceImpl::wallet_db_path = "wallet-db";
-
+PrivacyWalletServiceImpl::PrivacyWalletServiceImpl() {
+  wallet_ = Wallet::recoverFromStorage(PrivacyWalletServiceImpl::wallet_db_path);
+  if (wallet_) {
+    std::cout << "wallet service recovered from storage" << std::endl;
+  }
+}
 ::grpc::Status PrivacyWalletServiceImpl::PrivacyWalletService(::grpc::ServerContext* context,
                                                               const PrivacyWalletRequest* request,
                                                               PrivacyWalletResponse* response) {

--- a/utt/privacy-wallet-service/src/PrivacyService.cpp
+++ b/utt/privacy-wallet-service/src/PrivacyService.cpp
@@ -52,7 +52,13 @@ void PrivacyWalletService::Shutdown() {
   }
 }
 PrivacyWalletServiceImpl::PrivacyWalletServiceImpl() {
-  wallet_ = Wallet::recoverFromStorage(PrivacyWalletServiceImpl::wallet_db_path);
+  try {
+    wallet_ = Wallet::recoverFromStorage(PrivacyWalletServiceImpl::wallet_db_path);
+  } catch (...) {
+    std::cout << "storage is corrupted, unable to restore the wallet service from the given storage" << std::endl;
+    std::exit(0);
+  }
+
   if (wallet_) {
     std::cout << "wallet service recovered from storage" << std::endl;
   }

--- a/utt/privacy-wallet-service/src/PrivacyService.cpp
+++ b/utt/privacy-wallet-service/src/PrivacyService.cpp
@@ -22,8 +22,9 @@ using namespace ::vmware::concord::privacy::wallet::api::v1;
 namespace utt::walletservice {
 const std::string PrivacyWalletServiceImpl::wallet_db_path = "wallet-db";
 
-PrivacyWalletService::PrivacyWalletService() : privacy_wallet_service_(std::make_unique<PrivacyWalletServiceImpl>()) {
+PrivacyWalletService::PrivacyWalletService() {
   utt::client::Initialize();
+  privacy_wallet_service_ = std::make_unique<PrivacyWalletServiceImpl>();
 }
 
 PrivacyWalletService::~PrivacyWalletService() { std::cout << " Destroying privacy wallet service...\n"; }

--- a/utt/privacy-wallet-service/src/Wallet.cpp
+++ b/utt/privacy-wallet-service/src/Wallet.cpp
@@ -30,6 +30,18 @@ Wallet::Wallet(std::string userId,
   if (!user_) throw std::runtime_error("Failed to create user!");
   registered_ = user_->hasRegistrationCommitment();
 }
+
+std::unique_ptr<Wallet> Wallet::recoverFromStorage(const std::string& storage_path) {
+  auto storage_ = std::make_shared<utt::client::FileBasedUserStorage>(storage_path);
+  if (storage_->isNewStorage()) return nullptr;
+  std::unique_ptr<Wallet> wallet = std::unique_ptr<Wallet>(new Wallet());
+  wallet->userId_ = storage_->getUserId();
+  wallet->private_key_ = storage_->getKeyPair().first;
+  wallet->user_ = utt::client::loadUserFromStorage(storage_);
+  wallet->registered_ = wallet->user_->hasRegistrationCommitment();
+  return wallet;
+}
+
 std::optional<Wallet::RegistrationInput> Wallet::generateRegistrationInput() {
   if (registered_) return std::nullopt;
   Wallet::RegistrationInput ret;

--- a/utt/privacy-wallet-service/tests/grpc-service/grpc-server-test.cpp
+++ b/utt/privacy-wallet-service/tests/grpc-service/grpc-server-test.cpp
@@ -205,7 +205,7 @@ class test_privacy_wallet_grpc_service : public libutt::api::testing::test_utt_i
   }
   void restartServer() {
     server_->Shutdown();
-    server_.release();
+    (void)server_.release();
     server_ = std::make_unique<utt::walletservice::PrivacyWalletService>();
     // We listen on a different port to avoid Error code 14 : failed to connect to all addresses
     std::string grpc_uri_2 = "127.0.0.1:50052";

--- a/utt/utt-client-api/include/storage/IStorage.hpp
+++ b/utt/utt-client-api/include/storage/IStorage.hpp
@@ -14,6 +14,7 @@
 #pragma once
 #include <vector>
 #include "coin.hpp"
+#include "config.hpp"
 
 namespace utt::client {
 class IStorage {
@@ -73,6 +74,20 @@ class IStorage {
   virtual void setCoin(const libutt::api::Coin& coin) = 0;
 
   /**
+   * @brief Set user id
+   *
+   * @param user_id
+   */
+  virtual void setUserId(const std::string& user_id) = 0;
+
+  /**
+   * @brief Set the Utt Public Config object
+   *
+   * @param utt_public_config
+   */
+  virtual void setUttPublicConfig(const libutt::api::PublicConfig& utt_public_config) = 0;
+
+  /**
    * @brief Remove a utt coin from the storage
    *
    * @param coin a utt coin object
@@ -114,6 +129,19 @@ class IStorage {
    */
   virtual std::pair<std::string, std::string> getKeyPair() = 0;
 
+  /**
+   * @brief Get the User Id
+   *
+   * @return std::string
+   */
+  virtual std::string getUserId() = 0;
+
+  /**
+   * @brief Get the Utt Public Configuration
+   *
+   * @return libutt::api::PublicConfig
+   */
+  virtual libutt::api::PublicConfig getUttPublicConfig() = 0;
   /**
    * @brief Starts a new atomic transaction
    *

--- a/utt/utt-client-api/include/utt-client-api/ClientApi.hpp
+++ b/utt/utt-client-api/include/utt-client-api/ClientApi.hpp
@@ -58,6 +58,6 @@ std::unique_ptr<User> createUser(const std::string& userId,
                                  std::shared_ptr<IStorage> storage);
 
 // Load an existing user from storage
-std::unique_ptr<User> loadUserFromStorage(IStorage& storage);
+std::unique_ptr<User> loadUserFromStorage(std::shared_ptr<IStorage> storage);
 
 }  // namespace utt::client

--- a/utt/utt-client-api/include/utt-client-api/User.hpp
+++ b/utt/utt-client-api/include/utt-client-api/User.hpp
@@ -123,7 +123,7 @@ class User {
                                           const std::string& public_key,
                                           std::shared_ptr<IStorage> storage);
 
-  friend std::unique_ptr<User> loadUserFromStorage(IStorage& storage);
+  friend std::unique_ptr<User> loadUserFromStorage(std::shared_ptr<IStorage> storage);
 
   static std::unique_ptr<User> createInitial(const std::string& userId,
                                              const utt::PublicConfig& config,
@@ -131,7 +131,7 @@ class User {
                                              const std::string& public_key,
                                              std::shared_ptr<IStorage> storage);
 
-  void recoverFromStorage(IStorage& storage);
+  static std::unique_ptr<User> recoverFromStorage(std::shared_ptr<IStorage> storage);
 
   struct Impl;
   std::unique_ptr<Impl> pImpl_;

--- a/utt/utt-client-api/src/ClientApi.cpp
+++ b/utt/utt-client-api/src/ClientApi.cpp
@@ -81,4 +81,9 @@ std::unique_ptr<User> createUser(const std::string& userId,
   return User::createInitial(userId, config, private_key, public_key, storage);
 }
 
+std::unique_ptr<User> loadUserFromStorage(std::shared_ptr<IStorage> storage) {
+  if (!s_initialized) throw std::runtime_error("Privacy Client API not initialized!");
+  return User::recoverFromStorage(storage);
+}
+
 }  // namespace utt::client

--- a/utt/utt-client-api/src/User.cpp
+++ b/utt/utt-client-api/src/User.cpp
@@ -257,13 +257,11 @@ std::unique_ptr<User> User::createInitial(const std::string& userId,
   if (private_key.empty()) throw std::runtime_error("User private key cannot be empty!");
   if (public_key.empty()) throw std::runtime_error("User public key cannot be empty!");
 
-  bool isNewStorage = storage->isNewStorage();
-  if (isNewStorage) {
-    IStorage::tx_guard g(*storage);
-    storage->setKeyPair({private_key, public_key});
-  }
+  IStorage::tx_guard g(*storage);
+  storage->setUserId(userId);
+  storage->setKeyPair({private_key, public_key});
   auto uttConfig = libutt::api::deserialize<libutt::api::PublicConfig>(config);
-
+  storage->setUttPublicConfig(uttConfig);
   auto user = std::make_unique<User>();
   user->pImpl_->pk_ = public_key;
   user->pImpl_->params_ = uttConfig.getParams();
@@ -274,50 +272,56 @@ std::unique_ptr<User> User::createInitial(const std::string& userId,
 
   std::map<std::string, std::string> selfTxCredentials{{userId, public_key}};
   user->pImpl_->selfTxEncryptor_ = std::make_unique<libutt::RSAEncryptor>(selfTxCredentials);
-  if (!isNewStorage) {
-    logdbg << "loading user data from storage" << endl;
-    user->recoverFromStorage(*(user->pImpl_->storage_));
-  }
   return user;
 }
 
-void User::recoverFromStorage(IStorage& storage) {
+std::unique_ptr<User> User::recoverFromStorage(std::shared_ptr<IStorage> storage) {
+  // First lets create a User object.
+  if (storage->isNewStorage()) throw std::runtime_error("cannot recover user from non initialized state");
+  // As we have atomic transaction on createInitial, we know that if the storage is initiated, all the initial
+  // information is there
+  std::string user_id = storage->getUserId();
+  auto key_pair = storage->getKeyPair();
+  auto utt_public_config = libutt::api::serialize<libutt::api::PublicConfig>(storage->getUttPublicConfig());
+  std::unique_ptr<User> user = createInitial(user_id, utt_public_config, key_pair.first, key_pair.second, storage);
+
   /**
    * To recover the client we need to perform the following:
    * 1. recover registration data (if there is any)
    * 2. recover all existing coins
    */
-
-  auto s1 = storage.getClientSideSecret();
+  auto s1 = storage->getClientSideSecret();
   if (s1.empty()) {
-    logdbg_user << "This client has not started registration phase, no additional data to recover" << endl;
-    return;
+    logdbg << "The client has not started registration phase, no additional data to recover" << endl;
+    return user;
   }
-  pImpl_->s1_ = s1;
-  pImpl_->client_->setS1(s1);
+  user->pImpl_->s1_ = s1;
+  user->pImpl_->client_->setS1(s1);
   // We don't care about recovering rcm1. Its the system responsibility to prevent double registration
-  auto s2 = storage.getSystemSideSecret();
+  auto s2 = storage->getSystemSideSecret();
   if (s2.empty()) {
-    logdbg_user << "This client has not passed yet the registration phase, no additional data to recover" << endl;
-    return;
+    logdbg << "The client has not passed yet the registration phase, no additional data to recover" << endl;
+    return user;
   }
-  auto rcm_sig = storage.getRcmSignature();
+  auto rcm_sig = storage->getRcmSignature();
   if (rcm_sig.empty()) throw std::runtime_error("s2 exist but rcm signature is empty");
-  pImpl_->client_->setRCMSig(pImpl_->params_, s2, rcm_sig);
-  pImpl_->is_registered_ = true;
-  auto coins = storage.getCoins();
+  user->pImpl_->client_->setRCMSig(user->pImpl_->params_, s2, rcm_sig);
+  user->pImpl_->is_registered_ = true;
+  auto coins = storage->getCoins();
   for (const auto& c : coins) {
-    if (!pImpl_->client_->validate(c)) throw std::runtime_error("client has failed to validate its own stored coins");
+    if (!user->pImpl_->client_->validate(c))
+      throw std::runtime_error("client has failed to validate its own stored coins");
     if (c.getType() == libutt::api::Coin::Normal) {
-      pImpl_->coins_.emplace(c.getNullifier(), c);
+      user->pImpl_->coins_.emplace(c.getNullifier(), c);
     } else if (c.getType() == libutt::api::Coin::Budget) {
-      if (pImpl_->budgetNullifiers_.size() >= 1) {
+      if (user->pImpl_->budgetNullifiers_.size() >= 1) {
         throw std::runtime_error("Currently multiple budget coins are not supported");
       }
-      pImpl_->budgetCoin_.emplace(c);
-      pImpl_->budgetNullifiers_.insert(c.getNullifier());
+      user->pImpl_->budgetCoin_.emplace(c);
+      user->pImpl_->budgetNullifiers_.insert(c.getNullifier());
     }
   }
+  return user;
 }
 
 User::User() : pImpl_{new Impl{}} {}

--- a/utt/utt-client-api/tests/TestUTTClientApi.cpp
+++ b/utt/utt-client-api/tests/TestUTTClientApi.cpp
@@ -278,7 +278,10 @@ class InMemoryUserStorage : public utt::client::IStorage {
       throw std::runtime_error("trying to remove an non existed coin to storage");
     coins_.erase(coin.getNullifier());
   };
-
+  void setUserId(const std::string& user_id) override { user_id_ = user_id; }
+  void setUttPublicConfig(const libutt::api::PublicConfig& utt_public_config) override {
+    config_ = libutt::api::serialize(utt_public_config);
+  }
   libutt::api::types::CurvePoint getClientSideSecret() override { return s1_; }
   libutt::api::types::CurvePoint getSystemSideSecret() override { return s2_; }
   libutt::api::types::Signature getRcmSignature() override { return rcm_sig_; }
@@ -288,6 +291,10 @@ class InMemoryUserStorage : public utt::client::IStorage {
     return coins;
   }
   std::pair<std::string, std::string> getKeyPair() override { return keyPair_; }
+  std::string getUserId() override { return user_id_; }
+  libutt::api::PublicConfig getUttPublicConfig() override {
+    return libutt::api::deserialize<libutt::api::PublicConfig>(config_);
+  }
   void startTransaction() override {}
   void commit() override {}
 
@@ -297,6 +304,8 @@ class InMemoryUserStorage : public utt::client::IStorage {
   libutt::api::types::Signature rcm_sig_;
   std::unordered_map<std::string, libutt::api::Coin> coins_;
   std::pair<std::string, std::string> keyPair_;
+  std::string user_id_;
+  utt::PublicConfig config_;
 };
 
 const std::vector<std::string> user_ids({"user-1", "user-2", "user-3"});


### PR DESCRIPTION
* **Problem Overview**  
  Currently, to recover the wallet service from storage, the user has to call explicitly to the configure rpc command. 
This PR fixes it, such that once there is a backup, the wallet service will restore itself.
* **Testing Done**  
  CI + manaual tests + unitest
