### PR TITLE
Removing clang-related badges on the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![clang-tidy](https://github.com/vmware/concord-bft/workflows/clang-tidy/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3Aclang-tidy)<br/>
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Release%20build%20(gcc)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Release+build+%28gcc%29")<br/>
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(gcc)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28gcc%29")<br/>
-[![Build Status](https://github.com/vmware/concord-bft/workflows/Release%20build%20(clang)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Release+build+%28clang%29")<br/>
-[![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(clang)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28clang%29")<br/>
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Restart%20recovery%20suite/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Restart+recovery+suite")<br/>
 
 <!-- ![Concored-bft Logo](TBD) -->


### PR DESCRIPTION
* **Problem Overview**  
  Following the upgrade of our base image to Ubuntu 22, we have dropped support for the clang compiler. Accordingly, I'm removing the corresponding badges from the front page.
* **Testing Done**  
  Checked that the remaining badges are rendered correctly.
