### PR TITLE
[Readme] Add a link to the SBFT formal model

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Start with example usage [here](https://github.com/vmware/concord-bft/tree/maste
 
 ## Documentation
 
-See the github [wiki](https://github.com/vmware/concord-bft/wiki) for detailed explanation.
+See the github [wiki](https://github.com/vmware/concord-bft/wiki) for detailed explanation.</br>
+A formal specification of the SBFT protocol including automated invariant proofs can be found [here](https://github.com/vmware/concord-bft/tree/master/docs/sbft-formal-model).
 
 ## Community
 


### PR DESCRIPTION
* **Problem Overview**  
  The Readme does not advertise the detailed and high value formal model that we have developed for the SBFT protocol.
* **Testing Done**  
  Checked the Markdown preview, to make sure the new entry is rendered correctly, and that the link works.
