### PR TITLE
Draft: Initial changes to handle invalid coin(s) in transfer

### DIFF
--- a/utt/include/transaction.hpp
+++ b/utt/include/transaction.hpp
@@ -89,4 +89,13 @@ class Transaction {
   struct Impl;
   Impl* pImpl_;
 };
+
+class InvalidCoinsInTransfer : public std::exception {
+ public:
+  explicit InvalidCoinsInTransfer(const std::string& what) : msg(what){};
+  virtual const char* what() const noexcept override { return msg.c_str(); }
+
+ private:
+  std::string msg;
+};
 }  // namespace libutt::api::operations

--- a/utt/privacy-wallet-service/include/PrivacyService.hpp
+++ b/utt/privacy-wallet-service/include/PrivacyService.hpp
@@ -22,6 +22,7 @@
 #include "Wallet.hpp"
 #include <storage/IStorage.hpp>
 #include <utt-client-api/ClientApi.hpp>
+#include <transaction.hpp>
 
 namespace utt::walletservice {
 //@TODO hide on its own file..

--- a/utt/privacy-wallet-service/proto/api/v1/wallet-api.proto
+++ b/utt/privacy-wallet-service/proto/api/v1/wallet-api.proto
@@ -69,6 +69,7 @@ message ClaimCoinsRequest {
 
 message ClaimCoinsReponse {
     bool succ = 1;
+    string warning = 2;
 }
 
 message GenerateMintTx {

--- a/utt/privacy-wallet-service/src/PrivacyService.cpp
+++ b/utt/privacy-wallet-service/src/PrivacyService.cpp
@@ -275,14 +275,16 @@ std::pair<utt::Transaction, utt::TxOutputSigs> PrivacyWalletServiceImpl::buildCl
       response->set_err(err_msg);
       return grpc::Status(grpc::StatusCode::ABORTED, err_msg);
     }
+  } catch (const libutt::api::operations::InvalidCoinsInTransfer& e) {
+    std::cout << e.what() << std::endl;
+    response->mutable_claim_coins_response()->set_warning(e.what());
   } catch (const std::exception& e) {
     std::cout << e.what() << std::endl;
     response->set_err(e.what());
     return grpc::Status(grpc::StatusCode::ABORTED, e.what());
   }
   if (response) {
-    auto resp = response->mutable_claim_coins_response();
-    resp->set_succ(true);
+    response->mutable_claim_coins_response()->set_succ(true);
   }
   return grpc::Status::OK;
 }

--- a/utt/utt-client-api/src/User.cpp
+++ b/utt/utt-client-api/src/User.cpp
@@ -447,9 +447,12 @@ void User::updateTransferTx(const Transaction& tx, const TxOutputSigs& sigs) {
 
     // Claim coins
     auto claimedCoins = pImpl_->client_->claimCoins(uttTx, pImpl_->params_, sigs);
-
+    bool invalidCoinsInTransfer(false);
     for (auto& coin : claimedCoins) {
-      if (!pImpl_->client_->validate(coin)) throw std::runtime_error("Invalid normal coin in transfer!");
+      if (!pImpl_->client_->validate(coin)) {
+        invalidCoinsInTransfer = true;
+        continue;
+      }
       pImpl_->storage_->setCoin(coin);
       if (coin.getType() == libutt::api::Coin::Type::Normal) {
         logdbg_user << "claimed normal coin: " << dbgPrintCoins({coin}) << endl;
@@ -463,6 +466,9 @@ void User::updateTransferTx(const Transaction& tx, const TxOutputSigs& sigs) {
           pImpl_->budgetCoin_ = std::nullopt;
         }
       }
+    }
+    if (invalidCoinsInTransfer) {
+      throw libutt::api::operations::InvalidCoinsInTransfer("Invalid normal coin(s) in transfer!");
     }
   }
 }


### PR DESCRIPTION
* **Problem Overview**  
Current privacy library does not handle invalid coins gracefully. The logic of claiming coins is modified to handle this scenario.

* **Testing Done**  
Testcase: Create a scenario where an invalid coin is transferred to a user. Observe how the invalid coin is handled at the recipient's end.