### PR TITLE
Reenable restart recovery suite (Ubuntu 22)

### DIFF
--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -1,7 +1,7 @@
 name: Restart recovery suite
-on: [push, pull_request]
-  # schedule:
-  #   - cron: '0 1 * * *'
+on:
+  schedule:
+    - cron: '0 1 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -1,7 +1,7 @@
 name: Restart recovery suite
-on: [ push, pull_request ]
-  schedule:
-    - cron: '0 1 * * *'
+on: [push, pull_request]
+  # schedule:
+  #   - cron: '0 1 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -37,6 +37,9 @@ jobs:
             cd build
             cmake \
               -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
+              -DBUILD_COMM_UDP=ON \
+              -DBUILD_COMM_TCP_TLS=OFF \
+              -DBUILD_COMM_TCP_PLAIN=OFF \
               -DCMAKE_BUILD_TYPE=RELEASE \
               -DBUILD_COMM_TCP_TLS=FALSE \
               -DBUILD_TESTING=ON \

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -59,7 +59,7 @@ jobs:
           run: |
             cd build
             # many tests require administrative priviliges for running iptables or nc
-            sudo ctest --timeout=24000 --output-on-failure -R skvbc_multi_sig
+            sudo ctest --timeout 24000 --test-timeout 24000 --output-on-failure -R skvbc_restart_recovery_tests
         - name: Prepare artifacts
           if: ${{ failure() }}
           run: |

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -59,7 +59,7 @@ jobs:
           run: |
             cd build
             # many tests require administrative priviliges for running iptables or nc
-            sudo ctest --timeout=24000 --output-on-failure skvbc_restart_recovery_tests
+            sudo ctest --timeout=24000 --output-on-failure -R skvbc_multi_sig
         - name: Prepare artifacts
           if: failure()
           run: |

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -1,5 +1,6 @@
 name: Restart recovery suite
 on:
+  [ push, pull_request ]
   schedule:
     - cron: '0 1 * * *'
 
@@ -11,14 +12,13 @@ jobs:
   build:
     name: Build
     timeout-minutes: 420
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs:
       err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:
       fail-fast: false
       matrix:
-            compiler:
-                - "CONCORD_BFT_CONTAINER_CC=clang CONCORD_BFT_CONTAINER_CXX=clang++"
+        compiler: [g++]
     steps:
         - name: Cleanup pre-installed tools
           run: |
@@ -28,39 +28,34 @@ jobs:
             sudo rm -rf "/usr/local/share/boost"
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         - name: Checkout
-          uses: actions/checkout@v2
-        - name: Create artifact directory
-          run: mkdir -p ${{ github.workspace }}/artifact
-        #- name: Configure core dump location
-        #  run: |
-            # Uncomment the line below to enable core dump collection
-            # echo "/concord-bft/build/cores/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
-            # Uncomment this is you want to login into the running session.
-            # Please note that the build will block on this step.
-            # Refer to https://github.com/marketplace/actions/debugging-with-tmate
-        #- name: Setup tmate session
-        #  uses: mxschmitt/action-tmate@v2
-        - name: Build and test
+          uses: actions/checkout@v3
+        - name: Build
           run: |
-              script -q -e -c "make pull"
-              sudo df -h
-              script -q -e -c "make build \
-                              ${{ matrix.compiler}} \
-                              CONCORD_BFT_CMAKE_FLAGS=\"\
-                              -DCMAKE_BUILD_TYPE=RELEASE \
-                              -DBUILD_COMM_TCP_TLS=FALSE \
-                              -DBUILD_TESTING=ON \
-                              -DENABLE_RESTART_RECOVERY_TESTS=TRUE \
-                              -DBUILD_COMM_TCP_PLAIN=FALSE \
-                              -DCMAKE_CXX_FLAGS_RELEASE='-O3 -g' \
-                              -DUSE_LOG4CPP=TRUE \
-                              -DBUILD_ROCKSDB_STORAGE=TRUE \
-                              -DUSE_S3_OBJECT_STORE=OFF \
-                              -DUSE_OPENTRACING=ON \
-                              -DOMIT_TEST_OUTPUT=OFF\
-                              -DKEEP_APOLLO_LOGS=TRUE\
-                              -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\" "\
-              && script -q -e -c "CONCORD_BFT_CTEST_TIMEOUT=26000 make test-single-suite TEST_NAME=skvbc_restart_recovery_tests"
+            mkdir build
+            cd build
+            cmake \
+              ${{ matrix.compiler}} \
+              -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
+              -DCMAKE_BUILD_TYPE=RELEASE \
+              -DBUILD_COMM_TCP_TLS=FALSE \
+              -DBUILD_TESTING=ON \
+              -DENABLE_RESTART_RECOVERY_TESTS=TRUE \
+              -DBUILD_COMM_TCP_PLAIN=FALSE \
+              -DCMAKE_CXX_FLAGS_RELEASE='-O3 -g' \
+              -DUSE_LOG4CPP=TRUE \
+              -DBUILD_ROCKSDB_STORAGE=TRUE \
+              -DUSE_S3_OBJECT_STORE=OFF \
+              -DUSE_OPENTRACING=ON \
+              -DOMIT_TEST_OUTPUT=OFF\
+              -DKEEP_APOLLO_LOGS=TRUE\
+              -DUSE_FAKE_CLOCK_IN_TIME_SERVICE=TRUE\
+              ..
+              make -j$(nproc)
+        - name: Test
+          run: |
+            cd build
+            # many tests require administrative priviliges for running iptables or nc
+            sudo ctest --output-on-failure skvbc_restart_recovery_tests
         - name: Prepare artifacts
           if: failure()
           run: |
@@ -94,14 +89,3 @@ jobs:
           with:
             name: artifacts-${{ matrix.compiler }}-${{ matrix.ci_build_type }}-${{ github.sha }}
             path: ${{ github.workspace }}/artifact/
-  testlog:
-    name: Check ERROR/FATAL logs(Apollo)
-    runs-on: ubuntu-18.04
-    continue-on-error: true
-    needs: build
-    steps:
-        - name: Check ERROR/FATAL logs in apollo
-          if: needs.build.outputs.err_output == 'success'
-          run: |
-            echo "Errors exist in replica logs. Please check Artifacts"
-            exit 1

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -1,6 +1,5 @@
 name: Restart recovery suite
-on:
-  [ push, pull_request ]
+on: [ push, pull_request ]
   schedule:
     - cron: '0 1 * * *'
 
@@ -34,7 +33,6 @@ jobs:
             mkdir build
             cd build
             cmake \
-              ${{ matrix.compiler}} \
               -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_BUILD_TYPE=RELEASE \
               -DBUILD_COMM_TCP_TLS=FALSE \

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -12,6 +12,9 @@ jobs:
     name: Build
     timeout-minutes: 420
     runs-on: ubuntu-22.04
+    container:
+      image: concordbft/concord-bft:0.60
+      options: --cap-add=NET_ADMIN
     outputs:
       err_output: ${{ steps.prepare_err_artifacts.outputs.test}}
     strategy:

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -59,7 +59,7 @@ jobs:
           run: |
             cd build
             # many tests require administrative priviliges for running iptables or nc
-            sudo ctest --output-on-failure skvbc_restart_recovery_tests
+            sudo ctest --timeout=24000 --output-on-failure skvbc_restart_recovery_tests
         - name: Prepare artifacts
           if: failure()
           run: |

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -61,12 +61,11 @@ jobs:
             # many tests require administrative priviliges for running iptables or nc
             sudo ctest --timeout=24000 --output-on-failure -R skvbc_multi_sig
         - name: Prepare artifacts
-          if: failure()
+          if: ${{ failure() }}
           run: |
+            mkdir -p artifact
             sudo chown -R ${USER}:${GROUP} ${PWD}/build
-            tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
-            du -h ${{ github.workspace }}/artifact
-            sudo df -h
+            tar -czvf artifact/logs.tar.gz ./build/tests/apollo/logs
         - name: Upload artifacts
           uses: actions/upload-artifact@v2
           if: failure()


### PR DESCRIPTION
The restart_recovery_suite github action stopped working due to ubuntu update from 18.04 to 22.04. The action file has been updated accordingly

Suite is running correctly.
