### PR TITLE
Front-page badge for the Restart Recovery Suite status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(gcc)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28gcc%29")
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Release%20build%20(clang)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Release+build+%28clang%29")
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(clang)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28clang%29")
+[![Build Status](https://github.com/vmware/concord-bft/workflows/Restart%20recovery%20suite/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Restart+recovery+suite")
 
 <!-- ![Concored-bft Logo](TBD) -->
 
@@ -36,7 +37,8 @@ Start with example usage [here](https://github.com/vmware/concord-bft/tree/maste
 
 See the github [wiki](https://github.com/vmware/concord-bft/wiki) for detailed explanation.
 
-## Community
+## Commun
+ity
 
 [Concord-BFT Slack](https://concordbft.slack.com/).
 


### PR DESCRIPTION
* **Problem Overview**  
The restart recovery suite features that test advanced fault scenarios, repeated over time. It runs once per day for about 2h currently.

For more details see the [test suite code](https://github.com/vmware/concord-bft/blob/master/tests/apollo/test_skvbc_restart_recovery.py).

* **Testing Done**  
  Checked that the status badge is retrieved and displayed correctly.
