### PR TITLE
Fixing front page badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 # Concord-BFT: A Distributed Trust Framework
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)<br/>
-[![clang-tidy](https://github.com/vmware/concord-bft/workflows/clang-tidy/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3Aclang-tidy)<br/>
-[![Build Status](https://github.com/vmware/concord-bft/workflows/Release%20build%20(gcc)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Release+build+%28gcc%29")<br/>
-[![Build Status](https://github.com/vmware/concord-bft/workflows/Debug%20build%20(gcc)/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Debug+build+%28gcc%29")<br/>
+[![Build Status](https://github.com/vmware/concord-bft/workflows/Build%20and%20Test/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A%22Build+and+Test%22)<br/>
 [![Build Status](https://github.com/vmware/concord-bft/workflows/Restart%20recovery%20suite/badge.svg)](https://github.com/vmware/concord-bft/actions?query=workflow%3A"Restart+recovery+suite")<br/>
 
 <!-- ![Concored-bft Logo](TBD) -->


### PR DESCRIPTION
* **Problem Overview**  
  The build and test matrix has been simplified following the Ubuntu upgrade, and some of the legacy jobs are no longer active.
* **Testing Done**  
  Checked that the remaining badges are rendered correctly, and that their links work.
