### PR TITLE
[WIP] fix db checkpoint async bug

### DIFF
--- a/bftengine/include/bftengine/DbCheckpointManager.hpp
+++ b/bftengine/include/bftengine/DbCheckpointManager.hpp
@@ -99,7 +99,7 @@ class DbCheckpointManager {
   void initializeDbCheckpointManager(std::shared_ptr<concord::storage::IDBClient> dbClient,
                                      std::shared_ptr<bftEngine::impl::PersistentStorage> p,
                                      std::shared_ptr<concordMetrics::Aggregator> aggregator,
-                                     const std::function<BlockId()>& getLastBlockIdCb,
+                                     const std::function<BlockId(SeqNum)>& getCpBlockIdCb,
                                      const PrepareCheckpointCallback& prepareCheckpointCb,
                                      const std::function<void(bool, concord::kvbc::BlockId)>& checkpointInProcessCb);
   std::map<CheckpointId, DbCheckpointMetadata::DbCheckPointDescriptor> getListOfDbCheckpoints() const {
@@ -123,7 +123,7 @@ class DbCheckpointManager {
     if (monitorThread_.joinable()) monitorThread_.join();
   }
   void sendInternalCreateDbCheckpointMsg(const SeqNum& seqNum, bool noop);
-  BlockId getLastReachableBlock() const;
+  BlockId getCpBlockId(SeqNum sn) const;
   SeqNum getLastStableSeqNum() const;
   void setCheckpointInProcess(bool, concord::kvbc::BlockId) const;
   void setOnStableSeqNumCb_(std::function<void(SeqNum)> cb) { onStableSeqNumCb_ = cb; }
@@ -168,7 +168,7 @@ class DbCheckpointManager {
   void removeCheckpoint(const DbCheckpointId& checkPointId);
   void removeAllCheckpoints() const;
   void cleanUp();
-  std::function<BlockId()> getLastBlockIdCb_;
+  std::function<BlockId(SeqNum)> getCpBlockIdCb_;
   PrepareCheckpointCallback prepareCheckpointCb_;
   std::function<void(bool, concord::kvbc::BlockId)> checkpointInProcessCb_;
   // get total size recursively

--- a/bftengine/src/bftengine/RequestHandler.cpp
+++ b/bftengine/src/bftengine/RequestHandler.cpp
@@ -144,7 +144,7 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
           std::vector<std::uint8_t>(req.request, req.request + req.requestSize), createDbChkPtMsg);
       if (!createDbChkPtMsg.noop) {
         const auto& lastStableSeqNum = DbCheckpointManager::instance().getLastStableSeqNum();
-        std::optional blockId(DbCheckpointManager::instance().getLastReachableBlock());
+        std::optional blockId(DbCheckpointManager::instance().getCpBlockId(createDbChkPtMsg.seqNum));
         if (lastStableSeqNum == static_cast<SeqNum>(createDbChkPtMsg.seqNum)) {
           DbCheckpointManager::instance().createDbCheckpointAsync(createDbChkPtMsg.seqNum, timestamp, std::nullopt);
         } else {
@@ -159,11 +159,12 @@ void RequestHandler::execute(IRequestsHandler::ExecutionRequestsQueue& requests,
               DbCheckpointManager::instance().createDbCheckpointAsync(seqNumToCreateSanpshot, timestamp, blockId);
           });
         }
+        LOG_INFO(GL, "onCreateDbCheckpointMsg - " << KVLOG(createDbChkPtMsg.seqNum, *blockId));
       }
       req.outExecutionStatus = static_cast<uint32_t>(OperationResult::SUCCESS);
       req.outReply[0] = '1';
       req.outActualReplySize = 1;
-      LOG_INFO(GL, "onCreateDbCheckpointMsg - " << KVLOG(createDbChkPtMsg.seqNum));
+
       continue;
     }
 

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -147,6 +147,7 @@ class Replica : public IReplica,
                              const uint32_t blockSize,
                              bool lastBlock = false);
 
+  BlockId getBlockIdOfSeqNum(uint64_t seq_num) const;
   Replica(bft::communication::ICommunication *comm,
           const bftEngine::ReplicaConfig &config,
           std::unique_ptr<IStorageFactory> storageFactory,

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -708,16 +708,15 @@ void KeyValueBlockchain::checkpointInProcess(bool flag, kvbc::BlockId block_id_a
   // shouldn't have any contention or overhead
   const std::lock_guard<std::mutex> lock(map_mutex);
   if (flag) {
-    auto last_reachable_id = block_chain_.getLastReachable();
-    ConcordAssertEQ(last_reachable_id, block_id_at_chkpnt);
     auto new_snap_shot = RecoverySnapshot{&native_client_->rawDB()};
-    chkpnt_snap_shots_[last_reachable_id] = new_snap_shot.get();
+    chkpnt_snap_shots_[block_id_at_chkpnt] = new_snap_shot.get();
     LOG_INFO(V4_BLOCK_LOG,
              "Taking snapshot at checkpoint start with block id "
-                 << last_reachable_id << " snapshot sn " << chkpnt_snap_shots_[last_reachable_id]->GetSequenceNumber());
+                 << block_id_at_chkpnt << " snapshot sn "
+                 << chkpnt_snap_shots_[block_id_at_chkpnt]->GetSequenceNumber());
     native_client_->put(v4blockchain::detail::MISC_CF,
                         RecoverySnapshot::getStorableKey(block_id_at_chkpnt),
-                        new_snap_shot.getStorableSeqNumAndPreventRelease(last_reachable_id));
+                        new_snap_shot.getStorableSeqNumAndPreventRelease(block_id_at_chkpnt));
   } else {
     if (chkpnt_snap_shots_.count(block_id_at_chkpnt) > 0) {
       auto sn = chkpnt_snap_shots_[block_id_at_chkpnt]->GetSequenceNumber();

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -943,11 +943,29 @@ struct ResetMetadata {
     uint16_t numOfObjects = 0;
     auto objectDescriptors = ((PersistentStorageImp *)p.get())->getDefaultMetadataObjectDescriptors(numOfObjects);
     bool isNewStorage = mdtStorage->initMaxSizeOfObjects(objectDescriptors, numOfObjects);
+
+    // set manually the last executed sequence number and the last primary used sequence number to bypass some asserts
+    SeqNum last_stable_sn{0};
+    uint32_t actualObjectSize = 0;
+    mdtStorage->read(LAST_STABLE_SEQ_NUM, sizeof(last_stable_sn), (char *)&last_stable_sn, actualObjectSize);
+    mdtStorage->beginAtomicWriteOnlyBatch();
+    mdtStorage->writeInBatch(PRIMARY_LAST_USED_SEQ_NUM, (char *)&last_stable_sn, sizeof(last_stable_sn));
+    mdtStorage->writeInBatch(LAST_EXEC_SEQ_NUM, (char *)&last_stable_sn, sizeof(last_stable_sn));
+
+    bftEngine::impl::Bitmap bm;
+    bftEngine::impl::DescriptorOfLastExecution desc{last_stable_sn, bm, 0U};
+    const size_t bufLen = bftEngine::impl::DescriptorOfLastExecution::maxSize();
+    concord::serialize::UniquePtrToChar descBuf(new char[bufLen]);
+    size_t actualSize = 0;
+    char *ptr_buf = descBuf.get();
+    desc.serialize(ptr_buf, bufLen, actualSize);
+    mdtStorage->writeInBatch(LAST_EXEC_DESC, descBuf.get(), actualSize);
+    mdtStorage->commitAtomicWriteOnlyBatch();
+
     ((PersistentStorageImp *)p.get())->init(move(mdtStorage));
     SeqNum stableSeqNum = p->getLastStableSeqNum();
     CheckpointMsg *cpm = p->getAndAllocateCheckpointMsgInCheckWindow(stableSeqNum);
     result["new bft mdt"] = std::to_string(isNewStorage);
-    auto lastExecutedSn = p->getLastExecutedSeqNum();
     p->beginWriteTran();
     if (cpm && cpm->senderId() != repId) {
       cpm->setSenderId(repId);
@@ -955,7 +973,7 @@ struct ResetMetadata {
       result["stable seq num"] = std::to_string(stableSeqNum);
     }
     delete cpm;
-    p->setPrimaryLastUsedSeqNum(lastExecutedSn);
+
     if (removeRsis) {
       for (uint32_t principle = 0; principle < nVal + principles; principle++) {
         uint32_t baseIndex = principle * maxClientBatchSize;

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -931,7 +931,7 @@ class SkvbcDbSnapshotTest(ApolloTest):
 
         crashed_replica = list(bft_network.random_set_of_replicas(1, {initial_prim}))[0]
         bft_network.stop_replica(crashed_replica)
-        await skvbc.send_n_kvs_sequentially(DB_CHECKPOINT_WIN_SIZE)  # run till the next checkpoint
+        await skvbc.send_n_kvs_sequentially(DB_CHECKPOINT_WIN_SIZE + 100)  # run till the next checkpoint
 
         src_replica = list(bft_network.random_set_of_replicas(1, without={crashed_replica}))[0]
         await bft_network.wait_for_stable_checkpoint({src_replica}, stable_seqnum = 2 * DB_CHECKPOINT_WIN_SIZE)
@@ -941,13 +941,8 @@ class SkvbcDbSnapshotTest(ApolloTest):
         bft_network.restore_form_older_db_snapshot(snapshot_id, src_replica=src_replica,
                                          dest_replicas=[crashed_replica], prefix=TEMP_DB_SNAPSHOT_PREFIX)
         bft_network.reset_metadata(crashed_replica)
-        await skvbc.send_n_kvs_sequentially(3 * DB_CHECKPOINT_WIN_SIZE)
-
         bft_network.start_replica(crashed_replica)
-        await bft_network.wait_for_state_transfer_to_start()
-        await bft_network.wait_for_state_transfer_to_stop(initial_prim,
-                                                          crashed_replica,
-                                                          stop_on_stable_seq_num=False)
+        await skvbc.send_n_kvs_sequentially(3 * DB_CHECKPOINT_WIN_SIZE)
         # make sure that the restored replica participates in consensus
         await bft_network.wait_for_consensus_path(path_type=ConsensusPathType.OPTIMISTIC_FAST,
                                                   run_ops=lambda: skvbc.send_n_kvs_sequentially(DB_CHECKPOINT_WIN_SIZE),


### PR DESCRIPTION
* **Problem Overview**  
  The current implementation of the db checkpoint feature has a synchronization bug:
  While we take the db checkpoint in the background, we don't align anything with the checkpoint sequence number, i.e. the block number, bft metadata, pending reserved pages, and more. 
  Once we put more client requests in a different resolution than 150 we start to see a wide set of issues:
  For example:
  1. The recovered replica won't start from a stable checkpoint, instead, it starts from the point where the db checkpoint was taken.
  2. In a case where the checkpoint was taken in the middle of another execution phase, we won't have the pending reserved pages to recover correctly.
  3. We trim the block at the point where the db checkpoint was taken, but we don't update the bft metadata accordingly. 
Below is an example of part of these issues:
On replica 0, block 302 was created on sequence number 304
```
0|03-04-2023 10:48:24.125|INFO |skvbctest.replica|post-execution-thread|||304||executeWriteCommand|L:482|ConditionalWrite message handled; writesCounter=302 currBlock=302 | [SQ:1215]
```
However, on recovery, the recovered replica has the same block was created on sequence number 305:
```
5|03-04-2023 10:48:34.293|INFO |skvbctest.replica|post-execution-thread|||305||executeWriteCommand|L:482|ConditionalWrite message handled; writesCounter=1 currBlock=302 | [SQ:3]
```
This PR proposes a fix, in which, we pin the bft sequence number before starting the async part, and align everything accordingly.

This PR doesn't handle the case of explicitly creating db checkpoint by the operator, as it assumes to be used for clients only (which cares only about the blockchain) 
* **Testing Done**  
  CI +  Changing an existing test to verify the changes
