### PR TITLE
Introduce generic header to accomodate Eth and Non-Eth blocks 

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -150,12 +150,16 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   // Reconfiguration credentials
   CONFIG_PARAM(pathToOperatorPublicKey_, std::string, "", "Path to the operator public key pem file");
   CONFIG_PARAM(operatorEnabled_, bool, true, "true if operator is enabled");
+
   // Pruning parameters
   CONFIG_PARAM(pruningEnabled_, bool, false, "Enable pruning");
   CONFIG_PARAM(numBlocksToKeep_, uint64_t, 0, "how much blocks to keep while pruning");
 
   CONFIG_PARAM(debugPersistentStorageEnabled, bool, false, "whether persistent storage debugging is enabled");
   CONFIG_PARAM(deleteMetricsDumpInterval, uint64_t, 300, "delete metrics dump interval (s)");
+
+  // Storage
+  CONFIG_PARAM(extraHeader, bool, false, "Add extra header to every block?");
 
   // Messages
   CONFIG_PARAM(maxExternalMessageSize, uint32_t, 131072, "maximum size of external message");
@@ -391,6 +395,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
     serialize(outStream, debugPersistentStorageEnabled);
     serialize(outStream, deleteMetricsDumpInterval);
+    serialize(outStream, extraHeader);
     serialize(outStream, maxExternalMessageSize);
     serialize(outStream, maxReplyMessageSize);
     serialize(outStream, maxNumOfReservedPages);
@@ -493,6 +498,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
     deserialize(inStream, debugPersistentStorageEnabled);
     deserialize(inStream, deleteMetricsDumpInterval);
+    deserialize(inStream, extraHeader);
     deserialize(inStream, maxExternalMessageSize);
     deserialize(inStream, maxReplyMessageSize);
     deserialize(inStream, maxNumOfReservedPages);
@@ -634,7 +640,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.kvBlockchainVersion,
               replicaMsgSignAlgo,
               operatorMsgSignAlgo,
-              rc.singleSignatureScheme);
+              rc.singleSignatureScheme,
+              rc.extraHeader);
   os << ", ";
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -37,10 +37,12 @@ add_library(kvbc  src/ClientImp.cpp
     src/kvbc_adapter/categorization/app_state_adapter.cpp
     src/kvbc_adapter/categorization/blocks_deleter_adapter.cpp
 
+    src/kvbc_adapter/v4blockchain/blocks_adder_adapter.cpp
     src/kvbc_adapter/v4blockchain/blocks_deleter_adapter.cpp
     src/kvbc_adapter/v4blockchain/app_state_adapter.cpp
 
     src/kvbc_adapter/replica_adapter.cpp
+    src/block_header.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -115,6 +115,49 @@ Msg ParentDigest 2006 {
     fixedlist uint8 32 value
 }
 
+Msg BlockHeaderData 2007 {
+    int64 version
+    uint64 number
+    fixedlist uint8 32 parent_hash
+    list fixedlist uint8 32 transactions
+    uint64 timestamp
+    uint64 gas_limit
+    uint64 gas_used
+    fixedlist uint8 32 stateroot
+    fixedlist uint8 32 extra_data
+    fixedlist uint8 32 miner
+    fixedlist uint8 8 nonce
+}
+
+Msg LogData 2008 {
+    fixedlist uint8 20 address
+    list fixedlist uint8 32 topics
+    bytes data
+}
+
+Msg TransactionLogData 2009 {
+    list LogData logs
+}
+
+Msg TransactionData 2010 {
+    int64 version
+    uint64 nonce
+    uint64 block_number
+    fixedlist uint8 20 from
+    fixedlist uint8 20 to
+    fixedlist uint8 20 contract_address
+    bytes input
+    int64 status
+    fixedlist uint8 32 value
+    uint64 gas_price
+    uint64 gas_limit
+    uint64 gas_used
+    bytes sig_r
+    bytes sig_s
+    uint64 sig_v
+}
+
+
 # Misc
 
 Msg BenchmarkMessage 3000 {

--- a/kvbc/include/block_header.hpp
+++ b/kvbc/include/block_header.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+
+#pragma once
+#include <vector>
+#include <string>
+#include "util/serializable.hpp"
+#include "crypto/digest.hpp"
+#include "kvbc_app_filter/kvbc_key_types.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+namespace concord::kvbc {
+
+using concord::kvbc::categorization::BlockHeaderData;
+using uint256be_t = std::array<uint8_t, 32>;
+using nonce_t = std::array<uint8_t, 8>;
+using address_t = std::array<uint8_t, 20>;
+
+class BlockHeader {
+ public:
+  BlockHeader(void) : data({0}) {
+    data.transactions.resize(0);
+    data.version = kBlockStorageVersion;
+  }
+
+  static const std::string blockNumAsKeyToBlockHash(const uint8_t *bytes, size_t length);
+  static const std::string blockNumAsKeyToBlockHeader(const uint8_t *bytes, size_t length);
+  static std::string blockHashAsKeyToBlockNum(const uint8_t *bytes, size_t length);
+  uint256be_t hash() const;
+  std::string serialize() const;
+  static BlockHeader deserialize(const std::string &input);
+
+ public:
+  static constexpr int64_t kHashSizeInBytes = 32;
+  static constexpr int64_t kBlockStorageVersion = 1;
+  BlockHeaderData data;
+};
+
+}  // namespace concord::kvbc

--- a/kvbc/include/kvbc_adapter/v4blockchain/blocks_adder_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/v4blockchain/blocks_adder_adapter.hpp
@@ -17,6 +17,7 @@
 
 #include "db_interfaces.h"
 #include "v4blockchain/v4_blockchain.h"
+#include "block_header.hpp"
 
 using concord::storage::rocksdb::NativeClient;
 
@@ -28,12 +29,12 @@ class BlocksAdderAdapter : public IBlockAdder {
   explicit BlocksAdderAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc)
       : kvbc_{kvbc.get()} {}
 
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // IBlockAdder
-  BlockId add(concord::kvbc::categorization::Updates &&updates) override final {
-    return kvbc_->add(std::move(updates));
-  }
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  BlockId add(concord::kvbc::categorization::Updates &&updates) override final;
+
+ protected:
+  void getParentHeaderHash(const BlockId number, uint256be_t &parent_hash);
+  void writeParentHash(BlockId last_reachable_block_num, uint256be_t &parent_hash);
+  void addHeader(concord::kvbc::categorization::Updates &updates);
 
  private:
   concord::kvbc::v4blockchain::KeyValueBlockchain *kvbc_{nullptr};

--- a/kvbc/include/kvbc_app_filter/kvbc_key_types.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_key_types.h
@@ -27,7 +27,7 @@ const char kKvbKeyEthNonce = 0x06;
 const char kKvbKeyEthBlockHash = 0x07;
 const char kKvbKeyEthEventLog = 0x08;
 
-// Unused 0x10 - 0x1f
+// Unused 0x11 - 0x1f
 
 // Concord 0x20 - 0x2f
 const char kKvbKeyTimeSamples = 0x20;

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -16,6 +16,9 @@
 #include <string>
 
 namespace concord::kvbc::keyTypes {
+
+static const char kKvbKeyBlockHeaderHash = 0x10;
+
 static const char bft_seq_num_key = 0x21;
 static const char reconfiguration_pruning_key = 0x24;
 static const char reconfiguration_prune_compact_key = 0x25;

--- a/kvbc/proto/concord_kvbc.proto
+++ b/kvbc/proto/concord_kvbc.proto
@@ -27,48 +27,6 @@ message ValueWithTrids {
    optional google.protobuf.Timestamp expires_after = 3;
 }
 
-message Block {
-   optional int64 version = 1;
-   optional int64 number = 2;
-   optional bytes hash = 3;             // 32 bytes
-   optional bytes parent_hash = 4;      // 32 bytes
-   repeated bytes transaction = 5;      // 32 bytes
-   optional int64 timestamp = 6;
-   optional int64 gas_limit = 7;
-   optional int64 gas_used = 8;
-   optional bytes stateroot = 9;
-}
-
-message Transaction {
-   optional int64 version = 1;
-   optional int64 block_number = 2;
-   optional int64 nonce = 3;
-   optional bytes block_hash = 4;       // 32 bytes
-   optional bytes from = 5;             // 20 bytes
-   optional bytes to = 6;               // 20 bytes
-   optional bytes contract_address = 7; // 20 bytes
-   optional bytes input = 8;
-   optional int64 status = 9;
-   optional bytes value = 10;
-   optional int64 gas_price = 11;
-   optional int64 gas_limit = 12;
-   optional bytes sig_r = 13;           // 32 bytes
-   optional bytes sig_s = 14;           // 32 bytes
-   optional uint32 sig_v = 15;
-   optional int64 gas_used = 16;
-}
-
-message Log {
-   optional bytes address = 1;          // 20 bytes
-   repeated bytes topic = 2;            // 32 bytes each
-   optional bytes data = 3;
-}
-
-message TransactionLog {
-   optional int64 version = 1;
-   repeated Log logs = 2;
-}
-
 message Balance {
    optional int64 version = 1;
    optional bytes balance = 2;          // 32 bytes

--- a/kvbc/src/block_header.cpp
+++ b/kvbc/src/block_header.cpp
@@ -1,0 +1,74 @@
+// Concord
+//
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <string.h>
+
+#include "block_header.hpp"
+#include "log/logger.hpp"
+#include "kvbc_key_types.hpp"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+using namespace concord::serialize;
+using concord::kvbc::keyTypes::kKvbKeyBlockHeaderHash;
+
+namespace concord::kvbc {
+
+std::string BlockHeader::serialize() const {
+  std::string serialized_buffer;
+  categorization::serialize(serialized_buffer, data);
+  ConcordAssert(serialized_buffer.size() > 0);
+  return serialized_buffer;
+}
+
+BlockHeader BlockHeader::deserialize(const std::string &input) {
+  BlockHeader outblk;
+  categorization::deserialize(input, outblk.data);
+  if (outblk.data.version != kBlockStorageVersion) {
+    LOG_ERROR(V4_BLOCK_LOG, "Unknown block storage version " << outblk.data.version);
+    throw std::runtime_error("Unkown block storage version");
+  }
+  return outblk;
+}
+
+const std::string BlockHeader::blockNumAsKeyToBlockHash(const uint8_t *bytes, size_t length) {
+  std::string ret;
+  ret.push_back((char)kKvbKeyBlockHeaderHash);
+  ret.append(reinterpret_cast<const char *>(bytes), length);
+  return ret;
+}
+
+const std::string BlockHeader::blockNumAsKeyToBlockHeader(const uint8_t *bytes, size_t length) {
+  std::string ret;
+  ret.push_back((char)kKvbKeyEthBlockHash);
+  ret.append(reinterpret_cast<const char *>(bytes), length);
+  return ret;
+}
+
+std::string BlockHeader::blockHashAsKeyToBlockNum(const uint8_t *bytes, size_t length) {
+  std::string ret;
+  ret.push_back((char)kKvbKeyEthBlock);
+  ret.append(reinterpret_cast<const char *>(bytes), length);
+  return ret;
+}
+
+uint256be_t BlockHeader::hash() const {
+  static_assert(sizeof(crypto::BlockDigest) == sizeof(uint256be_t), "hash size should be same");
+  auto serialized_header = serialize();
+  crypto::DigestGenerator digest_generator;
+  uint256be_t hash{0};
+  digest_generator.update(reinterpret_cast<const char *>(serialized_header.c_str()), serialized_header.size());
+  digest_generator.writeDigest(reinterpret_cast<char *>(hash.data()));
+  return hash;
+}
+
+}  // namespace concord::kvbc

--- a/kvbc/src/kvbc_adapter/v4blockchain/blocks_adder_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/v4blockchain/blocks_adder_adapter.cpp
@@ -1,0 +1,117 @@
+// Concord
+//
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/v4blockchain/blocks_adder_adapter.hpp"
+#include "kvbc_app_filter/kvbc_key_types.h"
+#include "categorization/db_categories.h"
+#include "bftengine/ReplicaConfig.hpp"
+
+using bftEngine::ReplicaConfig;
+
+namespace concord::kvbc::adapter::v4blockchain {
+
+void BlocksAdderAdapter::getParentHeaderHash(const BlockId block_id, uint256be_t &parent_hash) {
+  auto key = BlockHeader::blockNumAsKeyToBlockHash((uint8_t *)&block_id, sizeof(block_id));
+  LOG_DEBUG(GL, KVLOG(block_id, concordUtils::bufferToHex(key.c_str(), key.size())));
+  auto opt_val = kvbc_->getLatest(kvbc::categorization::kExecutionPrivateCategory, key);
+  if (opt_val) {
+    auto val = std::get<kvbc::categorization::VersionedValue>(*opt_val);
+    static_assert(BlockHeader::kHashSizeInBytes == 32);
+    std::memcpy(parent_hash.data(), val.data.data(), BlockHeader::kHashSizeInBytes);
+    LOG_INFO(GL, concordUtils::bufferToHex(parent_hash.data(), parent_hash.size()));
+  }
+}
+
+void BlocksAdderAdapter::writeParentHash(BlockId block_id, uint256be_t &parent_hash) {
+  if (block_id) {
+    getParentHeaderHash(block_id - 1, parent_hash);
+    ConcordAssertEQ(parent_hash.empty(), false);
+  }
+}
+
+void BlocksAdderAdapter::addHeader(concord::kvbc::categorization::Updates &updates) {
+  auto cat_itr = updates.categoryUpdates().kv.find(kvbc::categorization::kExecutionPrivateCategory);
+
+  BlockHeader header;
+  bool found_existing_header = false;
+
+  BlockId to_be_written_block_num = kvbc_->getLastReachableBlockId();
+  auto to_be_written_block_header_key =
+      BlockHeader::blockNumAsKeyToBlockHeader((uint8_t *)&to_be_written_block_num, sizeof(to_be_written_block_num));
+  LOG_INFO(GL,
+           "key size " << to_be_written_block_header_key.size() << " key hash "
+                       << std::hash<std::string>{}(to_be_written_block_header_key) << " key "
+                       << concordUtils::bufferToHex(to_be_written_block_header_key.c_str(),
+                                                    to_be_written_block_header_key.size()));
+
+  if (cat_itr != updates.categoryUpdates().kv.cend()) {
+    const auto &kvs = std::get<kvbc::categorization::VersionedInput>(cat_itr->second).kv;
+    auto key_itr = kvs.find(to_be_written_block_header_key);
+    if (key_itr != kvs.cend()) {
+      // Eth block
+      header = BlockHeader::deserialize(key_itr->second.data);
+      found_existing_header = true;
+    }
+  }
+
+  if (not found_existing_header) {
+    // Reconfig block; !Eth block;
+    header.data.number = to_be_written_block_num;
+  }
+
+  writeParentHash(to_be_written_block_num, header.data.parent_hash);
+
+  // write block number to block header mapping into updates
+  auto serialized_header = header.serialize();
+  updates.addCategoryIfNotExisting<kvbc::categorization::VersionedInput>(
+      concord::kvbc::categorization::kExecutionPrivateCategory);
+  updates.appendKeyValue<kvbc::categorization::VersionedUpdates>(
+      concord::kvbc::categorization::kExecutionPrivateCategory,
+      std::move(to_be_written_block_header_key),
+      kvbc::categorization::VersionedUpdates::Value{serialized_header, true});
+
+  // write block num to block hash mapping in updates
+  auto header_hash = header.hash();
+  kvbc::categorization::VersionedUpdates::Value val{};
+  val.data.append(std::begin(header_hash), std::end(header_hash));
+  val.stale_on_update = true;
+  auto block_num_as_key_to_block_hash =
+      BlockHeader::blockNumAsKeyToBlockHash((uint8_t *)&to_be_written_block_num, sizeof(to_be_written_block_num));
+  updates.appendKeyValue<kvbc::categorization::VersionedUpdates>(
+      concord::kvbc::categorization::kExecutionPrivateCategory,
+      std::move(block_num_as_key_to_block_hash),
+      std::move(val));
+
+  // write block header hash to block number mapping in updates
+  auto block_hash_as_key_to_block_number =
+      BlockHeader::blockHashAsKeyToBlockNum((uint8_t *)&header_hash, sizeof(concord::kvbc::uint256be_t));
+  updates.appendKeyValue<kvbc::categorization::VersionedUpdates>(
+      concord::kvbc::categorization::kExecutionPrivateCategory,
+      std::move(block_hash_as_key_to_block_number),
+      kvbc::categorization::VersionedUpdates::Value{concordUtils::toBigEndianStringBuffer(to_be_written_block_num),
+                                                    true});
+
+  LOG_INFO(GL,
+           "Block number " << to_be_written_block_num << " header size " << serialized_header.size()
+                           << " and its header hash "
+                           << concordUtils::bufferToHex(header_hash.data(), header_hash.size()));
+}
+
+BlockId BlocksAdderAdapter::add(concord::kvbc::categorization::Updates &&updates) {
+  if (bftEngine::ReplicaConfig::instance().extraHeader == true) {
+    addHeader(updates);
+  }
+  return kvbc_->add(std::move(updates));
+}
+
+}  // namespace concord::kvbc::adapter::v4blockchain

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -307,6 +307,15 @@ if (BUILD_ROCKSDB_STORAGE)
         stdc++fs
     )
 
+    add_executable(blocks_adder_adapter_test kvbc_adapter/v4blockchain/blocks_adder_adapter_test.cpp)
+    add_test(blocks_adder_adapter_test blocks_adder_adapter_test)
+    target_link_libraries(blocks_adder_adapter_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        corebft
+        kvbc
+    )
+
     add_executable(common_state_snapshot_adapter_test
             kvbc_adapter/common/state_snapshot_adapter_test.cpp )
     add_test(common_state_snapshot_adapter_test common_state_snapshot_adapter_test)

--- a/kvbc/test/kvbc_adapter/v4blockchain/blocks_adder_adapter_test.cpp
+++ b/kvbc/test/kvbc_adapter/v4blockchain/blocks_adder_adapter_test.cpp
@@ -1,0 +1,94 @@
+// Concord
+//
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "categorization/db_categories.h"
+#include "kvbc_adapter/replica_adapter.hpp"
+#include "kvbc_key_types.hpp"
+#include "storage/test/storage_test_common.h"
+#include "block_metadata.hpp"
+#include "block_header.hpp"
+
+#include <map>
+
+namespace {
+using namespace ::testing;
+using namespace concord::kvbc;
+using namespace concord::kvbc::categorization;
+using concord::kvbc::adapter::ReplicaBlockchain;
+using concord::storage::rocksdb::NativeClient;
+
+class BlocksAdderAdapterTest : public Test {
+  void SetUp() override {
+    destroyDb();
+    db_ = TestRocksDb::createNative();
+    bftEngine::ReplicaConfig::instance().kvBlockchainVersion = BLOCKCHAIN_VERSION::V4_BLOCKCHAIN;
+    bftEngine::ReplicaConfig::instance().extraHeader = true;
+    kvbc_ = std::make_unique<ReplicaBlockchain>(
+        db_,
+        false,
+        std::map<std::string, CATEGORY_TYPE>{{kExecutionProvableCategory, CATEGORY_TYPE::block_merkle},
+                                             {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv},
+                                             {kExecutionPrivateCategory, CATEGORY_TYPE::versioned_kv}});
+  }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db_.reset();
+    ASSERT_EQ(0, db_.use_count());
+    cleanup();
+  }
+
+ public:
+  // read block header
+  BlockHeader read_block(BlockId block_id) {
+    auto key = BlockHeader::blockNumAsKeyToBlockHeader((uint8_t *)&block_id, sizeof(block_id));
+    auto opt_val = kvbc_->getLatest(kExecutionPrivateCategory, key);
+    auto val = std::get<VersionedValue>(*opt_val);
+    return BlockHeader::deserialize(val.data);
+  }
+
+ protected:
+  std::shared_ptr<NativeClient> db_;
+  std::unique_ptr<ReplicaBlockchain> kvbc_;
+};
+
+TEST_F(BlocksAdderAdapterTest, validate_header) {
+  // write two blocks
+  for (size_t i = 1; i <= 2; i++) {
+    auto updates = Updates{};
+    auto ver_updates = VersionedUpdates{};
+    ver_updates.addUpdate(std::string{BlockMetadata::kBlockMetadataKeyStr}, concordUtils::toBigEndianStringBuffer(i));
+    updates.add(kConcordInternalCategoryId, std::move(ver_updates));
+    ASSERT_EQ(kvbc_->add(std::move(updates)), i);
+  }
+  ASSERT_EQ(kvbc_->getLastReachableBlockNum(), 2);
+
+  // compare computed hash with the one read from storage
+  auto parent_header = read_block(0);
+  auto hash = parent_header.hash();
+  auto header = read_block(1);
+  ASSERT_EQ(hash, header.data.parent_hash);
+}
+
+}  // end namespace
+
+int main(int argc, char **argv) {
+  logging::initLogger("logging.properties");
+  ::testing::InitGoogleTest(&argc, argv);
+  int res = RUN_ALL_TESTS();
+  return res;
+}

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -85,6 +85,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.numOfClientServices = 1;
     replicaConfig.kvBlockchainVersion = 4;
     replicaConfig.useUnifiedCertificates = false;
+    replicaConfig.extraHeader = false;
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;


### PR DESCRIPTION
Introduce generic header to accommodate Ethereum and Non-Ethereum blocks.
Block, Transactions and other relevant definitions would be moved from PROTO to CMF format.

* **Problem Overview**  
V4 blockchain used contain Ethereum blocks and Concord internal blocks together on single blockchain. Ethereum blocks used to get stored in interleaved fashion and all the computation including retrieval of content or parent hash used to get into account only last know Ethereum block. This fix aims to simplify blockchain by bringing uniformity across blocks.


* **Testing Done**  

- Executed all tests locally.
- Validated block contents with Sirato block explorer