### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -85,7 +85,7 @@ jobs:
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
-            echo "::set-output name=test::success"
+            echo "test=success" >> $GITHUB_OUTPUT
         - name: Upload error artifacts
           uses: actions/upload-artifact@v2
           if: ${{ env.file_count > 0 }}

--- a/.github/workflows/restart_recovery_suite.yml
+++ b/.github/workflows/restart_recovery_suite.yml
@@ -85,7 +85,7 @@ jobs:
             tar -czvf ${{ github.workspace }}/artifact/logs.tar.gz ./build/tests/apollo/logs
             du -h ${{ github.workspace }}/artifact
             sudo df -h
-            echo "test=success" >> $GITHUB_OUTPUT
+            echo "test=success" >> "$GITHUB_OUTPUT"
         - name: Upload error artifacts
           uses: actions/upload-artifact@v2
           if: ${{ env.file_count > 0 }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


