### PR TITLE
updating the paths for mac compilation

### DIFF
--- a/libs/crypto/CMakeLists.txt
+++ b/libs/crypto/CMakeLists.txt
@@ -14,7 +14,12 @@ if(USE_OPENSSL)
     target_sources(concord-crypto PRIVATE src/openssl/crypto.cpp
                                           src/openssl/certificates.cpp
                                           )
-    target_link_libraries(concord-crypto PUBLIC OpenSSL::Crypto z ${CMAKE_DL_LIBS} Threads::Threads)
+    if(BUILD_CONFIG_GEN_TOOL_FOR_MAC)
+        find_library(OPEN_SSL_STATIC_LIBRARY NAMES "libcrypto.a" HINTS  ${OPENSSL_ROOT_DIR}/lib/)
+        target_link_libraries(concord-crypto PUBLIC ${OPEN_SSL_STATIC_LIBRARY} z ${CMAKE_DL_LIBS} Threads::Threads)
+    else()
+        target_link_libraries(concord-crypto PUBLIC OpenSSL::Crypto z ${CMAKE_DL_LIBS} Threads::Threads)
+    endif()
     target_compile_definitions(concord-crypto PUBLIC USE_OPENSSL)
 endif()
 

--- a/libs/crypto/src/threshsign/CMakeLists.txt
+++ b/libs/crypto/src/threshsign/CMakeLists.txt
@@ -15,7 +15,7 @@ if(USE_MULTISIG_EDDSA)
 endif()
 
 if(BUILD_CONFIG_GEN_TOOL_FOR_MAC)
-    target_include_directories(threshsign PUBLIC /usr/local/ssl/include ${CMAKE_CURRENT_SOURCE_DIR}/../../util/include/ /usr/local/include/)
+    target_include_directories(threshsign PUBLIC /usr/local/ssl/include ${CONCORD-BFT_LOCAL_PATH}/libs/util/include/ /usr/local/include/  ${CONCORD-BFT_LOCAL_PATH}/libs/)
 endif()
 
 if(BUILD_TESTING)

--- a/libs/diagnostics/CMakeLists.txt
+++ b/libs/diagnostics/CMakeLists.txt
@@ -9,6 +9,9 @@ find_library(HDR_HISTOGRAM_LIBRARY hdr_histogram_static HINTS /usr/local/lib REQ
 
 set_property(TARGET diagnostics PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(diagnostics PUBLIC include ${HDR_HISTOGRAM_INCLUDE_DIR})
+if(BUILD_CONFIG_GEN_TOOL_FOR_MAC)
+    target_include_directories(diagnostics PUBLIC /usr/local/include/ ../ ../util/include/)
+endif()
 target_link_libraries(diagnostics ${HDR_HISTOGRAM_LIBRARY})
 
 target_sources(diagnostics PUBLIC FILE_SET diagnostics_pub_hdrs


### PR DESCRIPTION
* **Problem Overview**  
Due to recent refactoring changes in libs directory, the conc_genconfig tool compilation in mac was failing. It has been fixed as part of the PR.
* **Testing Done**  
Tested the changes by compiling and generating the conc_genconfig tool in mac env.