### PR TITLE
MultiSizeBufferPool: lock MultiSizeBufferPool::SubPool::allocateChunk

### DIFF
--- a/libs/util/src/MultiSizeBufferPool.cpp
+++ b/libs/util/src/MultiSizeBufferPool.cpp
@@ -569,6 +569,7 @@ void MultiSizeBufferPool::SubPool::pushChunk(char* chunk) {
 }
 
 std::pair<char*, MultiSizeBufferPool::SubPool::AllocationStatus> MultiSizeBufferPool::SubPool::allocateChunk() {
+  std::lock_guard<std::mutex> lock(waitForAvailChunkMutex_);
   char* chunk = nullptr;
   const auto& numAllocatedChunks{stats_.current_.numAllocatedChunks_};
 


### PR DESCRIPTION
* **Problem Overview**  
This function increases the size of the actual elements in the queue by allocating from the heap and then updating queue size. This should be done in an atomic manner. Here we add a lock to this function. This should not impact performance, since this operation is rare.
* **Testing Done**  
Running same tests, no new tests are added.
